### PR TITLE
Align sample filtering requirements with previous augur builds

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -168,7 +168,6 @@ rule filter:
         Filtering {wildcards.lineage} {wildcards.segment} sequences:
           - less than {params.min_length} bases
           - outliers
-          - samples with missing region and country metadata
         """
     input:
         metadata = rules.parse.output.metadata,
@@ -185,7 +184,6 @@ rule filter:
             --metadata {input.metadata} \
             --min-length {params.min_length} \
             --exclude {input.exclude} \
-            --exclude-where country=? region=? \
             --output {output}
         """
 

--- a/Snakefile
+++ b/Snakefile
@@ -3,6 +3,7 @@ import pandas as pd
 from treetime.utils import numeric_date
 
 path_to_fauna = '../fauna'
+min_length = 900
 segments = ['ha', 'na']
 lineages = ['h3n2']
 resolutions = ['2y', '3y', '6y', '12y']
@@ -161,22 +162,49 @@ rule parse:
             --fields {params.fasta_fields}
         """
 
+rule filter:
+    message:
+        """
+        Filtering {wildcards.lineage} {wildcards.segment} sequences:
+          - less than {params.min_length} bases
+          - outliers
+          - samples with missing region and country metadata
+        """
+    input:
+        metadata = rules.parse.output.metadata,
+        sequences = 'results/sequences_{lineage}_{segment}.fasta',
+        exclude = files.outliers
+    output:
+        sequences = 'results/filtered_{lineage}_{segment}.fasta'
+    params:
+        min_length = min_length
+    shell:
+        """
+        augur filter \
+            --sequences {input.sequences} \
+            --metadata {input.metadata} \
+            --min-length {params.min_length} \
+            --exclude {input.exclude} \
+            --exclude-where country=? region=? \
+            --output {output}
+        """
+
 rule select_strains:
     input:
+        sequences = expand("results/filtered_{{lineage}}_{segment}.fasta", segment=segments),
         metadata = expand("results/metadata_{{lineage}}_{segment}.tsv", segment=segments),
         titers = rules.download_titers.output.titers
     output:
         strains = "results/strains_{lineage}_{resolution}.txt",
     params:
         viruses_per_month = vpm,
-        exclude = files.outliers,
         include = files.references
     shell:
         """
         python3 scripts/select_strains.py \
+            --sequences {input.sequences} \
             --metadata {input.metadata} \
             --segments {segments} \
-            --exclude {params.exclude} \
             --include {params.include} \
             --lineage {wildcards.lineage} \
             --resolution {wildcards.resolution} \
@@ -185,21 +213,19 @@ rule select_strains:
             --output {output.strains}
         """
 
-rule filter:
+rule extract:
     input:
-        metadata = rules.parse.output.metadata,
-        sequences = 'results/sequences_{lineage}_{segment}.fasta',
+        sequences = 'results/filtered_{lineage}_{segment}.fasta',
         strains = rules.select_strains.output.strains
     output:
         sequences = 'results/filtered_{lineage}_{segment}_{resolution}.fasta'
-    run:
-        from Bio import SeqIO
-        with open(input.strains) as infile:
-            strains = set(map(lambda x:x.strip(), infile.readlines()))
-        with open(output.sequences, 'w') as outfile:
-            for seq in SeqIO.parse(input.sequences, 'fasta'):
-                if seq.name in strains:
-                    SeqIO.write(seq, outfile, 'fasta')
+    shell:
+        """
+        python3 scripts/extract_sequences.py \
+            --sequences {input.sequences} \
+            --samples {input.strains} \
+            --output {output}
+        """
 
 rule align:
     message:
@@ -208,7 +234,7 @@ rule align:
           - filling gaps with N
         """
     input:
-        sequences = rules.filter.output.sequences,
+        sequences = rules.extract.output.sequences,
         reference = files.reference
     output:
         alignment = "results/aligned_{lineage}_{segment}_{resolution}.fasta"

--- a/scripts/extract_sequences.py
+++ b/scripts/extract_sequences.py
@@ -1,0 +1,24 @@
+"""Extract sequences from a given FASTA file that match the given list of sample names.
+"""
+import argparse
+import Bio
+import Bio.SeqIO
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Extract sample sequences by name",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--sequences", required=True, help="FASTA file of all sample sequences")
+    parser.add_argument("--samples", required=True, help="text file of samples names with one name per line")
+    parser.add_argument("--output", required=True, help="FASTA file of extracted sample sequences")
+    args = parser.parse_args()
+
+    with open(args.samples) as infile:
+        samples = set([line.strip() for line in infile])
+
+    with open(args.output, 'w') as outfile:
+        for seq in Bio.SeqIO.parse(args.sequences, 'fasta'):
+            if seq.name in samples:
+                Bio.SeqIO.write(seq, outfile, 'fasta')


### PR DESCRIPTION
Adds a new filter rule that applies the augur filter command to omit sequences
shorter than a minimum length, outliers, and samples with missing geographic
metadata prior to strain selection, in an attempt to match the filtering
requirements used by previous augur builds [1]. This commit also updates
`select_strains.py` to accept one or more FASTA files and to only consider
metadata for samples whose sequences made it through the aforementioned
filters. After strains are selected, we still need a rule to extract the segment
sequences corresponding to each strain. This rule has been renamed from "filter"
to "extract" and its body has been replaced with a call to a standalone script
that performs the extraction using the same logic as the original Python code.

On a related note, this commit also imposes an upper date limit on included
strains in `select_strains.py` to prevent reference strains from the future from
being included in a build. This modification has no effect on standard "live"
builds, but it ensures consistent output for custom builds that request a
specific time interval from the past (e.g., 2005-2015) that should not be
assigned any sequences after the last date in the requested time interval.

Resolves #6.

[1] https://github.com/nextstrain/augur/blob/3.1.0/builds/flu/flu.prepare.py#L102-L112