### PR TITLE
Add logs and data directories to clean.

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -109,6 +109,8 @@ rule clean:
         "results ",
         "targets ",
         "auspice ",
-        "auspice-who"
+        "auspice-who ",
+        "logs ",
+        "data"
     shell:
         "rm -rfv {params}"

--- a/Snakefile
+++ b/Snakefile
@@ -110,6 +110,17 @@ rule clean:
         "targets ",
         "auspice ",
         "auspice-who ",
+        "logs"
+    shell:
+        "rm -rfv {params}"
+
+rule clobber:
+    message: "Removing directories: {params}"
+    params:
+        "results ",
+        "targets ",
+        "auspice ",
+        "auspice-who ",
         "logs ",
         "data"
     shell:


### PR DESCRIPTION
This is a QOL change since before each new build I had to run additional `rm` commands for the `log` and `data` directories after running `snakemake clean`. This adds those directories to the regular command.  