### PR TITLE
Build tip frequencies for auspice

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -27,9 +27,11 @@ def translations(w):
     return ["results/aa-seq_%s_%s_%s_%s.fasta"%(w.lineage, w.segment, w.resolution, g)
             for g in genes]
 
-def pivots_per_year(w):
-    pivots_per_year = {'2y':12, '3y':6, '6y':4, '12y':2}
-    return pivots_per_year[w.resolution]
+def pivot_interval(w):
+    """Returns the number of months between pivots by build resolution.
+    """
+    pivot_intervals_by_resolution = {'2y': 1, '3y': 2, '6y': 3, '12y': 6}
+    return pivot_intervals_by_resolution[w.resolution]
 
 def min_date(w):
     now = numeric_date(date.today())
@@ -384,7 +386,7 @@ rule mutation_frequencies:
         genes = gene_names,
         min_date = min_date,
         max_date = max_date,
-        pivots_per_year = pivots_per_year
+        pivot_interval = pivot_interval
     output:
         mut_freq = "results/mutation-frequencies_{lineage}_{segment}_{resolution}.json"
     shell:
@@ -395,7 +397,7 @@ rule mutation_frequencies:
             --gene-names {params.genes} \
             --min-date {params.min_date} \
             --max-date {params.max_date} \
-            --pivots-per-year {params.pivots_per_year} \
+            --pivot-interval {params.pivot_interval} \
             --output {output.mut_freq}
         """
 
@@ -411,7 +413,7 @@ rule tip_frequencies:
         weight_attribute = "region",
         min_date = min_date,
         max_date = max_date,
-        pivots_per_year = pivots_per_year
+        pivot_interval = pivot_interval
     output:
         tip_freq = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tip-frequencies.json",
     shell:
@@ -425,7 +427,7 @@ rule tip_frequencies:
             --proportion-wide {params.proportion_wide} \
             --weights {input.weights} \
             --weights-attribute {params.weight_attribute} \
-            --pivots-per-year {params.pivots_per_year} \
+            --pivot-interval {params.pivot_interval} \
             --min-date {params.min_date} \
             --max-date {params.max_date} \
             --output {output}

--- a/Snakefile
+++ b/Snakefile
@@ -116,15 +116,14 @@ rule download_sequences:
         fasta_fields = "strain virus accession collection_date region country division location passage_category submitting_lab age gender"
     shell:
         """
-        env PYTHONPATH={path_to_fauna} \
-            python2 {path_to_fauna}/vdb/download.py \
-                --database vdb \
-                --virus flu \
-                --fasta_fields {params.fasta_fields} \
-                --resolve_method split_passage \
-                --select locus:{wildcards.segment} lineage:seasonal_{wildcards.lineage} \
-                --path data \
-                --fstem {wildcards.lineage}_{wildcards.segment}
+        python3 {path_to_fauna}/vdb/download.py \
+            --database vdb \
+            --virus flu \
+            --fasta_fields {params.fasta_fields} \
+            --resolve_method split_passage \
+            --select locus:{wildcards.segment} lineage:seasonal_{wildcards.lineage} \
+            --path data \
+            --fstem {wildcards.lineage}_{wildcards.segment}
         """
 
 rule download_titers:
@@ -135,14 +134,13 @@ rule download_titers:
         fasta_fields = "strain virus accession collection_date region country division location passage_category submitting_lab age gender"
     shell:
         """
-        env PYTHONPATH={path_to_fauna} \
-            python2 {path_to_fauna}/tdb/download.py \
-                --database cdc_tdb \
-                --virus flu \
-                --subtype {wildcards.lineage} \
-                --select assay_type:hi \
-                --path data \
-                --fstem {wildcards.lineage}_hi
+        python3 {path_to_fauna}/tdb/download.py \
+            --database cdc_tdb \
+            --virus flu \
+            --subtype {wildcards.lineage} \
+            --select assay_type:hi \
+            --path data \
+            --fstem {wildcards.lineage}_hi
         """
 
 rule parse:

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -75,5 +75,10 @@
     "region",
     "country",
     "authors"
+  ],
+  "panels": [
+    "tree",
+    "entropy",
+    "frequencies"
   ]
 }

--- a/config/frequency_weights_by_region.json
+++ b/config/frequency_weights_by_region.json
@@ -1,0 +1,12 @@
+{
+    "africa": 1.02,
+    "europe": 0.74,
+    "north_america": 0.54,
+    "china": 1.36,
+    "south_asia": 1.45,
+    "japan_korea": 0.20,
+    "oceania": 0.04,
+    "south_america": 0.41,
+    "southeast_asia": 0.62,
+    "west_asia": 0.75
+}


### PR DESCRIPTION
Addressing issue #3, this PR modifies auspice configuration to hide the map and show the frequencies panel and uses the KDE frequencies method to estimate region-weighted frequencies from
the refined tree.
