### PR TITLE
Subsample by region/year/month

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -46,7 +46,7 @@ def substitution_rates(w):
     return references[(w.lineage, w.segment)]
 
 def vpm(v):
-    vpm = {'2y':92, '3y':2, '6y':2, '12y':1}
+    vpm = {'2y':90, '3y':60, '6y':30, '12y':15}
     return vpm[v.resolution] if v.resolution in vpm else 5
 
 #

--- a/Snakefile
+++ b/Snakefile
@@ -46,7 +46,7 @@ def substitution_rates(w):
     return references[(w.lineage, w.segment)]
 
 def vpm(v):
-    vpm = {'2y':90, '3y':60, '6y':30, '12y':15}
+    vpm = {'2y':90, '3y':58, '6y':28, '12y':14}
     return vpm[v.resolution] if v.resolution in vpm else 5
 
 #

--- a/Snakefile
+++ b/Snakefile
@@ -46,7 +46,7 @@ def substitution_rates(w):
     return references[(w.lineage, w.segment)]
 
 def vpm(v):
-    vpm = {'2y':2, '3y':2, '6y':2, '12y':1}
+    vpm = {'2y':92, '3y':2, '6y':2, '12y':1}
     return vpm[v.resolution] if v.resolution in vpm else 5
 
 #

--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -64,8 +64,7 @@ def count_titer_measurements(fname):
 
 
 def populate_categories(metadata):
-    super_category = lambda x: (x['region'],
-                                x['year'],
+    super_category = lambda x: (x['year'],
                                 x['month'])
 
     category = lambda x: (x['region'],
@@ -104,13 +103,12 @@ def flu_subsampling(metadata, viruses_per_month, time_interval, titer_fname=None
             return viruses_per_month
 
         # otherwise, sort sub categories by strain count
-        sub_counts = sorted([(r, virus_by_super_category[(r, x[1], x[2])]) for r in subcats],
+        sub_counts = sorted([(r, virus_by_category[(r, x[1], x[2])]) for r in subcats],
                              key=lambda y:len(y[1]))
 
         # if all (the smallest) subcat has more strains than the threshold, return threshold
         if len(sub_counts[0][1]) > subcat_threshold:
             return subcat_threshold
-
 
         strains_selected = 0
         tmp_subcat_threshold = subcat_threshold
@@ -123,10 +121,10 @@ def flu_subsampling(metadata, viruses_per_month, time_interval, titer_fname=None
         return subcat_threshold
 
     selected_strains = []
-    for cat, val in virus_by_category.items():
+    for cat, val in list(virus_by_category.items()):
         if cat_valid(cat, time_interval):
-            val.sort(key=priority, reverse=True)
-            selected_strains.extend(val[:threshold_fn(cat)])
+            tmp = sorted(val, key=priority, reverse=True)
+            selected_strains.extend(tmp[:threshold_fn(cat)])
 
     return selected_strains
 
@@ -265,6 +263,7 @@ if __name__ == '__main__':
 
     # summary of selected strains by region
     summary(selected_strains, filtered_metadata, args.segments, ['region'])
+    summary(selected_strains, filtered_metadata, args.segments, ['year', 'month'])
 
     # write the list of selected strains to file
     with open(args.output, 'w') as ofile:

--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -64,7 +64,8 @@ def count_titer_measurements(fname):
 
 
 def populate_categories(metadata):
-    super_category = lambda x: (x['year'],
+    super_category = lambda x: (x['region'],
+                                x['year'],
                                 x['month'])
 
     category = lambda x: (x['region'],


### PR DESCRIPTION
@rneher ---

I noticed that the existing `subsampling.py` was behaving strangely with regards to counts, particularly region counts. When running a 2y build with vcm=92 (this matches old augur) I get the following on `master` (before this PR):
```
Summary of strain counts by category
Categories for segment ha
africa 135
china 209
europe 184
japan_korea 311
north_america 328
oceania 454
south_america 438
south_asia 119
southeast_asia 317
west_asia 597
total 3092
```
Notice that `west_asia` gets a brunch of extra strains. If I instead switch `super_category` to region/year/month as in the PR and set vcm=15 (to get about the same total strains), I get the following much more even distribution:
```
Summary of strain counts by category
Categories for segment ha
africa 184
china 218
europe 240
japan_korea 260
north_america 358
oceania 326
south_america 265
south_asia 118
southeast_asia 224
west_asia 223
total 2416
```
I tried to debug `flu_subsampling` without real success. This PR however, fixes the immediate issue. Might be good to fix the underlying problem in `flu_subsampling` before Feb to be able to include more North American and European strains at height of winter. (But on the flipside, this more even subsampling will protect things like LBI to some degree from sampling bias, might want a real decision on how to handle subsampling)