### PR TITLE
Vaccine info node-data JSONs

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -46,7 +46,8 @@ def _get_node_data_for_export(wildcards):
         rules.titers_sub.output.titers_model,
         rules.clades.output.clades,
         rules.traits.output.node_data,
-        rules.lbi.output.lbi
+        rules.lbi.output.lbi,
+        files.vaccine_json
     ]
 
     if wildcards.lineage == "h3n2" and wildcards.segment == "ha" and wildcards.resolution == "2y":

--- a/Snakefile_base
+++ b/Snakefile_base
@@ -218,7 +218,8 @@ rule files:
         references = "config/references_{lineage}.txt",
         reference = "config/reference_{lineage}_{segment}.gb",
         colors = "config/colors.tsv",
-        auspice_config = _get_auspice_config
+        auspice_config = _get_auspice_config,
+        vaccine_json = "config/vaccines_{lineage}.json"
 
 files = rules.files.params
 

--- a/config/vaccines_h1n1pdm.json
+++ b/config/vaccines_h1n1pdm.json
@@ -1,0 +1,19 @@
+{
+    "nodes": {
+        "A/California/7/2009": {
+            "vaccine": {
+                "selection_date": "2009-09-25"
+            }
+        },
+        "A/Michigan/45/2015": {
+            "vaccine": {
+                "selection_date": "2016-09-29"
+            }
+        },
+        "A/Brisbane/2/2018": {
+            "vaccine": {
+                "selection_date": "2019-02-20"
+            }
+        }
+    }
+}

--- a/config/vaccines_h3n2.json
+++ b/config/vaccines_h3n2.json
@@ -1,0 +1,59 @@
+{
+    "nodes": {
+        "A/Wisconsin/67/2005": {
+            "vaccine": {
+                "selection_date": "2006-02-21"
+            }
+        },
+        "A/Brisbane/10/2007": {
+            "vaccine": {
+                "selection_date": "2007-09-25"
+            }
+        },
+        "A/Perth/16/2009": {
+            "vaccine": {
+                "selection_date": "2009-09-25"
+            }
+        },
+        "A/Victoria/361/2011": {
+            "vaccine": {
+                "selection_date": "2012-02-21"
+            }
+        },
+        "A/Texas/50/2012": {
+            "vaccine": {
+                "selection_date": "2013-09-25"
+            }
+        },
+        "A/Switzerland/9715293/2013": {
+            "vaccine": {
+                "selection_date": "2014-09-25"
+            }
+        },
+        "A/HongKong/4801/2014": {
+            "vaccine": {
+                "selection_date": "2015-09-24"
+            }
+        },
+        "A/Singapore/Infimh-16-0019/2016": {
+            "vaccine": {
+                "selection_date": "2017-09-28"
+            }
+        },
+        "A/Switzerland/8060/2017": {
+            "vaccine": {
+                "selection_date": "2018-09-27"
+            }
+        },
+        "A/Kansas/14/2017": {
+            "vaccine": {
+                "selection_date": "2019-03-21"
+            }
+        },
+        "A/SouthAustralia/34/2019": {
+            "vaccine": {
+                "selection_date": "2019-09-27"
+            }
+        }
+    }
+}

--- a/config/vaccines_vic.json
+++ b/config/vaccines_vic.json
@@ -1,0 +1,24 @@
+{
+    "nodes": {
+        "B/Malaysia/2506/2004": {
+            "vaccine": {
+                "selection_date": "2006-09-25"
+            }
+        },
+        "B/Brisbane/60/2008": {
+            "vaccine": {
+                "selection_date": "2009-09-25"
+            }
+        },
+        "B/Colorado/6/2017": {
+            "vaccine": {
+                "selection_date": "2018-02-22"
+            }
+        },
+        "B/Washington/2/2019": {
+            "vaccine": {
+                "selection_date": "2019-09-27"
+            }
+        }
+    }
+}

--- a/config/vaccines_yam.json
+++ b/config/vaccines_yam.json
@@ -1,0 +1,24 @@
+{
+    "nodes": {
+        "B/Shanghai/361/2002": {
+            "vaccine": {
+                "selection_date": "2004-09-25"
+            }
+        },
+        "B/Florida/4/2006": {
+            "vaccine": {
+                "selection_date": "2008-09-25"
+            }
+        },
+        "B/Wisconsin/1/2010": {
+            "vaccine": {
+                "selection_date": "2012-02-25"
+            }
+        },
+        "B/Phuket/3073/2013": {
+            "vaccine": {
+                "selection_date": "2014-09-25"
+            }
+        }
+    }
+}


### PR DESCRIPTION
The information, previously exported in `export [v1]` via the auspice config file are stored in dedicated JSON files for `export v2`. The auspice config files remain unchanged so that `export v1` still works as expected, but this information should be removed from them when it's no longer needed.

You will need to use this PR of augur: https://github.com/nextstrain/augur/pull/410

P.S. I don't believe the travis failures are due to this PR, although I only tested it on `3y` builds to speed things up.