### PR TITLE
CI: Upgrade Python environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ services:
   - docker
 language: python
 python:
-  - "3.6"
+  - "3.9"
 install:
   - pip3 install git+https://github.com/nextstrain/cli
   - nextstrain version


### PR DESCRIPTION
## Description of proposed changes

Updates the Travis CI environment to use Python 3.9 instead of 3.6. This change addresses two separate issues:

 - The default version of pip for Travis's Python 3.9 environment (20.3.1) supports the deterministic dependency resolution required by the Nextstrain CLI installation step that 3.7's pip (20.1.1) does not. See the Travis docs for more details [1].
 - Python 3.6 will reach end of life in one month [2].

Python 3.9 was released a year ago and should be entirely reasonable to use as a default now.

[1] https://docs.travis-ci.com/user/languages/python/#new-dependency-resolver-in-pip-203
[2] https://endoflife.date/python

## Testing

 - [x] Tested by CI