### PR TITLE
Update reference to titer TSV file in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,5 @@ script:
   - mkdir -p data/
   - cp -v example_data/h3n2_ha.fasta data/
   - cp -v example_data/h3n2_na.fasta data/
-  - cp -v example_data/h3n2_hi_titers.tsv data/cdc_h3n2_cell_hi_titers.tsv
+  - cp -v example_data/cdc_h3n2_cell_hi_titers.tsv data/
   - nextstrain build . auspice/flu_seasonal_h3n2_ha_12y_tree.json auspice/flu_seasonal_h3n2_ha_12y_tip-frequencies.json


### PR DESCRIPTION
The titer TSV was renamed but the Travis script was not updated. This led CI
builds to fail when titers were missing and could not be downloaded from
RethinkDB.