### PR TITLE
Update WHO build

### DIFF
--- a/scripts/global_frequencies.py
+++ b/scripts/global_frequencies.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
         with open(freq_file) as fh:
             frequencies[region] = json.load(fh)
 
-    all_mutations = sorted(filter(lambda x:('counts' not in x) and ('pivots' not in x),
+    all_mutations = sorted(filter(lambda x:('counts' not in x) and ('pivots' not in x) and (x != 'generated_by'),
                            set.union(*[set(frequencies[region].keys()) for region in frequencies])))
     pivots = frequencies[args.regions[0]]['pivots']
     frequencies['global']['pivots'] = format_frequencies(pivots)

--- a/scripts/vaccination_coverage.py
+++ b/scripts/vaccination_coverage.py
@@ -57,7 +57,7 @@ def read_all_vaccination_data():
 	vaccov = defaultdict(list)
 	for d in [vaccov_SA, vaccov_europe, vaccov_OECD]:
 		for c,v in d.items():
-			vaccov[c.lower().replace(' ', '_')].append(v)
+			vaccov[c].append(v)
 	for c,v in vaccov.items():
 		vaccov[c] = np.median(v)
 


### PR DESCRIPTION
This PR fixes the downstream errors in the WHO build due to changes in augur.

1. Ignore the top level `generated_by` key within the frequencies JSON generated by `augur frequencies`.

2. Remove lowering and conversion to snakecase of country names from the static vaccine TSVs, since the metadata now comes in with the country names already "prettified".