### PR TITLE
Export v2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ script:
   - cp -v example_data/h3n2_ha.fasta data/
   - cp -v example_data/h3n2_na.fasta data/
   - cp -v example_data/cdc_h3n2_cell_hi_titers.tsv data/
-  - nextstrain build . auspice/flu_seasonal_h3n2_ha_12y_tree.json auspice/flu_seasonal_h3n2_ha_12y_tip-frequencies.json
+  - nextstrain build . auspice/flu_seasonal_h3n2_ha_12y.json auspice/flu_seasonal_h3n2_ha_12y_tip-frequencies.json

--- a/Snakefile
+++ b/Snakefile
@@ -183,8 +183,7 @@ rule export:
         auspice_config = files.auspice_config,
         node_data = _get_node_data_for_export
     output:
-        auspice_main = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}.json",
-        auspice_root_sequence = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_root-sequence.json"
+        auspice_json = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}.json"
     shell:
         """
         augur export v2 \
@@ -192,7 +191,7 @@ rule export:
             --metadata {input.metadata} \
             --node-data {input.node_data} \
             --auspice-config {input.auspice_config} \
-            --output {output.auspice_main} \
+            --output {output.auspice_json} \
             --minify-json
         """
 
@@ -205,23 +204,19 @@ def get_tip_frequencies(wildcards):
 rule simplify_auspice_names:
     input:
         main = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi.json",
-        root_sequence = "auspice/flu_cdc_{lineage}_{segment}_{resolution}_cell_hi_root-sequence.json",
         frequencies = get_tip_frequencies
     output:
         main = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}.json",
-        root_sequence = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_root-sequence.json",
         frequencies = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tip-frequencies.json"
     shell:
         '''
         mv {input.main} {output.main} &
-        mv {input.root_sequence} {output.root_sequence} &
         mv {input.frequencies} {output.frequencies} &
         '''
 
 rule targets:
     input:
         main = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}.json",
-        root_sequence = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_root-sequence.json",
         frequencies = "auspice/flu_seasonal_{lineage}_{segment}_{resolution}_tip-frequencies.json"
     output:
         target = "targets/flu_seasonal_{lineage}_{segment}_{resolution}"

--- a/Snakefile_base
+++ b/Snakefile_base
@@ -266,14 +266,16 @@ rule parse:
         sequences = "results/sequences_{lineage}_{segment}.fasta",
         metadata = "results/metadata_{lineage}_{segment}.tsv"
     params:
-        fasta_fields =  "strain virus accession date region country division location passage authors age gender"
+        fasta_fields =  "strain virus accession date region country division location passage submitting_lab age gender",
+        prettify_fields = "region country division location submitting_lab"
     shell:
         """
         augur parse \
             --sequences {input.sequences} \
             --output-sequences {output.sequences} \
             --output-metadata {output.metadata} \
-            --fields {params.fasta_fields}
+            --fields {params.fasta_fields} \
+            --prettify-fields {params.prettify_fields}
         """
 
 rule filter:

--- a/Snakefile_base
+++ b/Snakefile_base
@@ -228,7 +228,7 @@ rule download_sequences:
     output:
         sequences = "data/{lineage}_{segment}.fasta"
     params:
-        fasta_fields = "strain virus accession collection_date region country division location passage_category submitting_lab age gender"
+        fasta_fields = "strain virus accession collection_date region country division location passage_category originating_lab submitting_lab age gender"
     shell:
         """
         python3 {path_to_fauna}/vdb/download.py \
@@ -266,8 +266,8 @@ rule parse:
         sequences = "results/sequences_{lineage}_{segment}.fasta",
         metadata = "results/metadata_{lineage}_{segment}.tsv"
     params:
-        fasta_fields =  "strain virus accession date region country division location passage submitting_lab age gender",
-        prettify_fields = "region country division location submitting_lab"
+        fasta_fields =  "strain virus accession date region country division location passage originating_lab submitting_lab age gender",
+        prettify_fields = "region country division location originating_lab submitting_lab"
     shell:
         """
         augur parse \

--- a/Snakefile_countries
+++ b/Snakefile_countries
@@ -68,7 +68,7 @@ rule export:
         auspice_meta = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_meta.json"
     shell:
         """
-        augur export \
+        augur export v1 \
             --tree {input.tree} \
             --metadata {input.metadata} \
             --node-data {input.node_data} \

--- a/Snakefile_report
+++ b/Snakefile_report
@@ -22,7 +22,7 @@ def mutations_to_plot(v):
 
 def clades_to_plot(v):
     clades = {
-        ('h3n2', 'ha'): ["A1b/135K", "A1b/131K", "A2/re", "3c3.A"],
+        ('h3n2', 'ha'): ["A1b/135K", "A1b/131K", "A1b/137F", "A1b/197R", "A2/re", "3c3.A"],
         ('h1n1pdm', 'ha'): ["6b1.A/183P-1", "6b1.A/183P-2", "6b1.A/183P-5"],
         ('vic', 'ha'): ["V1A", "V1A.1", "V1A.2", "V1A.3", "V1A/165N"],
         ('yam', 'ha'): ["172Q", "3"],
@@ -30,7 +30,7 @@ def clades_to_plot(v):
     return clades[(v.lineage, v.segment)]
 
 def get_extra_muts(w):
-	extra_muts = {'h1n1pdm':'156K', 'h3n2':'137S', 'vic':'133R', 'yam':''}
+    extra_muts = {'h1n1pdm':'156K 156D', 'h3n2':'', 'vic':'133R', 'yam':''}
     return extra_muts[w.lineage]
 
 regions_to_graph = ['china', 'europe', 'japan_korea', 'oceania', 'north_america', 'south_america', 'global']

--- a/config/auspice_config_h1n1pdm.json
+++ b/config/auspice_config_h1n1pdm.json
@@ -21,10 +21,6 @@
       "title": "Country",
       "type": "categorical"
     },
-    "submitting_lab": {
-      "title": "Submitting lab",
-      "type": "categorical"
-    },
     "cTiter": {
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
@@ -46,6 +42,14 @@
     "ne": {
       "title": "Non-epitope mutations",
       "type": "ordinal"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    "originating_lab": {
+      "title": "Originating lab",
+      "type": "categorical"
     }
   },
   "geo_resolutions": [

--- a/config/auspice_config_h1n1pdm.json
+++ b/config/auspice_config_h1n1pdm.json
@@ -1,84 +1,75 @@
 {
   "title": "Real-time tracking of influenza A/H1N1pdm evolution",
-  "color_options": {
+  "colorings": {
     "gt": {
-      "menuItem": "genotype",
-      "legendTitle": "Genotype",
-      "type": "discrete",
-      "key": "genotype"
+      "title": "Genotype",
+      "type": "categorical"
     },
     "num_date": {
-      "menuItem": "date",
-      "legendTitle": "Sampling date",
-      "type": "continuous",
-      "key": "num_date"
-    },
-    "region": {
-      "key":"region",
-      "legendTitle":"Region",
-      "menuItem":"region",
-      "type":"discrete"
+      "title": "Date",
+      "type": "continuous"
     },
     "clade_membership": {
-      "key": "clade_membership",
-      "legendTitle": "Clade",
-      "menuItem": "clade",
-      "type": "discrete"
+      "title": "Clade",
+      "type": "categorical"
+    },
+    "region": {
+      "title": "Region",
+      "type": "categorical"
+    },
+    "country": {
+      "title": "Country",
+      "type": "categorical"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
     },
     "cTiter": {
-      "key": "cTiter",
-      "legendTitle": "Antigenic advance (tree model)",
-      "menuItem": "antigenic advance (tree model)",
+      "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
     "cTiterSub": {
-      "key": "cTiterSub",
-      "legendTitle": "Antigenic advance (sub model)",
-      "menuItem": "antigenic advance (sub model)",
+      "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
     "lbi": {
       "vmin": 0,
       "vmax": 0.7,
-      "legendTitle": "local branching index",
-      "key": "lbi",
-      "menuItem": "local branching index",
+      "title": "Local branching index",
       "type": "continuous"
     },
     "ep": {
-      "menuItem": "epitope mutations",
-      "legendTitle": "Epitope mutations",
-      "type": "continuous",
-      "key": "ep"
+      "title": "Epitope mutations",
+      "type": "ordinal"
     },
     "ne": {
-      "menuItem": "non-epitope mutations",
-      "legendTitle": "Non-epitope mutations",
-      "type": "continuous",
-      "key": "ne"
+      "title": "Non-epitope mutations",
+      "type": "ordinal"
     }
   },
-  "geo": [
+  "geo_resolutions": [
     "country",
     "region"
   ],
-  "defaults": {
-    "mapTriplicate": true,
-    "colorBy": "clade_membership"
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
   },
-  "maintainer": [
-    "Trevor Bedford and Barney Potter",
-    "http://bedford.io/"
+  "maintainers": [
+    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
+    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
+    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
   ],
   "filters": [
     "clade_membership",
     "region",
     "country",
-    "authors"
+    "submitting_lab"
   ],
   "panels": [
     "tree",
-    "map",    
+    "map",
     "entropy",
     "frequencies"
   ],

--- a/config/auspice_config_h1n1pdm.json
+++ b/config/auspice_config_h1n1pdm.json
@@ -1,57 +1,67 @@
 {
   "title": "Real-time tracking of influenza A/H1N1pdm evolution",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Date",
       "type": "continuous"
     },
-    "clade_membership": {
+    {
+      "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"
     },
-    "region": {
-      "title": "Region",
-      "type": "categorical"
-    },
-    "country": {
-      "title": "Country",
-      "type": "categorical"
-    },
-    "cTiter": {
+    {
+      "key": "cTiter",
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
-    "cTiterSub": {
+    {
+      "key": "cTiterSub",
       "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
-    "lbi": {
-      "vmin": 0,
-      "vmax": 0.7,
+    {
+      "key": "lbi",
       "title": "Local branching index",
       "type": "continuous"
     },
-    "ep": {
+    {
+      "key": "ep",
       "title": "Epitope mutations",
       "type": "ordinal"
     },
-    "ne": {
+    {
+      "key": "ne",
       "title": "Non-epitope mutations",
       "type": "ordinal"
     },
-    "submitting_lab": {
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
     },
-    "originating_lab": {
+    {
+      "key": "originating_lab",
       "title": "Originating lab",
       "type": "categorical"
     }
-  },
+  ],
   "geo_resolutions": [
     "country",
     "region"
@@ -61,9 +71,9 @@
     "color_by": "clade_membership"
   },
   "maintainers": [
-    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
-    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
-    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
   ],
   "filters": [
     "clade_membership",

--- a/config/auspice_config_h1n1pdm.json
+++ b/config/auspice_config_h1n1pdm.json
@@ -1,5 +1,11 @@
 {
   "title": "Real-time tracking of influenza A/H1N1pdm evolution",
+  "maintainers": [
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
   "colorings": [
     {
       "key": "gt",
@@ -70,11 +76,6 @@
     "map_triplicate": true,
     "color_by": "clade_membership"
   },
-  "maintainers": [
-    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
-    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
-    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
-  ],
   "filters": [
     "clade_membership",
     "region",

--- a/config/auspice_config_h3n2.json
+++ b/config/auspice_config_h3n2.json
@@ -1,86 +1,75 @@
 {
   "title": "Real-time tracking of influenza A/H3N2 evolution",
-  "color_options": {
+  "colorings": {
     "gt": {
-      "menuItem": "genotype",
-      "legendTitle": "Genotype",
-      "type": "discrete",
-      "key": "genotype"
+      "title": "Genotype",
+      "type": "categorical"
     },
     "num_date": {
-      "menuItem": "date",
-      "legendTitle": "Sampling date",
-      "type": "continuous",
-      "key": "num_date"
-    },
-    "region": {
-      "key":"region",
-      "legendTitle":"Region",
-      "menuItem":"region",
-      "type":"discrete"
+      "title": "Date",
+      "type": "continuous"
     },
     "clade_membership": {
-      "key": "clade_membership",
-      "legendTitle": "Clade",
-      "menuItem": "clade",
-      "type": "discrete"
+      "title": "Clade",
+      "type": "categorical"
+    },
+    "region": {
+      "title": "Region",
+      "type": "categorical"
+    },
+    "country": {
+      "title": "Country",
+      "type": "categorical"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
     },
     "cTiter": {
-      "key": "cTiter",
-      "legendTitle": "Antigenic advance (tree model)",
-      "menuItem": "antigenic advance (tree model)",
+      "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
     "cTiterSub": {
-      "key": "cTiterSub",
-      "legendTitle": "Antigenic advance (sub model)",
-      "menuItem": "antigenic advance (sub model)",
+      "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
     "lbi": {
       "vmin": 0,
       "vmax": 0.7,
-      "legendTitle": "local branching index",
-      "key": "lbi",
-      "menuItem": "local branching index",
+      "title": "Local branching index",
       "type": "continuous"
     },
     "ep": {
-      "menuItem": "epitope mutations",
-      "legendTitle": "Epitope mutations",
-      "type": "continuous",
-      "key": "ep"
+      "title": "Epitope mutations",
+      "type": "ordinal"
     },
     "ne": {
-      "menuItem": "non-epitope mutations",
-      "legendTitle": "Non-epitope mutations",
-      "type": "continuous",
-      "key": "ne"
+      "title": "Non-epitope mutations",
+      "type": "ordinal"
     },
     "rb": {
-      "menuItem": "RBS adjacent mutations",
-      "legendTitle": "RBS adjacent mutations",
-      "type": "continuous",
-      "key": "rb"
+      "title": "RBS adjacent mutations",
+      "type": "ordinal"
     }
   },
-  "geo": [
+  "geo_resolutions": [
     "country",
     "region"
   ],
-  "defaults": {
-    "mapTriplicate": true,
-    "colorBy": "clade_membership"
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
   },
-  "maintainer": [
-    "Trevor Bedford and Barney Potter",
-    "http://bedford.io/"
+  "maintainers": [
+    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
+    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
+    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
   ],
   "filters": [
     "clade_membership",
     "region",
     "country",
-    "authors"
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/config/auspice_config_h3n2.json
+++ b/config/auspice_config_h3n2.json
@@ -1,61 +1,72 @@
 {
   "title": "Real-time tracking of influenza A/H3N2 evolution",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Date",
       "type": "continuous"
     },
-    "clade_membership": {
+    {
+      "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"
     },
-    "region": {
-      "title": "Region",
-      "type": "categorical"
-    },
-    "country": {
-      "title": "Country",
-      "type": "categorical"
-    },
-    "cTiter": {
+    {
+      "key": "cTiter",
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
-    "cTiterSub": {
+    {
+      "key": "cTiterSub",
       "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
-    "lbi": {
-      "vmin": 0,
-      "vmax": 0.7,
+    {
+      "key": "lbi",
       "title": "Local branching index",
       "type": "continuous"
     },
-    "ep": {
+    {
+      "key": "ep",
       "title": "Epitope mutations",
       "type": "ordinal"
     },
-    "ne": {
+    {
+      "key": "ne",
       "title": "Non-epitope mutations",
       "type": "ordinal"
     },
-    "rb": {
+    {
+      "key": "rb",
       "title": "RBS adjacent mutations",
       "type": "ordinal"
     },
-    "submitting_lab": {
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
     },
-    "originating_lab": {
+    {
+      "key": "originating_lab",
       "title": "Originating lab",
       "type": "categorical"
     }
-  },
+  ],
   "geo_resolutions": [
     "country",
     "region"
@@ -65,9 +76,9 @@
     "color_by": "clade_membership"
   },
   "maintainers": [
-    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
-    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
-    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
   ],
   "filters": [
     "clade_membership",

--- a/config/auspice_config_h3n2.json
+++ b/config/auspice_config_h3n2.json
@@ -1,5 +1,11 @@
 {
   "title": "Real-time tracking of influenza A/H3N2 evolution",
+  "maintainers": [
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
   "colorings": [
     {
       "key": "gt",
@@ -75,11 +81,6 @@
     "map_triplicate": true,
     "color_by": "clade_membership"
   },
-  "maintainers": [
-    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
-    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
-    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
-  ],
   "filters": [
     "clade_membership",
     "region",

--- a/config/auspice_config_h3n2.json
+++ b/config/auspice_config_h3n2.json
@@ -21,10 +21,6 @@
       "title": "Country",
       "type": "categorical"
     },
-    "submitting_lab": {
-      "title": "Submitting lab",
-      "type": "categorical"
-    },
     "cTiter": {
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
@@ -50,6 +46,14 @@
     "rb": {
       "title": "RBS adjacent mutations",
       "type": "ordinal"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    "originating_lab": {
+      "title": "Originating lab",
+      "type": "categorical"
     }
   },
   "geo_resolutions": [

--- a/config/auspice_config_h3n2_fitness.json
+++ b/config/auspice_config_h3n2_fitness.json
@@ -21,10 +21,6 @@
       "title": "Country",
       "type": "categorical"
     },
-    "submitting_lab": {
-      "title": "Submitting lab",
-      "type": "categorical"
-    },
     "cTiter": {
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
@@ -58,6 +54,14 @@
     "weighted_distance_to_future": {
       "title": "Distance to future population",
       "type": "continuous"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    "originating_lab": {
+      "title": "Originating lab",
+      "type": "categorical"
     }
   },
   "geo_resolutions": [

--- a/config/auspice_config_h3n2_fitness.json
+++ b/config/auspice_config_h3n2_fitness.json
@@ -1,98 +1,83 @@
 {
   "title": "Real-time tracking of influenza A/H3N2 evolution",
-  "color_options": {
+  "colorings": {
     "gt": {
-      "menuItem": "genotype",
-      "legendTitle": "Genotype",
-      "type": "discrete",
-      "key": "genotype"
+      "title": "Genotype",
+      "type": "categorical"
     },
     "num_date": {
-      "menuItem": "date",
-      "legendTitle": "Sampling date",
-      "type": "continuous",
-      "key": "num_date"
-    },
-    "region": {
-      "key":"region",
-      "legendTitle":"Region",
-      "menuItem":"region",
-      "type":"discrete"
+      "title": "Date",
+      "type": "continuous"
     },
     "clade_membership": {
-      "key": "clade_membership",
-      "legendTitle": "Clade",
-      "menuItem": "clade",
-      "type": "discrete"
+      "title": "Clade",
+      "type": "categorical"
+    },
+    "region": {
+      "title": "Region",
+      "type": "categorical"
+    },
+    "country": {
+      "title": "Country",
+      "type": "categorical"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
     },
     "cTiter": {
-      "key": "cTiter",
-      "legendTitle": "Antigenic advance (tree model)",
-      "menuItem": "antigenic advance (tree model)",
+      "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
     "cTiterSub": {
-      "key": "cTiterSub",
-      "legendTitle": "Antigenic advance (sub model)",
-      "menuItem": "antigenic advance (sub model)",
+      "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
     "lbi": {
       "vmin": 0,
       "vmax": 0.7,
-      "legendTitle": "local branching index",
-      "key": "lbi",
-      "menuItem": "local branching index",
+      "title": "Local branching index",
       "type": "continuous"
     },
     "ep": {
-      "menuItem": "epitope mutations",
-      "legendTitle": "Epitope mutations",
-      "type": "continuous",
-      "key": "ep"
+      "title": "Epitope mutations",
+      "type": "ordinal"
     },
     "ne": {
-      "menuItem": "non-epitope mutations",
-      "legendTitle": "Non-epitope mutations",
-      "type": "continuous",
-      "key": "ne"
+      "title": "Non-epitope mutations",
+      "type": "ordinal"
     },
     "rb": {
-      "menuItem": "RBS adjacent mutations",
-      "legendTitle": "RBS adjacent mutations",
-      "type": "continuous",
-      "key": "rb"
+      "title": "RBS adjacent mutations",
+      "type": "ordinal"
     },
     "fitness": {
-      "menuItem": "fitness",
-      "legendTitle": "Fitness",
-      "type": "continuous",
-      "key": "fitness"
+      "title": "Fitness",
+      "type": "continuous"
     },
     "weighted_distance_to_future": {
-      "menuItem": "distance to future population",
-      "legendTitle": "Distance to future population",
-      "type": "continuous",
-      "key": "weighted_distance_to_future"
+      "title": "Distance to future population",
+      "type": "continuous"
     }
   },
-  "geo": [
+  "geo_resolutions": [
     "country",
     "region"
   ],
-  "defaults": {
-    "mapTriplicate": true,
-    "colorBy": "clade_membership"
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
   },
-  "maintainer": [
-    "Trevor Bedford and Barney Potter",
-    "http://bedford.io/"
+  "maintainers": [
+    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
+    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
+    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
   ],
   "filters": [
     "clade_membership",
     "region",
     "country",
-    "authors"
+    "submitting_lab"
   ],
   "panels": [
     "tree",
@@ -111,6 +96,6 @@
     "A/Singapore/Infimh-16-0019/2016": "2017-09-28",
     "A/Switzerland/8060/2017": "2018-09-27",
     "A/Kansas/14/2017": "2019-03-21",
-    "A/SouthAustralia/34/2019": "2019-09-27"    
+    "A/SouthAustralia/34/2019": "2019-09-27"
   }
 }

--- a/config/auspice_config_h3n2_fitness.json
+++ b/config/auspice_config_h3n2_fitness.json
@@ -1,69 +1,82 @@
 {
   "title": "Real-time tracking of influenza A/H3N2 evolution",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Date",
       "type": "continuous"
     },
-    "clade_membership": {
+    {
+      "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"
     },
-    "region": {
-      "title": "Region",
-      "type": "categorical"
-    },
-    "country": {
-      "title": "Country",
-      "type": "categorical"
-    },
-    "cTiter": {
-      "title": "Antigenic advance (tree model)",
-      "type": "continuous"
-    },
-    "cTiterSub": {
-      "title": "Antigenic advance (sub model)",
-      "type": "continuous"
-    },
-    "lbi": {
-      "vmin": 0,
-      "vmax": 0.7,
-      "title": "Local branching index",
-      "type": "continuous"
-    },
-    "ep": {
-      "title": "Epitope mutations",
-      "type": "ordinal"
-    },
-    "ne": {
-      "title": "Non-epitope mutations",
-      "type": "ordinal"
-    },
-    "rb": {
-      "title": "RBS adjacent mutations",
-      "type": "ordinal"
-    },
-    "fitness": {
+    {
+      "key": "fitness",
       "title": "Fitness",
       "type": "continuous"
     },
-    "weighted_distance_to_future": {
+    {
+      "key": "weighted_distance_to_future",
       "title": "Distance to future population",
       "type": "continuous"
     },
-    "submitting_lab": {
+    {
+      "key": "cTiter",
+      "title": "Antigenic advance (tree model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiterSub",
+      "title": "Antigenic advance (sub model)",
+      "type": "continuous"
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "ep",
+      "title": "Epitope mutations",
+      "type": "ordinal"
+    },
+    {
+      "key": "ne",
+      "title": "Non-epitope mutations",
+      "type": "ordinal"
+    },
+    {
+      "key": "rb",
+      "title": "RBS adjacent mutations",
+      "type": "ordinal"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
     },
-    "originating_lab": {
+    {
+      "key": "originating_lab",
       "title": "Originating lab",
       "type": "categorical"
     }
-  },
+  ],
   "geo_resolutions": [
     "country",
     "region"
@@ -73,9 +86,9 @@
     "color_by": "clade_membership"
   },
   "maintainers": [
-    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
-    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
-    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
   ],
   "filters": [
     "clade_membership",

--- a/config/auspice_config_h3n2_fitness.json
+++ b/config/auspice_config_h3n2_fitness.json
@@ -1,5 +1,11 @@
 {
   "title": "Real-time tracking of influenza A/H3N2 evolution",
+  "maintainers": [
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
   "colorings": [
     {
       "key": "gt",
@@ -85,11 +91,6 @@
     "map_triplicate": true,
     "color_by": "clade_membership"
   },
-  "maintainers": [
-    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
-    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
-    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
-  ],
   "filters": [
     "clade_membership",
     "region",

--- a/config/auspice_config_vic.json
+++ b/config/auspice_config_vic.json
@@ -1,72 +1,67 @@
 {
   "title": "Real-time tracking of influenza B/Vic evolution",
-  "color_options": {
+  "colorings": {
     "gt": {
-      "menuItem": "genotype",
-      "legendTitle": "Genotype",
-      "type": "discrete",
-      "key": "genotype"
+      "title": "Genotype",
+      "type": "categorical"
     },
     "num_date": {
-      "menuItem": "date",
-      "legendTitle": "Sampling date",
-      "type": "continuous",
-      "key": "num_date"
-    },
-    "region": {
-      "key":"region",
-      "legendTitle":"Region",
-      "menuItem":"region",
-      "type":"discrete"
+      "title": "Date",
+      "type": "continuous"
     },
     "clade_membership": {
-      "key": "clade_membership",
-      "legendTitle": "Clade",
-      "menuItem": "clade",
-      "type": "discrete"
+      "title": "Clade",
+      "type": "categorical"
+    },
+    "region": {
+      "title": "Region",
+      "type": "categorical"
+    },
+    "country": {
+      "title": "Country",
+      "type": "categorical"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
     },
     "cTiter": {
-      "key": "cTiter",
-      "legendTitle": "Antigenic advance (tree model)",
-      "menuItem": "antigenic advance (tree model)",
+      "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
     "cTiterSub": {
-      "key": "cTiterSub",
-      "legendTitle": "Antigenic advance (sub model)",
-      "menuItem": "antigenic advance (sub model)",
+      "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
     "lbi": {
       "vmin": 0,
       "vmax": 0.7,
-      "legendTitle": "local branching index",
-      "key": "lbi",
-      "menuItem": "local branching index",
+      "title": "Local branching index",
       "type": "continuous"
     }
   },
-  "geo": [
+  "geo_resolutions": [
     "country",
     "region"
   ],
-  "defaults": {
-    "mapTriplicate": true,
-    "colorBy": "clade_membership"
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
   },
-  "maintainer": [
-    "Trevor Bedford and Barney Potter",
-    "http://bedford.io/"
+  "maintainers": [
+    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
+    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
+    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
   ],
   "filters": [
     "clade_membership",
     "region",
     "country",
-    "authors"
+    "submitting_lab"
   ],
   "panels": [
     "tree",
-    "map",    
+    "map",
     "entropy",
     "frequencies"
   ],

--- a/config/auspice_config_vic.json
+++ b/config/auspice_config_vic.json
@@ -1,49 +1,57 @@
 {
   "title": "Real-time tracking of influenza B/Vic evolution",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Date",
       "type": "continuous"
     },
-    "clade_membership": {
+    {
+      "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"
     },
-    "region": {
-      "title": "Region",
-      "type": "categorical"
-    },
-    "country": {
-      "title": "Country",
-      "type": "categorical"
-    },
-    "cTiter": {
+    {
+      "key": "cTiter",
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
-    "cTiterSub": {
+    {
+      "key": "cTiterSub",
       "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
-    "lbi": {
-      "vmin": 0,
-      "vmax": 0.7,
+    {
+      "key": "lbi",
       "title": "Local branching index",
       "type": "continuous"
     },
-    "submitting_lab": {
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
     },
-    "originating_lab": {
+    {
+      "key": "originating_lab",
       "title": "Originating lab",
       "type": "categorical"
     }
-  },
+  ],
   "geo_resolutions": [
     "country",
     "region"
@@ -53,9 +61,9 @@
     "color_by": "clade_membership"
   },
   "maintainers": [
-    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
-    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
-    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
   ],
   "filters": [
     "clade_membership",

--- a/config/auspice_config_vic.json
+++ b/config/auspice_config_vic.json
@@ -1,5 +1,11 @@
 {
   "title": "Real-time tracking of influenza B/Vic evolution",
+  "maintainers": [
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
   "colorings": [
     {
       "key": "gt",
@@ -60,11 +66,6 @@
     "map_triplicate": true,
     "color_by": "clade_membership"
   },
-  "maintainers": [
-    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
-    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
-    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
-  ],
   "filters": [
     "clade_membership",
     "region",

--- a/config/auspice_config_vic.json
+++ b/config/auspice_config_vic.json
@@ -21,10 +21,6 @@
       "title": "Country",
       "type": "categorical"
     },
-    "submitting_lab": {
-      "title": "Submitting lab",
-      "type": "categorical"
-    },
     "cTiter": {
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
@@ -38,6 +34,14 @@
       "vmax": 0.7,
       "title": "Local branching index",
       "type": "continuous"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    "originating_lab": {
+      "title": "Originating lab",
+      "type": "categorical"
     }
   },
   "geo_resolutions": [

--- a/config/auspice_config_yam.json
+++ b/config/auspice_config_yam.json
@@ -1,68 +1,63 @@
 {
   "title": "Real-time tracking of influenza B/Yam evolution",
-  "color_options": {
+  "colorings": {
     "gt": {
-      "menuItem": "genotype",
-      "legendTitle": "Genotype",
-      "type": "discrete",
-      "key": "genotype"
+      "title": "Genotype",
+      "type": "categorical"
     },
     "num_date": {
-      "menuItem": "date",
-      "legendTitle": "Sampling date",
-      "type": "continuous",
-      "key": "num_date"
-    },
-    "region": {
-      "key":"region",
-      "legendTitle":"Region",
-      "menuItem":"region",
-      "type":"discrete"
+      "title": "Date",
+      "type": "continuous"
     },
     "clade_membership": {
-      "key": "clade_membership",
-      "legendTitle": "Clade",
-      "menuItem": "clade",
-      "type": "discrete"
+      "title": "Clade",
+      "type": "categorical"
+    },
+    "region": {
+      "title": "Region",
+      "type": "categorical"
+    },
+    "country": {
+      "title": "Country",
+      "type": "categorical"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
     },
     "cTiter": {
-      "key": "cTiter",
-      "legendTitle": "Antigenic advance (tree model)",
-      "menuItem": "antigenic advance (tree model)",
+      "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
     "cTiterSub": {
-      "key": "cTiterSub",
-      "legendTitle": "Antigenic advance (sub model)",
-      "menuItem": "antigenic advance (sub model)",
+      "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
     "lbi": {
       "vmin": 0,
       "vmax": 0.7,
-      "legendTitle": "local branching index",
-      "key": "lbi",
-      "menuItem": "local branching index",
+      "title": "Local branching index",
       "type": "continuous"
     }
   },
-  "geo": [
+  "geo_resolutions": [
     "country",
     "region"
   ],
-  "defaults": {
-    "mapTriplicate": true,
-    "colorBy": "clade_membership"
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
   },
-  "maintainer": [
-    "Trevor Bedford and Barney Potter",
-    "http://bedford.io/"
+  "maintainers": [
+    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
+    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
+    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
   ],
   "filters": [
     "clade_membership",
     "region",
     "country",
-    "authors"
+    "submitting_lab"
   ],
   "panels": [
     "tree",

--- a/config/auspice_config_yam.json
+++ b/config/auspice_config_yam.json
@@ -1,5 +1,11 @@
 {
   "title": "Real-time tracking of influenza B/Yam evolution",
+  "maintainers": [
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
   "colorings": [
     {
       "key": "gt",
@@ -60,11 +66,6 @@
     "map_triplicate": true,
     "color_by": "clade_membership"
   },
-  "maintainers": [
-    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
-    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
-    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
-  ],
   "filters": [
     "clade_membership",
     "region",

--- a/config/auspice_config_yam.json
+++ b/config/auspice_config_yam.json
@@ -21,10 +21,6 @@
       "title": "Country",
       "type": "categorical"
     },
-    "submitting_lab": {
-      "title": "Submitting lab",
-      "type": "categorical"
-    },
     "cTiter": {
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
@@ -38,6 +34,14 @@
       "vmax": 0.7,
       "title": "Local branching index",
       "type": "continuous"
+    },
+    "submitting_lab": {
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    "originating_lab": {
+      "title": "Originating lab",
+      "type": "categorical"
     }
   },
   "geo_resolutions": [

--- a/config/auspice_config_yam.json
+++ b/config/auspice_config_yam.json
@@ -1,49 +1,57 @@
 {
   "title": "Real-time tracking of influenza B/Yam evolution",
-  "colorings": {
-    "gt": {
+  "colorings": [
+    {
+      "key": "gt",
       "title": "Genotype",
       "type": "categorical"
     },
-    "num_date": {
+    {
+      "key": "num_date",
       "title": "Date",
       "type": "continuous"
     },
-    "clade_membership": {
+    {
+      "key": "clade_membership",
       "title": "Clade",
       "type": "categorical"
     },
-    "region": {
-      "title": "Region",
-      "type": "categorical"
-    },
-    "country": {
-      "title": "Country",
-      "type": "categorical"
-    },
-    "cTiter": {
+    {
+      "key": "cTiter",
       "title": "Antigenic advance (tree model)",
       "type": "continuous"
     },
-    "cTiterSub": {
+    {
+      "key": "cTiterSub",
       "title": "Antigenic advance (sub model)",
       "type": "continuous"
     },
-    "lbi": {
-      "vmin": 0,
-      "vmax": 0.7,
+    {
+      "key": "lbi",
       "title": "Local branching index",
       "type": "continuous"
     },
-    "submitting_lab": {
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
     },
-    "originating_lab": {
+    {
+      "key": "originating_lab",
       "title": "Originating lab",
       "type": "categorical"
     }
-  },
+  ],
   "geo_resolutions": [
     "country",
     "region"
@@ -53,9 +61,9 @@
     "color_by": "clade_membership"
   },
   "maintainers": [
-    ["Jover Lee", "https://bedford.io/team/jover-lee/"],
-    ["Richard Neher", "https://neherlab.org/richard-neher.html"],
-    ["Trevor Bedford", "https://bedford.io/team/trevor-bedford/"]
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
   ],
   "filters": [
     "clade_membership",

--- a/config/frequency_weights_by_region.json
+++ b/config/frequency_weights_by_region.json
@@ -1,12 +1,12 @@
 {
     "africa": 1.02,
     "europe": 0.74,
-    "north_america": 0.54,
+    "north america": 0.54,
     "china": 1.36,
-    "south_asia": 1.45,
-    "japan_korea": 0.20,
+    "south asia": 1.45,
+    "japan korea": 0.20,
     "oceania": 0.04,
-    "south_america": 0.41,
-    "southeast_asia": 0.62,
-    "west_asia": 0.75
+    "south america": 0.41,
+    "southeast asia": 0.62,
+    "west asia": 0.75
 }

--- a/flu-forecasting/src/forecast_model.py
+++ b/flu-forecasting/src/forecast_model.py
@@ -61,17 +61,12 @@ if __name__ == "__main__":
     # collect fitness and projection
     forecasts_df = model.predict(tips)
     forecasts_df["weighted_distance_to_future_by_%s" % "-".join(predictors)] = forecasts_df["y"]
-    forecasts_df["future_timepoint"] = forecasts_df["timepoint"] + delta_offset
 
     # collect dicts from dataframe
     strain_to_fitness = {}
-    strain_to_future_timepoint = {}
-    strain_to_projected_frequency = {}
     strain_to_weighted_distance_to_future = {}
     for index, row in forecasts_df.iterrows():
         strain_to_fitness[row['strain']] = row['fitness']
-        strain_to_future_timepoint[row['strain']] = row["future_timepoint"].strftime("%Y-%m-%d")
-        strain_to_projected_frequency[row['strain']] = row['projected_frequency']
         strain_to_weighted_distance_to_future[row['strain']] = row['y']
 
     # populate node data
@@ -80,8 +75,6 @@ if __name__ == "__main__":
     for strain in strains:
         node_data[strain] = {
             "fitness": strain_to_fitness[strain],
-            "future_timepoint": strain_to_future_timepoint[strain],
-            "projected_frequency": strain_to_projected_frequency[strain],
             "weighted_distance_to_future": strain_to_weighted_distance_to_future[strain]
         }
 

--- a/scripts/graph_frequencies.py
+++ b/scripts/graph_frequencies.py
@@ -290,7 +290,7 @@ if __name__ == '__main__':
         if args.clade_annotations:
             clade_annotations = load_frequencies(args.clade_annotations)
             clade_to_node = {node["clade_annotation"]:node_name for node_name, node in clade_annotations['nodes'].items()
-                             if "clade_annotation" in node}
-
+                             if "clade_annotation" in node and node_name[:4]=='NODE'}
+            print(clade_to_node) #, [(c,tree_frequencies[n]) for c,n in clade_to_node.items()])
             plot_clades_by_region(tree_frequencies, args.clades, clade_to_node,
                                   args.output_clades, regions=args.regions, drop=1)

--- a/scripts/plot_titer_matrices.py
+++ b/scripts/plot_titer_matrices.py
@@ -12,7 +12,7 @@ import seaborn as sns
 from select_strains import read_strain_list, regions, determine_time_interval, parse_metadata
 
 
-h3n2_clades = ['A1', 'A1a', 'A1b', 'A1b/135K', 'A1b/135N', 'A1b/131K','A2', 'A2/re', '3c3.A']
+h3n2_clades = ['A1', 'A1a', 'A1b', 'A1b/135K', 'A1b/137F','A1b/135N', 'A1b/131K', 'A1b/197R', 'A2', 'A2/re', '3c3.A']
 h1n1_clades = ["6b1.A", "6b1.A/183P-1", "6b1.A/183P-2", "6b1.A/183P-3", "6b1.A/183P-5", "6b1.A/183P-6", "6b1.A/183P-7"]
 vic_clades =  ["V1A", "V1A.1","V1A.2", "V1A.3", "V1A/165N"]
 yam_clades = ["172Q", "3"]


### PR DESCRIPTION
This updates the seasonal flu build to use `augur export v2`. Major changes include:

* Snakefile: Request single JSON, don't reques root sequence
* Snakefile: Include wildcard constraints. Without these there was degeneracy of files in the auspice/ directory
* Snakefile_base: Prettify region, country and submitting lab
* frequency_weights_by_region: Swap "_" to " "
* auspice_config: Update "colorings", "geo_resolutions", "display_defaults", "maintainers", "filters" and include "build_url"
* revise sort order of colorings
* remove extraneous "vmin" and "vmax"  attached to "lbi"
* define vaccine info in JSON files within `config/`
