### PR TITLE
Import clade membership using HA tree structure

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -515,7 +515,7 @@ rule tree_frequencies:
 rule clades:
     message: "Annotating clades"
     input:
-        tree = rules.refine.output.tree,
+        tree = "results/tree_{lineage}_ha_{resolution}.nwk",
         nt_muts = rules.ancestral.output,
         aa_muts = rules.translate.output,
         clades = _get_clades_file_for_wildcards
@@ -533,6 +533,7 @@ rule clades:
         else:
             shell("""
                 python scripts/import_tip_clades.py \
+                    --tree {input.tree} \
                     --clades {input.clades} \
                     --output {output.clades}
             """)

--- a/scripts/import_tip_clades.py
+++ b/scripts/import_tip_clades.py
@@ -10,27 +10,34 @@ and creates a new file that has internal nodes 'clade_membership' set to 'unassi
 """
 
 import argparse
+import Bio
+import Bio.Phylo
 import json
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description="Import clade membership",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter
     )
+    parser.add_argument("--tree", required=True, help="Newick tree originally used to assign tips to clades")
     parser.add_argument("--clades", required=True, help="JSON file with clade memberships")
     parser.add_argument("--output", required=True, help="JSON file with scrubbed clade memberships")
     args = parser.parse_args()
+
+    tree = Bio.Phylo.read(args.tree, 'newick')
 
     with open(args.clades) as infile:
         json_data = json.load(infile)
 
     scrubbed_json_data = {'nodes':{}}
 
-    for node, values in json_data['nodes'].items():
-        clade_membership = values['clade_membership']
-        if node[0:4] == 'NODE':
-            clade_membership = 'unassigned'
-        scrubbed_json_data['nodes'][node] = {'clade_membership': clade_membership}
+    # Copy clade membership for tips to a new JSON and omit internal nodes from
+    # the original tree that was used to assign tips to clades.
+    for node in tree.find_clades():
+        if node.is_terminal():
+            clade_membership = json_data['nodes'][node.name]['clade_membership']
+            scrubbed_json_data['nodes'][node.name] = {'clade_membership': clade_membership}
 
     with open(args.output, 'w') as outfile:
         json.dump(scrubbed_json_data, outfile, indent=1, sort_keys=True)


### PR DESCRIPTION
Uses the original HA tree used to assign clade memberships to tips to select
only tips when importing clade memberships for other segments. Note that this
commit omits export of any internal node data, since we would not expect
internal node names to match meaningfully between trees for different segments
and auspice can handle missing data for internal nodes gracefully.

Closes #13.