### PR TITLE
Update WHO builds to work with distance maps.

### DIFF
--- a/Snakefile_WHO
+++ b/Snakefile_WHO
@@ -210,7 +210,7 @@ def _get_node_data_for_report_export(wildcards):
 
     # Only request a distance file for builds that have mask configurations
     # defined.
-    if _get_build_mask_config(wildcards) is not None:
+    if _get_build_distance_map_config(wildcards) is not None:
         inputs.append(rules.distances.output.distances)
 
     # Convert input files from wildcard strings to real file names.


### PR DESCRIPTION
This replaces old `_get_mask_config` with a call to `_get_build_distance_map_config` to mimic the behavior of the regular `Snakefile` from https://github.com/nextstrain/seasonal-flu/pull/26.