### PR TITLE
Harmonize regions

### DIFF
--- a/Snakefile_WHO
+++ b/Snakefile_WHO
@@ -59,9 +59,10 @@ for seg, genes in genes_to_translate.items():
                                                  --metadata {input.metadata} \
                                                  --exclude {input.exclude} \
                                                  --genes {params.genes} \
-                                                 --region {params.region} \
+                                                 --region {params.region:q} \
+                                                 --resolution {wildcards.resolution} \
                                                  --reference {input.reference} \
-                                                 --output {output.alignments}
+                                                 --output {output.alignments:q}
             """
 
 
@@ -82,7 +83,7 @@ rule complete_mutation_frequencies_by_region:
     shell:
         """
         augur frequencies --method diffusion \
-                          --alignments {input.alignment} \
+                          --alignments {input.alignment:q} \
                           --metadata {input.metadata} \
                           --gene-names {params.genes} \
                           --pivot-interval {params.pivot_interval} \
@@ -92,7 +93,7 @@ rule complete_mutation_frequencies_by_region:
                           --min-date {params.min_date} \
                           --max-date {params.max_date} \
                           --minimal-frequency {params.min_freq} \
-                          --output {output.mut_freq}
+                          --output {output.mut_freq:q}
         """
 
 rule global_mutation_frequencies:
@@ -107,9 +108,9 @@ rule global_mutation_frequencies:
         augur="results/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_frequencies.json"
     shell:
         '''
-        python3 scripts/global_frequencies.py --region-frequencies {input.frequencies} \
+        python3 scripts/global_frequencies.py --region-frequencies {input.frequencies:q} \
                                               --tree-frequencies {input.tree_freq} \
-                                              --regions {params.regions} \
+                                              --regions {params.regions:q} \
                                               --output-auspice {output.auspice} \
                                               --output-augur {output.augur}
         '''

--- a/Snakefile_base
+++ b/Snakefile_base
@@ -643,7 +643,7 @@ rule tree_frequencies:
             --method diffusion \
             --include-internal-nodes \
             --tree {input.tree} \
-            --regions {params.regions} \
+            --regions {params.regions:q} \
             --metadata {input.metadata} \
             --pivot-interval {params.pivot_interval} \
             --minimal-clade-size {params.min_clade} \
@@ -669,7 +669,7 @@ rule diffusion_frequencies:
             --method diffusion \
             --include-internal-nodes \
             --tree {input.tree} \
-            --regions {params.regions} \
+            --regions {params.regions:q} \
             --metadata {input.metadata} \
             --pivot-interval {params.pivot_interval} \
             --min-date {params.min_date} \

--- a/Snakefile_base
+++ b/Snakefile_base
@@ -2,11 +2,11 @@ import datetime
 from datetime import date
 import pandas as pd
 from treetime.utils import numeric_date
+from scripts.flu_regions import region_names
 
 path_to_fauna = '../fauna'
 min_length = 900
-frequency_regions = ['north_america', 'south_america', 'europe', 'china', 'oceania',
-                     'southeast_asia', 'japan_korea', 'south_asia', 'africa']
+frequency_regions = region_names
 
 
 localrules: download_titers, download_sequences

--- a/Snakefile_report
+++ b/Snakefile_report
@@ -33,7 +33,7 @@ def get_extra_muts(w):
     extra_muts = {'h1n1pdm':'156K 156D', 'h3n2':'', 'vic':'133R', 'yam':''}
     return extra_muts[w.lineage]
 
-regions_to_graph = ['china', 'europe', 'japan_korea', 'oceania', 'north_america', 'south_america', 'global']
+regions_to_graph = ['China', 'Europe', 'Japan Korea', 'Oceania', 'North America', 'South America', 'global']
 
 rule figures:
     input:

--- a/Snakefile_report
+++ b/Snakefile_report
@@ -33,7 +33,7 @@ def get_extra_muts(w):
     extra_muts = {'h1n1pdm':'156K 156D', 'h3n2':'', 'vic':'133R', 'yam':''}
     return extra_muts[w.lineage]
 
-regions_to_graph = ['China', 'Europe', 'Japan Korea', 'Oceania', 'North America', 'South America', 'global']
+regions_to_graph = ['China', 'Europe', 'Japan Korea', 'Oceania', 'North America', 'South America', 'South Asia', 'global']
 
 rule figures:
     input:
@@ -57,7 +57,7 @@ rule mutation_frequency_graphs:
         """
         python3 scripts/graph_frequencies.py --mutation-frequencies {input.mutations} \
                                             --mutations {params.mutations} \
-                                            --regions {params.regions} \
+                                            --regions {params.regions:q} \
                                             --output-mutations {output.mutations} \
                                             --output-total-counts {output.total_counts} \
         """
@@ -77,7 +77,7 @@ rule clade_frequency_graphs:
         python3 scripts/graph_frequencies.py --tree-frequencies {input.tree} \
                                             --clade-annotation {input.clades} \
                                             --clades {params.clades} \
-                                            --regions {params.regions} \
+                                            --regions {params.regions:q} \
                                             --output-clades {output.clades} \
                                             --output-tree-counts {output.tree_counts}
         """

--- a/scripts/age_distributions.py
+++ b/scripts/age_distributions.py
@@ -7,6 +7,7 @@ from treetime.utils import numeric_date
 from augur.utils import read_metadata, get_numerical_dates
 from select_strains import read_strain_list, regions, determine_time_interval, parse_metadata
 from graph_frequencies import region_label, region_colors
+from flu_regions import *
 
 def age_distribution(metadata, fname, title=None):
     import matplotlib
@@ -19,8 +20,7 @@ def age_distribution(metadata, fname, title=None):
     bc = 0.5*(bins[1:]+bins[:-1])
     plt.figure()
 
-    for region in ['africa','china','europe','japan_korea','north_america','oceania',
-                   'south_america','south_asia','southeast_asia','west_asia','global']:
+    for region in region_names:
         y,x = np.histogram([m['age'] for m in metadata
                             if m['age']!='unknown' and (m['region']==region or region=='global')], bins=bins)
         total = np.sum(y)

--- a/scripts/age_distributions.py
+++ b/scripts/age_distributions.py
@@ -5,8 +5,7 @@ from collections import defaultdict
 from Bio import SeqIO, AlignIO
 from treetime.utils import numeric_date
 from augur.utils import read_metadata, get_numerical_dates
-from select_strains import read_strain_list, regions, determine_time_interval, parse_metadata
-from graph_frequencies import region_label, region_colors
+from select_strains import read_strain_list, determine_time_interval, parse_metadata
 from flu_regions import *
 
 def age_distribution(metadata, fname, title=None):
@@ -21,12 +20,13 @@ def age_distribution(metadata, fname, title=None):
     plt.figure()
 
     for region in region_names:
+        props = region_properties[region]
         y,x = np.histogram([m['age'] for m in metadata
                             if m['age']!='unknown' and (m['region']==region or region=='global')], bins=bins)
         total = np.sum(y)
         y = np.array(y, dtype=float)/total
-        plt.plot(bc, y, label=region_label.get(region, region),
-                 lw=4 if region=='global' else 2, c=region_colors[region])
+        plt.plot(bc, y, label=props.get('label', region),
+                 lw=4 if region=='global' else 2, c=props['color'])
 
     plt.legend(fontsize=fs*0.8, ncol=2)
     if title:

--- a/scripts/age_distributions.py
+++ b/scripts/age_distributions.py
@@ -6,7 +6,7 @@ from Bio import SeqIO, AlignIO
 from treetime.utils import numeric_date
 from augur.utils import read_metadata, get_numerical_dates
 from select_strains import read_strain_list, determine_time_interval, parse_metadata
-from flu_regions import *
+from flu_regions import region_names, region_properties
 
 def age_distribution(metadata, fname, title=None):
     import matplotlib

--- a/scripts/flu_regions.py
+++ b/scripts/flu_regions.py
@@ -1,15 +1,25 @@
+import json
+import os
+
+with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),'../config/frequency_weights_by_region.json')) as fh:
+    population_sizes = json.load(fh)
+
 region_properties = {
     "global":           {'label':"Global", "color":"#111111"},
-    'Africa':           {'abbr':'AF', 'label':'Africa', 'popsize': 1.02, 'color':'#A0CCA5'},
-    'Europe':           {'abbr':'EU', 'label':'Europe', 'popsize': 0.74, 'color':'#658447'},
-    'North America':    {'abbr':'NA', 'label':'N America', 'popsize': 0.54, 'color':'#D6C568'},
-    'China':            {'abbr':'CN', 'label':'China', 'popsize': 1.36, 'color':'#A76BB1'},
-    'South Asia':       {'abbr':'SAS', 'label':'South Asia', 'popsize': 1.45, 'color':'#5199B7'},
-    'Japan Korea':      {'abbr':'JK', 'label':'Japan/Korea', 'popsize': 0.20, 'color':'#2A4786'},
-    'Oceania':          {'abbr':'OC', 'label':'Oceania', 'popsize': 0.04, 'color':'#8E1616'},
-    'South America':    {'abbr':'SA', 'label':'S America', 'popsize': 0.41, 'color':'#EBA85F'},
-    'Southeast Asia':   {'abbr':'SEA', 'label':'SE Asia', 'popsize': 0.62, 'color':'#8FBDD0'},
-    'West Asia':        {'abbr':'WA', 'label':'W Asia', 'popsize': 0.75, 'color':'#76104B'},
+    'Africa':           {'abbr':'AF', 'label':'Africa', 'color':'#A0CCA5'},
+    'Europe':           {'abbr':'EU', 'label':'Europe', 'color':'#658447'},
+    'North America':    {'abbr':'NA', 'label':'N America', 'color':'#D6C568'},
+    'China':            {'abbr':'CN', 'label':'China', 'color':'#A76BB1'},
+    'South Asia':       {'abbr':'SAS', 'label':'South Asia', 'color':'#5199B7'},
+    'Japan Korea':      {'abbr':'JK', 'label':'Japan/Korea', 'color':'#2A4786'},
+    'Oceania':          {'abbr':'OC', 'label':'Oceania', 'color':'#8E1616'},
+    'South America':    {'abbr':'SA', 'label':'S America', 'color':'#EBA85F'},
+    'Southeast Asia':   {'abbr':'SEA', 'label':'SE Asia', 'color':'#8FBDD0'},
+    'West Asia':        {'abbr':'WA', 'label':'W Asia', 'color':'#76104B'},
 }
 
-region_names = [x for x in region_properties.keys() if x != 'global']
+for region in region_properties:
+    if region in population_sizes:
+        region_properties[region]['popsize'] = population_sizes[region]
+
+region_names = [x for x in region_properties.keys() if x!='global']

--- a/scripts/flu_regions.py
+++ b/scripts/flu_regions.py
@@ -1,0 +1,26 @@
+import json
+
+with open('../config/frequency_weights_by_region.json') as fh:
+    population_sizes = json.load(fh)
+
+region_properties = {
+    "global":       {'label':"Global", "color":"#111111"},
+    'Africa':       {'abbr':'AF', 'label':'Africa', 'color':'#A0CCA5'},
+    'Europe':       {'abbr':'EU', 'label':'Europe', 'color':'#658447'},
+    'North America':{'abbr':'NA', 'label':'N America', 'color':'#D6C568'},
+    'China':        {'abbr':'CN', 'label':'China', 'color':'#A76BB1'},
+    'South Asia':   {'abbr':'SAS', 'label':'South Asia', 'color':'#EBA85F'},
+    'Japan Korea':  {'abbr':'JK', 'label':'Japan/Korea', 'color':'#2A4786'},
+    'Oceania':      {'abbr':'OC', 'label':'Oceania', 'color':'#8E1616'},
+    'South America':{'abbr':'SA', 'label':'S America', 'color':'#EBA85F'},
+    'Southeast Asia':{'abbr':'SEA', 'label':'SE Asia', 'color':'#8FBDD0'},
+    'West Asia':    {'abbr':'WA', 'label':'W Asia', 'color':'#76104B'},
+}
+
+for region in region_properties:
+    if region in population_sizes:
+        region_properties['popsize'] = population_sizes[region]
+
+region_names = [x for x in region_abbreviations.keys() if x!='global']
+
+

--- a/scripts/flu_regions.py
+++ b/scripts/flu_regions.py
@@ -1,27 +1,15 @@
-import json
-import os
-
-with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),'../config/frequency_weights_by_region.json')) as fh:
-    population_sizes = json.load(fh)
-
 region_properties = {
-    "global":       {'label':"Global", "color":"#111111"},
-    'Africa':       {'abbr':'AF', 'label':'Africa', 'color':'#A0CCA5'},
-    'Europe':       {'abbr':'EU', 'label':'Europe', 'color':'#658447'},
-    'North America':{'abbr':'NA', 'label':'N America', 'color':'#D6C568'},
-    'China':        {'abbr':'CN', 'label':'China', 'color':'#A76BB1'},
-    'South Asia':   {'abbr':'SAS', 'label':'South Asia', 'color':'#5199B7'},
-    'Japan Korea':  {'abbr':'JK', 'label':'Japan/Korea', 'color':'#2A4786'},
-    'Oceania':      {'abbr':'OC', 'label':'Oceania', 'color':'#8E1616'},
-    'South America':{'abbr':'SA', 'label':'S America', 'color':'#EBA85F'},
-    'Southeast Asia':{'abbr':'SEA', 'label':'SE Asia', 'color':'#8FBDD0'},
-    'West Asia':    {'abbr':'WA', 'label':'W Asia', 'color':'#76104B'},
+    "global":           {'label':"Global", "color":"#111111"},
+    'Africa':           {'abbr':'AF', 'label':'Africa', 'popsize': 1.02, 'color':'#A0CCA5'},
+    'Europe':           {'abbr':'EU', 'label':'Europe', 'popsize': 0.74, 'color':'#658447'},
+    'North America':    {'abbr':'NA', 'label':'N America', 'popsize': 0.54, 'color':'#D6C568'},
+    'China':            {'abbr':'CN', 'label':'China', 'popsize': 1.36, 'color':'#A76BB1'},
+    'South Asia':       {'abbr':'SAS', 'label':'South Asia', 'popsize': 1.45, 'color':'#5199B7'},
+    'Japan Korea':      {'abbr':'JK', 'label':'Japan/Korea', 'popsize': 0.20, 'color':'#2A4786'},
+    'Oceania':          {'abbr':'OC', 'label':'Oceania', 'popsize': 0.04, 'color':'#8E1616'},
+    'South America':    {'abbr':'SA', 'label':'S America', 'popsize': 0.41, 'color':'#EBA85F'},
+    'Southeast Asia':   {'abbr':'SEA', 'label':'SE Asia', 'popsize': 0.62, 'color':'#8FBDD0'},
+    'West Asia':        {'abbr':'WA', 'label':'W Asia', 'popsize': 0.75, 'color':'#76104B'},
 }
 
-for region in region_properties:
-    if region in population_sizes:
-        region_properties[region]['popsize'] = population_sizes[region]
-
-region_names = [x for x in region_properties.keys() if x!='global']
-
-
+region_names = [x for x in region_properties.keys() if x != 'global']

--- a/scripts/flu_regions.py
+++ b/scripts/flu_regions.py
@@ -10,7 +10,7 @@ region_properties = {
     'Europe':       {'abbr':'EU', 'label':'Europe', 'color':'#658447'},
     'North America':{'abbr':'NA', 'label':'N America', 'color':'#D6C568'},
     'China':        {'abbr':'CN', 'label':'China', 'color':'#A76BB1'},
-    'South Asia':   {'abbr':'SAS', 'label':'South Asia', 'color':'#EBA85F'},
+    'South Asia':   {'abbr':'SAS', 'label':'South Asia', 'color':'#5199B7'},
     'Japan Korea':  {'abbr':'JK', 'label':'Japan/Korea', 'color':'#2A4786'},
     'Oceania':      {'abbr':'OC', 'label':'Oceania', 'color':'#8E1616'},
     'South America':{'abbr':'SA', 'label':'S America', 'color':'#EBA85F'},

--- a/scripts/flu_regions.py
+++ b/scripts/flu_regions.py
@@ -1,6 +1,7 @@
 import json
+import os
 
-with open('../config/frequency_weights_by_region.json') as fh:
+with open(os.path.join(os.path.dirname(os.path.realpath(__file__)),'../config/frequency_weights_by_region.json')) as fh:
     population_sizes = json.load(fh)
 
 region_properties = {
@@ -19,8 +20,8 @@ region_properties = {
 
 for region in region_properties:
     if region in population_sizes:
-        region_properties['popsize'] = population_sizes[region]
+        region_properties[region]['popsize'] = population_sizes[region]
 
-region_names = [x for x in region_abbreviations.keys() if x!='global']
+region_names = [x for x in region_properties.keys() if x!='global']
 
 

--- a/scripts/full_region_alignments.py
+++ b/scripts/full_region_alignments.py
@@ -8,7 +8,7 @@ from treetime.utils import numeric_date
 from augur.utils import read_metadata, get_numerical_dates, load_features
 from augur import align
 from augur.translate import safe_translate
-from select_strains import read_strain_list, regions, determine_time_interval, parse_metadata
+from select_strains import read_strain_list, determine_time_interval, parse_metadata
 from codon_align import codon_align, get_cds
 
 class pseudo_args(object):
@@ -57,7 +57,7 @@ if __name__ == '__main__':
         if seq.name in metadata:
             if metadata[seq.name]["num_date"]>=time_interval[0] and \
                metadata[seq.name]["num_date"]<time_interval[1] and \
-               metadata[seq.name]["region"].lower().replace(' ', '_')==region:
+               metadata[seq.name]["region"]==region:
                 sequences.append(seq)
 
     tmp_str = "".join(sample('ABCDEFGHILKLMOPQRSTUVWXYZ', 20))

--- a/scripts/global_frequencies.py
+++ b/scripts/global_frequencies.py
@@ -1,31 +1,6 @@
 import argparse, json
 import numpy as np
-
-population_sizes = {
-    'africa':1.02,
-    'europe': 0.74,
-    'north_america': 0.54,
-    'china': 1.36,
-    'south_asia': 1.45,
-    'japan_korea': 0.20,
-    'oceania': 0.04,
-    'south_america': 0.41,
-    'southeast_asia': 0.62,
-    'west_asia': 0.75
-}
-
-region_abbreviations = {
-    'africa':'AF',
-    'europe': 'EU',
-    'north_america': 'NA',
-    'china': 'CN',
-    'south_asia': 'SAS',
-    'japan_korea': 'JK',
-    'oceania': 'OC',
-    'south_america': 'SA',
-    'southeast_asia': 'SEA',
-    'west_asia': "WAS"
-}
+from flu_regions import *
 
 def format_frequencies(x):
     return [round(y,4) for y in x]
@@ -54,6 +29,7 @@ if __name__ == '__main__':
     pivots = frequencies[args.regions[0]]['pivots']
     frequencies['global']['pivots'] = format_frequencies(pivots)
 
+    # TODO: THIS NEEDS TO USE POPULATION SIZES!!
     seasonal_profile = {}
     total_weights = {}
     for region in frequencies:

--- a/scripts/global_frequencies.py
+++ b/scripts/global_frequencies.py
@@ -1,6 +1,6 @@
 import argparse, json
 import numpy as np
-from flu_regions import *
+from flu_regions import region_properties
 
 def format_frequencies(x):
     return [round(y,4) for y in x]

--- a/scripts/graph_frequencies.py
+++ b/scripts/graph_frequencies.py
@@ -70,7 +70,7 @@ def plot_mutations_by_region(frequencies, mutations, fname, show_errorbars=True,
                 ax.plot(pivots[:-drop], tmp_freq[:-drop], '-o',
                         ms=7 if region=='global' else 4, lw=3 if region=='global' else 1,
                         label=props.get('label', region) if region not in region_labeled else '',
-                        c=prop['colors'])
+                        c=props['color'])
                 region_labeled.add(region)
                 if show_errorbars and region!="global":
                     std_dev = np.sqrt(tmp_freq*(1-tmp_freq)/(smoothed_count_by_region[(gene, region)]+1))
@@ -211,7 +211,7 @@ def plot_counts(counts, date_bins, fname, drop=3, regions=None):
         props=region_properties[region]
         if region!='global':
             plt.bar(date_bins, counts[region], bottom=tmpcounts, width=width, linewidth=0,
-                    label=props.get('label', region), color=props['colors'],
+                    label=props.get('label', region), color=props['color'],
                     clip_on=False, alpha=0.8)
             tmpcounts += np.array(counts[region])
     ax.set_xlim([date_bins[0]-width*0.5, date_bins[-1]])

--- a/scripts/plot_titer_matrices.py
+++ b/scripts/plot_titer_matrices.py
@@ -9,7 +9,7 @@ matplotlib.use('agg')
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
-from select_strains import read_strain_list, regions, determine_time_interval, parse_metadata
+from select_strains import read_strain_list, determine_time_interval, parse_metadata
 
 
 h3n2_clades = ['A1', 'A1a', 'A1b', 'A1b/135K', 'A1b/137F','A1b/135N', 'A1b/131K', 'A1b/197R', 'A2', 'A2/re', '3c3.A']

--- a/scripts/scores.py
+++ b/scripts/scores.py
@@ -3,7 +3,7 @@ import numpy as np
 from collections import defaultdict
 from Bio import Phylo
 from augur.utils import read_metadata, get_numerical_dates
-from select_strains import read_strain_list, regions, determine_time_interval, parse_metadata
+from select_strains import read_strain_list, determine_time_interval, parse_metadata
 from vaccination_coverage import read_all_vaccination_data
 
 def calculate_average_on_tree(tree, func, min_clade_size=20):

--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -8,10 +8,9 @@ import Bio.SeqIO
 import numpy as np
 from treetime.utils import numeric_date
 from augur.utils import read_metadata, get_numerical_dates
+from flu_regions import *
 
-regions = ['africa', 'europe', 'north_america', 'china', 'south_asia',
-           'japan_korea', 'oceania', 'south_america', 'southeast_asia', 'west_asia']
-subcats = regions
+subcats = region_names
 
 def read_strain_list(fname):
     """

--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -8,7 +8,7 @@ import Bio.SeqIO
 import numpy as np
 from treetime.utils import numeric_date
 from augur.utils import read_metadata, get_numerical_dates
-from flu_regions import *
+from flu_regions import region_names
 
 subcats = region_names
 


### PR DESCRIPTION
This PR extracts the information on regions that were scattered across multiple scripts into single file `scripts/flu_regions.py`. In addition, this file sources the region weights from config thereby reducing these to one source. 

Working through the different files revealed two problems in our previous graphs
 * global frequencies weren't actually region weighted.
 * any other resolution then 2y wasn't using the correct alignments for region frequencies.  

I added South Asia to the plots: this corresponds to such a big population that not having it included distorts the picture. 
