### PR TITLE
Annotate tree nodes with titer substitution model

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -347,7 +347,8 @@ rule titers_sub:
     input:
         titers = rules.download_titers.output.titers,
         aa_muts = rules.translate.output,
-        alignments = translations
+        alignments = translations,
+        tree = rules.refine.output.tree
     params:
         genes = gene_names
     output:
@@ -358,6 +359,7 @@ rule titers_sub:
             --titers {input.titers} \
             --alignment {input.alignments} \
             --gene-names {params.genes} \
+            --tree {input.tree} \
             --output {output.titers_model}
         """
 
@@ -493,6 +495,7 @@ def _get_node_data_for_export(wildcards):
         rules.ancestral.output.node_data,
         rules.translate.output.node_data,
         rules.titers_tree.output.titers_model,
+        rules.titers_sub.output.titers_model,
         rules.clades.output.clades,
         rules.traits.output.node_data,
         rules.lbi.output.lbi

--- a/config/auspice_config.json
+++ b/config/auspice_config.json
@@ -31,6 +31,12 @@
       "menuItem": "antigenic advance (tree model)",
       "type": "continuous"
     },
+    "cTiterSub": {
+      "key": "cTiterSub",
+      "legendTitle": "Antigenic advance (sub model)",
+      "menuItem": "antigenic advance (sub model)",
+      "type": "continuous"
+    },
     "lbi": {
       "vmin": 0,
       "vmax": 0.7,


### PR DESCRIPTION
Passes a tree to the titer substitition model to add a "nodes" attribute to the
JSON output with antigenic advance values per node. Additionally, adds the
resulting JSON to the default inputs for auspice export and adds a corresponding
auspice color-by configuration for "cTiterSub".

Relies on code from the corresponding `ctitersub-tree` branch of augur.

Resolves #4.