### PR TITLE
Export root sequences JSON as a standard auspice output

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -58,7 +58,7 @@ rule export:
     output:
         auspice_tree = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_tree.json",
         auspice_meta = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_meta.json",
-        auspice_seq = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_seq.json"
+        auspice_seq = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_root-sequence.json"
     shell:
         """
         augur export \
@@ -75,12 +75,12 @@ rule simplify_auspice_names:
     input:
         tree = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_tree.json",
         meta = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_meta.json",
-        seq = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_seq.json",
+        seq = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_root-sequence.json",
         frequencies = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_tip-frequencies.json"
     output:
         tree = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tree.json",
         meta = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_meta.json",
-        seq = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_seq.json",
+        seq = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_root-sequence.json",
         frequencies = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tip-frequencies.json"
     shell:
         '''

--- a/Snakefile
+++ b/Snakefile
@@ -57,7 +57,8 @@ rule export:
         node_data = _get_node_data_for_export
     output:
         auspice_tree = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_tree.json",
-        auspice_meta = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_meta.json"
+        auspice_meta = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_meta.json",
+        auspice_seq = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_seq.json"
     shell:
         """
         augur export \
@@ -66,22 +67,26 @@ rule export:
             --node-data {input.node_data} \
             --auspice-config {input.auspice_config} \
             --output-tree {output.auspice_tree} \
-            --output-meta {output.auspice_meta}
+            --output-meta {output.auspice_meta} \
+            --output-sequence {output.auspice_seq}
         """
 
 rule simplify_auspice_names:
     input:
         tree = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_tree.json",
         meta = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_meta.json",
+        seq = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_seq.json",
         frequencies = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_tip-frequencies.json"
     output:
         tree = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tree.json",
         meta = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_meta.json",
+        seq = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_seq.json",
         frequencies = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tip-frequencies.json"
     shell:
         '''
         mv {input.tree} {output.tree} &
         mv {input.meta} {output.meta} &
+        mv {input.seq} {output.seq} &
         mv {input.frequencies} {output.frequencies} &
         '''
 


### PR DESCRIPTION
This export costs little in time and space, but it enables downstream analyses that depend on amino acid sequences for seasonal flu. For example, auspice JSONs with the root sequence could be used as inputs to forecasts without needing to build new trees just for that purpose.