### PR TITLE
Add selection flag for segment.

### DIFF
--- a/batch.py
+++ b/batch.py
@@ -11,23 +11,14 @@ import os
 
 if __name__ == '__main__':
 
-    parser = argparse.ArgumentParser(description='Run flu builds on aws')
-    parser.add_argument('-l', '--lineages', nargs='+', type = str,  help ="flu lineages to include")
-    parser.add_argument('-r', '--resolutions', nargs='+', type = str,  help ="flu resolutions to include")
-    parser.add_argument('-s', '--segments', nargs='+', type = str, help ="flu segments to include")
+    parser = argparse.ArgumentParser(description='Run flu builds on aws', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-l', '--lineages', nargs='+', type = str,  help ="flu lineages to include", default=['h3n2', 'h1n1pdm', 'vic', 'yam'])
+    parser.add_argument('-r', '--resolutions', nargs='+', type = str,  help ="flu resolutions to include", default=['2y', '3y', '6y', '12y'])
+    parser.add_argument('-s', '--segments', nargs='+', type = str, help ="flu segments to include", default=['ha', 'na'])
     params = parser.parse_args()
 
     if not os.path.exists("logs"):
         os.makedirs("logs")
-
-    if params.segments is None:
-        params.segments = ['ha', 'na']
-
-    if params.lineages is None:
-        params.lineages = ['h3n2', 'h1n1pdm', 'vic', 'yam']
-
-    if params.resolutions is None:
-        params.resolutions = ['2y', '3y', '6y', '12y']
 
     for lineage in params.lineages:
         for resolution in params.resolutions:

--- a/batch.py
+++ b/batch.py
@@ -14,12 +14,14 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run flu builds on aws')
     parser.add_argument('-l', '--lineages', nargs='+', type = str,  help ="flu lineages to include")
     parser.add_argument('-r', '--resolutions', nargs='+', type = str,  help ="flu resolutions to include")
+    parser.add_argument('-s', '--segments', nargs='+', type = str, help ="flu segments to include")
     params = parser.parse_args()
-
-    segments = ["ha", "na"]
 
     if not os.path.exists("logs"):
         os.makedirs("logs")
+
+    if params.segments is None:
+        params.segments = ['ha', 'na']
 
     if params.lineages is None:
         params.lineages = ['h3n2', 'h1n1pdm', 'vic', 'yam']
@@ -31,7 +33,7 @@ if __name__ == '__main__':
         for resolution in params.resolutions:
             call = ['nextstrain', 'build', '--aws-batch', '.', '-j 2']
             targets = []
-            for segment in segments:
+            for segment in params.segments:
                 targets.append('auspice/flu_seasonal_%s_%s_%s_tree.json'%(lineage, segment, resolution))
                 targets.append('auspice/flu_seasonal_%s_%s_%s_meta.json'%(lineage, segment, resolution))
                 targets.append('auspice/flu_seasonal_%s_%s_%s_tip-frequencies.json'%(lineage, segment, resolution))


### PR DESCRIPTION
This PR adds a selection flag for segment to the batch submission script for seasonal flu. This gives the user control over all three variables (segment, lineage, resolution) as opposed to just two. Allows re-runs (i.e. for an added outlier) to ignore NA builds, as is often the case.

Defaults to ["ha", "na"].