### PR TITLE
Specify batch resources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ auspice-who/
 build/
 logs/
 figures/
+targets/
 
 # Sensitive environment variables
 environment*

--- a/Snakefile
+++ b/Snakefile
@@ -97,12 +97,17 @@ rule targets:
         seq = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_root-sequence.json",
         frequencies = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tip-frequencies.json"
     output:
-        target = "targets/flu_seasonal_{lineage}_{segment}_{resolution}",
+        target = "targets/flu_seasonal_{lineage}_{segment}_{resolution}"
+    shell:
+        '''
+        touch {output.target}
+        '''
 
 rule clean:
     message: "Removing directories: {params}"
     params:
         "results ",
+        "targets ",
         "auspice ",
         "auspice-who"
     shell:

--- a/Snakefile
+++ b/Snakefile
@@ -90,6 +90,15 @@ rule simplify_auspice_names:
         mv {input.frequencies} {output.frequencies} &
         '''
 
+rule targets:
+    input:
+        tree = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tree.json",
+        meta = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_meta.json",
+        seq = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_root-sequence.json",
+        frequencies = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tip-frequencies.json"
+    output:
+        target = "targets/flu_seasonal_{lineage}_{segment}_{resolution}",
+
 rule clean:
     message: "Removing directories: {params}"
     params:

--- a/Snakefile_WHO
+++ b/Snakefile_WHO
@@ -247,6 +247,10 @@ rule targets:
         sequences = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_sequences.json",
         titer_sub_model = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_titer-sub-model.json",
         titer_tree_model = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_titer-tree-model.json",
-        titers = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_titers.json",
+        titers = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_titers.json"
     output:
-        target = "targets/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}",
+        target = "targets/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}"
+    shell:
+        '''
+        touch {output.target}
+        '''

--- a/Snakefile_WHO
+++ b/Snakefile_WHO
@@ -237,3 +237,16 @@ rule export_who:
             --output-tree {output.tree} \
             --output-meta {output.meta}
         """
+
+rule targets:
+    input:
+        tree = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_tree.json",
+        meta = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_meta.json",
+        entropy = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_entropy.json",
+        frequencies = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_frequencies.json",
+        sequences = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_sequences.json",
+        titer_sub_model = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_titer-sub-model.json",
+        titer_tree_model = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_titer-tree-model.json",
+        titers = "auspice-who/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_titers.json",
+    output:
+        target = "targets/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}",

--- a/Snakefile_base
+++ b/Snakefile_base
@@ -261,7 +261,7 @@ rule align:
             --reference-sequence {input.reference} \
             --output {output.alignment} \
             --remove-reference \
-            --nthreads auto
+            --nthreads 1
         """
 
 rule tree:
@@ -276,7 +276,7 @@ rule tree:
         augur tree \
             --alignment {input.alignment} \
             --output {output.tree} \
-            --nthreads auto \
+            --nthreads 1 \
             --exclude-sites {input.exclude_sites}
         """
 

--- a/batch.py
+++ b/batch.py
@@ -33,7 +33,7 @@ if __name__ == '__main__':
             if params.system == 'local':
                 call = ['nextstrain', 'build', '.', '-j', '1']
             elif params.system == 'batch':
-                call = ['nextstrain', 'build', '--aws-batch', '.', '-j', '4'] # 4 jobs to match xlarge nodes
+                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '8', '--aws-batch-memory', '14800', '.', '--jobs', '8']
             targets = []
             for resolution in params.resolutions:
                 for segment in params.segments:
@@ -42,22 +42,22 @@ if __name__ == '__main__':
                     targets.append('auspice/flu_seasonal_%s_%s_%s_tip-frequencies.json'%(lineage, segment, resolution))
             call.extend(targets)
             print(' '.join(call))
-            log = open('logs/live_flu_%s.txt'%(lineage), 'w')
+            log = open('logs/live_%s.txt'%(lineage), 'w')
             if params.system == 'local':
                 pro = subprocess.call(call)
             if params.system == 'batch':
                 pro = subprocess.Popen(call, stdout=log, stderr=log)
 
     if params.version == 'who' or params.version == 'both':
-        for center in params.centers:
-            for lineage in params.lineages:
-                if params.system == 'local':
-                    call = ['nextstrain', 'build', '.', '-s', 'Snakefile_WHO', '-j', '1']
-                elif params.system == 'batch':
-                    call = ['nextstrain', 'build', '--aws-batch', '.', '-s', 'Snakefile_WHO', '-j', '4'] # 4 jobs to match xlarge nodes
-                targets = []
-                segment = 'ha'
-                resolutions = [r for r in params.resolutions if r == '2y' or r == '6y']
+        for lineage in params.lineages:
+            if params.system == 'local':
+                call = ['nextstrain', 'build', '.', '-s', 'Snakefile_WHO', '-j', '1']
+            elif params.system == 'batch':
+                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '8', '--aws-batch-memory', '14800', '.', '--snakefile', 'Snakefile_WHO', '--jobs', '8']
+            targets = []
+            segment = 'ha'
+            resolutions = [r for r in params.resolutions if r == '2y' or r == '6y']
+            for center in params.centers:
                 for resolution in resolutions:
                     for passage in params.passages:
                         assays = [assay for assay in params.assays if lineage == 'h3n2' or assay == 'hi']
@@ -70,10 +70,10 @@ if __name__ == '__main__':
                             targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_titer-sub-model.json'%(center, lineage, segment, resolution, passage, assay))
                             targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_titer-tree-model.json'%(center, lineage, segment, resolution, passage, assay))
                             targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_titers.json'%(center, lineage, segment, resolution, passage, assay))
-                call.extend(targets)
-                print(' '.join(call))
-                log = open('logs/who_flu_%s_%s.txt'%(center, lineage), 'w')
-                if params.system == 'local':
-                    pro = subprocess.call(call)
-                if params.system == 'batch':
-                    pro = subprocess.Popen(call, stdout=log, stderr=log)
+            call.extend(targets)
+            print(' '.join(call))
+            log = open('logs/who_%s.txt'%(lineage), 'w')
+            if params.system == 'local':
+                pro = subprocess.call(call)
+            if params.system == 'batch':
+                pro = subprocess.Popen(call, stdout=log, stderr=log)

--- a/batch.py
+++ b/batch.py
@@ -31,15 +31,13 @@ if __name__ == '__main__':
     if params.version == 'live' or params.version == 'both':
         for lineage in params.lineages:
             if params.system == 'local':
-                call = ['nextstrain', 'build', '.', '-j', '1']
+                call = ['nextstrain', 'build', '.', '--jobs', '1']
             elif params.system == 'batch':
-                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '8', '--aws-batch-memory', '14800', '.', '--jobs', '8']
+                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '8', '--aws-batch-memory', '15200', '.', '--jobs', '8']
             targets = []
             for resolution in params.resolutions:
                 for segment in params.segments:
-                    targets.append('auspice/flu_seasonal_%s_%s_%s_tree.json'%(lineage, segment, resolution))
-                    targets.append('auspice/flu_seasonal_%s_%s_%s_meta.json'%(lineage, segment, resolution))
-                    targets.append('auspice/flu_seasonal_%s_%s_%s_tip-frequencies.json'%(lineage, segment, resolution))
+                    targets.append('targets/flu_seasonal_%s_%s_%s'%(lineage, segment, resolution))
             call.extend(targets)
             print(' '.join(call))
             log = open('logs/live_%s.txt'%(lineage), 'w')
@@ -51,9 +49,9 @@ if __name__ == '__main__':
     if params.version == 'who' or params.version == 'both':
         for lineage in params.lineages:
             if params.system == 'local':
-                call = ['nextstrain', 'build', '.', '-s', 'Snakefile_WHO', '-j', '1']
+                call = ['nextstrain', 'build', '.', '--snakefile', 'Snakefile_WHO', '--jobs', '1']
             elif params.system == 'batch':
-                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '8', '--aws-batch-memory', '14800', '.', '--snakefile', 'Snakefile_WHO', '--jobs', '8']
+                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '16', '--aws-batch-memory', '31000', '.', '--snakefile', 'Snakefile_WHO', '--jobs', '16']
             targets = []
             segment = 'ha'
             resolutions = [r for r in params.resolutions if r == '2y' or r == '6y']
@@ -62,14 +60,7 @@ if __name__ == '__main__':
                     for passage in params.passages:
                         assays = [assay for assay in params.assays if lineage == 'h3n2' or assay == 'hi']
                         for assay in assays:
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_tree.json'%(center, lineage, segment, resolution, passage, assay))
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_meta.json'%(center, lineage, segment, resolution, passage, assay))
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_entropy.json'%(center, lineage, segment, resolution, passage, assay))
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_frequencies.json'%(center, lineage, segment, resolution, passage, assay))
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_sequences.json'%(center, lineage, segment, resolution, passage, assay))
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_titer-sub-model.json'%(center, lineage, segment, resolution, passage, assay))
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_titer-tree-model.json'%(center, lineage, segment, resolution, passage, assay))
-                            targets.append('auspice-who/flu_%s_%s_%s_%s_%s_%s_titers.json'%(center, lineage, segment, resolution, passage, assay))
+                            targets.append('targets/flu_%s_%s_%s_%s_%s_%s'%(center, lineage, segment, resolution, passage, assay))
             call.extend(targets)
             print(' '.join(call))
             log = open('logs/who_%s.txt'%(lineage), 'w')

--- a/batch.py
+++ b/batch.py
@@ -30,10 +30,12 @@ if __name__ == '__main__':
 
     if params.version == 'live' or params.version == 'both':
         for lineage in params.lineages:
+            cpus = len(params.resolutions) * len(params.segments)
+            memory = 1800 * cpus
             if params.system == 'local':
                 call = ['nextstrain', 'build', '.', '--jobs', '1']
             elif params.system == 'batch':
-                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '8', '--aws-batch-memory', '15200', '.', '--jobs', '8']
+                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', str(cpus), '--aws-batch-memory', str(memory), '.', '--jobs', str(cpus)]
             targets = []
             for resolution in params.resolutions:
                 for segment in params.segments:
@@ -48,17 +50,19 @@ if __name__ == '__main__':
 
     if params.version == 'who' or params.version == 'both':
         for lineage in params.lineages:
+            segment = 'ha'
+            resolutions = [r for r in params.resolutions if r == '2y' or r == '6y']
+            assays = [assay for assay in params.assays if lineage == 'h3n2' or assay == 'hi']
+            cpus = len(params.centers) * len(resolutions) * len(params.passages) * len(assays)
+            memory = 1800 * cpus
             if params.system == 'local':
                 call = ['nextstrain', 'build', '.', '--snakefile', 'Snakefile_WHO', '--jobs', '1']
             elif params.system == 'batch':
-                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', '16', '--aws-batch-memory', '31000', '.', '--snakefile', 'Snakefile_WHO', '--jobs', '16']
+                call = ['nextstrain', 'build', '--aws-batch', '--aws-batch-cpus', str(cpus), '--aws-batch-memory', str(memory), '.', '--snakefile', 'Snakefile_WHO', '--jobs', str(cpus)]
             targets = []
-            segment = 'ha'
-            resolutions = [r for r in params.resolutions if r == '2y' or r == '6y']
             for center in params.centers:
                 for resolution in resolutions:
                     for passage in params.passages:
-                        assays = [assay for assay in params.assays if lineage == 'h3n2' or assay == 'hi']
                         for assay in assays:
                             targets.append('targets/flu_%s_%s_%s_%s_%s_%s'%(center, lineage, segment, resolution, passage, assay))
             call.extend(targets)

--- a/scripts/full_region_alignments.py
+++ b/scripts/full_region_alignments.py
@@ -70,7 +70,7 @@ if __name__ == '__main__':
     SeqIO.write(sequences, tmp_file, 'fasta')
     fail = align.run(pseudo_args(sequences=tmp_file, reference_sequence=args.reference_sequence,
                       output = tmp_file_out, reference_name=None, remove_reference=True,
-                      method='mafft', nthreads=2, fill_gaps=False))
+                      method='mafft', nthreads=1, fill_gaps=False))
     if fail:
         sys.exit(fail)
 


### PR DESCRIPTION
This is more of an FYI than a request for code review. These are changes to improve scheduling and performance of `--aws-batch` builds. These changes should not impact HPC-based builds. I did a few things here:

1. I made new build-specific "targets" like `targets/flu_seasonal_h3n2_ha_3y` that include the `tree.json`, `meta.json`, etc... so these don't have to be spelled out. I figure this will also be generally convenient.

2. I modified `batch.py` to specify `--aws-batch-cpus` and `--aws-batch-memory` based on number of simultaneous build targets and set snakemake's `--jobs` to correspond.

3. I set `--nthreads 1` to prevent threadlocking (improving AWS Batch builds from 4 hours to 1 hour).

I'm letting AWS Batch handle resource provisioning. This sometimes results in large instances that aren't completely utilized, but by and large works quite nicely. And I prefer specifying `--aws-batch-cpus` as a job specific request and then push provisioning logic to AWS Batch rather than baking in provisioning into job submission.

cc @barneypotter24, @tsibley 