### PR TITLE
Fix undefined name pivots in fitness_model.py

### DIFF
--- a/flu-forecasting/src/forecast/fitness_model.py
+++ b/flu-forecasting/src/forecast/fitness_model.py
@@ -550,7 +550,7 @@ class fitness_model(object):
                 else:
                     node.fit_frequencies[time] = self.node_parents[node].fit_frequencies[time]
                 try:
-                    slope, intercept, rval, pval, stderr = linregress(pivots[pivots_fit:-1], node.fit_frequencies[time][pivots_fit:-1])
+                    slope, intercept, rval, pval, stderr = linregress(self.pivots[pivots_fit:-1], node.fit_frequencies[time][pivots_fit:-1])
                     node.freq_slope[time] = slope
                 except:
                     import ipdb; ipdb.set_trace()


### PR DESCRIPTION
`pivots` is an _undefined name_ in this context but `self.pivots` is defined on line 334.  Undefined names have the potential to raise `NameError` at runtime so this PR advocates replacing `pivots` with `self.pivots`.

[flake8](http://flake8.pycqa.org) testing of https://github.com/nextstrain/seasonal-flu on Python 3.8.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./flu-forecasting/src/forecast/fitness_model.py:553:71: F821 undefined name 'pivots'
                    slope, intercept, rval, pval, stderr = linregress(pivots[pivots_fit:-1], node.fit_frequencies[time][pivots_fit:-1])
                                                                      ^
./flu-forecasting/src/forecast/fitness_model.py:1189:73: F821 undefined name 'augur_path'
            epitope_masks_fname="%s/builds/flu/metadata/ha_masks.tsv" % augur_path,
                                                                        ^
./flu-forecasting/src/forecast/fitness_model.py:1288:14: F821 undefined name 'test'
        fm = test(params)
             ^
3     F821 undefined name 'pivots'
3
```
https://flake8.pycqa.org/en/latest/user/error-codes.html

On the flake8 test selection, this PR does _not_ focus on "_style violations_" (the majority of flake8 error codes that [__psf/black__](https://github.com/psf/black) can autocorrect).  Instead these tests are focus on runtime safety and correctness:
* E9 tests are about Python syntax errors usually raised because flake8 can not build an Abstract Syntax Tree (AST).  Often these issues are a sign of unused code or code that has not been ported to Python 3.  These would be compile-time errors in a compiled language but in a dynamic language like Python they result in the script halting/crashing on the user.
* F63 tests are usually about the confusion between identity and equality in Python.  Use ==/!= to compare str, bytes, and int literals is the classic case.  These are areas where __a == b__ is True but __a is b__ is False (or vice versa).  Python >= 3.8 will raise SyntaxWarnings on these instances.
* F7 tests logic errors and syntax errors in type hints
* F82 tests are almost always _undefined names_ which are usually a sign of a typo, missing imports, or code that has not been ported to Python 3.  These also would be compile-time errors in a compiled language but in Python a __NameError__ is raised which will halt/crash the script on the user.

### Description of proposed changes    
What is the goal of this pull request? What does this pull request change?

### Related issue(s)  
<!-- Start typing the name of a related issue and github will autosuggest the issue number for you -->
Fixes #  
Related to #  

### Testing
What steps should be taken to test the changes you've proposed?  
If you added or changed behavior in the codebase, did you update the tests, or do you need help with this?  

### Thank you for contributing to Nextstrain!
