### PR TITLE
CI: Upgrade setuptools suite prior to installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ services:
   - docker
 language: python
 python:
-  - "3.9"
+  - "3.7"
+before_install:
+  - python3 -m pip install --upgrade pip setuptools wheel
 install:
   - pip3 install git+https://github.com/nextstrain/cli
   - nextstrain version


### PR DESCRIPTION
## Description of proposed changes

Follows recommended practice for new Python installations to ensure that
pip, setuptools, and wheel are always upgraded [1] regardless of the
system-wide Python version. Also, follows our internal standard to use
the oldest supported Python version in CI when we do not use a matrix of
all supported versions, to best catch possible issues with older
versions.

[1] https://packaging.python.org/tutorials/installing-packages/#ensure-pip-setuptools-and-wheel-are-up-to-date