### PR TITLE
Update region names in frequency weights to match metadata

### DIFF
--- a/config/frequency_weights_by_region.json
+++ b/config/frequency_weights_by_region.json
@@ -1,12 +1,12 @@
 {
-    "africa": 1.02,
-    "europe": 0.74,
-    "north america": 0.54,
-    "china": 1.36,
-    "south asia": 1.45,
-    "japan korea": 0.20,
-    "oceania": 0.04,
-    "south america": 0.41,
-    "southeast asia": 0.62,
-    "west asia": 0.75
+    "Africa": 1.02,
+    "Europe": 0.74,
+    "North America": 0.54,
+    "China": 1.36,
+    "South Asia": 1.45,
+    "Japan Korea": 0.20,
+    "Oceania": 0.04,
+    "South America": 0.41,
+    "Southeast Asia": 0.62,
+    "West Asia": 0.75
 }


### PR DESCRIPTION
Resolves an issue with KDE frequency weighting where the regions used to weight
frequencies were represented differently in the metadata and the weights
JSON. For example, the metadata contains prettified regions like "North America"
while the weights JSON referred to this region as "north america". This issue
was revealed after introducing code to augur frequencies that eliminated all
unrepresented weight attributes from consideration. When no weights were
represented by the given tips (because of the casing difference shown above),
weighted frequency estimation failed with a ValueError.

[1] https://github.com/nextstrain/augur/pull/420