### PR TITLE
Import HA clades to non-HA segments

### DIFF
--- a/scripts/import_tip_clades.py
+++ b/scripts/import_tip_clades.py
@@ -1,0 +1,36 @@
+"""
+Take clades.json file that lists:
+{
+ "nodes": {
+  "A/AbuDhabi/16/2017": {
+   "clade_membership": "A1b/135N"
+  },
+...
+and creates a new file that has internal nodes 'clade_membership' set to 'unassigned'.
+"""
+
+import argparse
+import json
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Import clade membership",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--clades", required=True, help="JSON file with clade memberships")
+    parser.add_argument("--output", required=True, help="JSON file with scrubbed clade memberships")
+    args = parser.parse_args()
+
+    with open(args.clades) as infile:
+        json_data = json.load(infile)
+
+    scrubbed_json_data = {'nodes':{}}
+
+    for node, values in json_data['nodes'].items():
+        clade_membership = values['clade_membership']
+        if node[0:4] == 'NODE':
+            clade_membership = 'unassigned'
+        scrubbed_json_data['nodes'][node] = {'clade_membership': clade_membership}
+
+    with open(args.output, 'w') as outfile:
+        json.dump(scrubbed_json_data, outfile, indent=1, sort_keys=True)


### PR DESCRIPTION
This splits the `clades` rule so that `augur clades` is run on the HA segment and `scripts/import_tip_clades.py` is run on non-HA segments. This was the cleanest snakemake build I could come up with and I'm pretty happy with the result. Other approaches like discussed in #8 seemed to needlessly cascade in the Snakefile. For example, splitting this into `ha_clades` and `non_ha_clades` rules meant dealing with this split in the `export` rule. Whereas keeping things within the `clades` rule did not impact downstream behavior.

Resolves #8.