### PR TITLE
Annotate division-level geographic data

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -236,6 +236,7 @@ rule export:
         node_data = _get_node_data_for_export,
         description = files.description,
         colors = files.colors,
+        lat_longs = files.lat_longs,
     output:
         auspice_json = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}.json",
         root_sequence = "auspice/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_root-sequence.json"
@@ -248,6 +249,7 @@ rule export:
             --node-data {input.node_data} \
             --auspice-config {input.auspice_config} \
             --colors {input.colors} \
+            --lat-longs {input.lat_longs} \
             --output {output.auspice_json} \
             --description {input.description} \
             --include-root-sequence \

--- a/Snakefile_base
+++ b/Snakefile_base
@@ -248,7 +248,8 @@ rule files:
         colors = "config/colors.tsv",
         auspice_config = _get_auspice_config,
         vaccine_json = "config/vaccines_{lineage}.json",
-        description = "config/description.md"
+        description = "config/description.md",
+        lat_longs = "config/lat_longs.tsv",
 
 files = rules.files.params
 

--- a/config/auspice_config_h1n1pdm.json
+++ b/config/auspice_config_h1n1pdm.json
@@ -68,6 +68,11 @@
       "type": "categorical"
     },
     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
       "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
@@ -89,6 +94,7 @@
     }
   ],
   "geo_resolutions": [
+    "division",
     "country",
     "region"
   ],
@@ -100,6 +106,7 @@
     "clade_membership",
     "region",
     "country",
+    "division",
     "submitting_lab",
     "recency",
     "epiweek"

--- a/config/auspice_config_h3n2.json
+++ b/config/auspice_config_h3n2.json
@@ -78,6 +78,11 @@
       "type": "categorical"
     },
     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
       "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
@@ -99,6 +104,7 @@
     }
   ],
   "geo_resolutions": [
+    "division",
     "country",
     "region"
   ],
@@ -110,6 +116,7 @@
     "clade_membership",
     "region",
     "country",
+    "division",
     "submitting_lab",
     "recency",
     "epiweek"

--- a/config/auspice_config_h3n2_fitness.json
+++ b/config/auspice_config_h3n2_fitness.json
@@ -102,6 +102,11 @@
       "title": "Country",
       "type": "categorical"
     },
+     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
     {
       "key": "submitting_lab",
       "title": "Submitting lab",
@@ -124,6 +129,7 @@
     }
   ],
   "geo_resolutions": [
+    "division",
     "country",
     "region"
   ],
@@ -135,6 +141,7 @@
     "clade_membership",
     "region",
     "country",
+    "division",
     "submitting_lab",
     "recency",
     "epiweek"

--- a/config/auspice_config_vic.json
+++ b/config/auspice_config_vic.json
@@ -57,6 +57,11 @@
       "title": "Country",
       "type": "categorical"
     },
+     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
     {
       "key": "submitting_lab",
       "title": "Submitting lab",
@@ -79,6 +84,7 @@
     }
   ],
   "geo_resolutions": [
+    "division",
     "country",
     "region"
   ],
@@ -90,6 +96,7 @@
     "clade_membership",
     "region",
     "country",
+    "division",
     "submitting_lab",
     "recency",
     "epiweek"

--- a/config/auspice_config_yam.json
+++ b/config/auspice_config_yam.json
@@ -58,6 +58,11 @@
       "type": "categorical"
     },
     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
       "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"
@@ -79,6 +84,7 @@
     }
   ],
   "geo_resolutions": [
+    "division",
     "country",
     "region"
   ],
@@ -90,6 +96,7 @@
     "clade_membership",
     "region",
     "country",
+    "division",
     "submitting_lab",
     "recency",
     "epiweek"

--- a/config/lat_longs.tsv
+++ b/config/lat_longs.tsv
@@ -1,462 +1,14600 @@
-division	wales	52.2928116	-3.73893
-division	england	52.7954791	-0.540240286617432
-division	northern ireland	54.6294982	-6.7654416
-division	united kingdom	54.7023545	-3.2765753
-division	alberta	55.001251	-115.002136
-division	canada	61.0666922	-107.9917071
-division	new brunswick	46.500283	-66.750183
-division	newfoundland	49.12120935	-56.696296212741
-division	north west territories	65.0000004	-118.0
-division	nova scotia	45.1960403	-63.1653789
-division	nunavut	70.0000073	-90.0
-division	prince edward island	46.50354535	-63.5955171399145
-division	quebec	52.4760892	-71.8258668
-division	saskatchewan	55.5321257	-106.1412243
-division	denmark	55.670249	10.3333283
-division	finland	63.2467777	25.9209164
-division	uusimaa	60.2246684	25.1272630822577
-division	provence alpes cote d azur	43.3081805	6.63516386111111
-division	alsace champagne ardenne lorraine	48.4845157	6.113035
-division	auvergne rhone alpes	45.2968119	4.6604809
-division	normandy	49.0677708	0.3138532
-division	aquitaine limousin poitou charentes	45.4039367	0.3756199
-division	bourgogne franche comte	47.0510946	5.0740568
-division	bretagne	48.16282835	-2.68414734452184
-division	centre	47.5490251	1.7324062
-division	corsica	42.18808965	9.06841377142769
-division	france	46.603354	1.8883335
-division	franche comte	47.14258475	6.13202223357538
-division	herault	43.5914424	3.35528302489692
-division	saint denis	48.935773	2.3580232
-division	charente maritime	45.73022675	-0.721287587256379
-division	nord pas de calais	50.52896905	2.45451490916875
-division	pays de la loire	47.6594864	-0.8186143
-division	ile de france	48.6443057	2.7537863
-division	nouvelle aquitaine	45.4039367	0.3756199
-division	centre val de loire	47.5490251	1.7324062
-division	baden wurttemberg	48.6296972	9.1949534
-division	bayern	48.9467562	11.4038717
-division	berlin	52.5170365	13.3888599
-division	brandenburg	52.8455492	13.2461296
-division	bremen	53.0758196	8.8071646
-division	germany	51.0834196	10.4234469
-division	hessen	50.6118537	9.1909725
-division	hamburg	53.550341	10.000654
-division	niedersachsen	52.8398531	9.075962
-division	mecklenburg vorpommern	53.7735234	12.5755746
-division	nordrhein westfalen	51.4785568	7.5533645
-division	rheinland pfalz	49.7497346	7.4396553
-division	saarland	49.4173988	6.9805789
-division	sachsen	50.9295798	13.4585052
-division	schleswig holstein	54.1853998	9.8220089
-division	thuringen	50.7333163	11.0747905
-division	north holland	52.7212825	4.820665
-division	utrecht	52.0809856	5.12768396945229
-division	north brabant	51.6017723	5.4441391
-division	overijssel	52.4254143	6.4610611
-division	south holland	51.9966792	4.5597397
-division	netherlands	52.5001698	5.7480821
-division	gelderland	52.1014041	5.9515701
-division	norway	64.5731537	11.5280364395482
-division	ostlandet	59.9056001	10.6821197
-division	adygea	44.6939006	40.1520421
-division	arkhangelsk	64.543022	40.537121
-division	astrakhan	46.349854	48.031567
-division	altai krai	52.6932243	82.6931424
-division	belgorod	50.595299	36.586933
-division	jewish oblast	48.5601613	132.2775662
-division	amur	48.5601613	132.2775662
-division	buryatia	48.5601613	132.2775662
-division	chuvash	55.4259922	47.0849429
-division	chelyabinsk	55.1598408	61.4025547
-division	karachay- cherkess	43.7368326	41.7267991
-division	zabaykalsky krai	43.7368326	41.7267991
-division	sverdlovsk oblast	43.7368326	41.7267991
-division	chechnya	43.3976147	45.6985005
-division	irkutsk	52.289597	104.280586
-division	udmurt	52.289597	104.280586
-division	kaliningrad	52.289597	104.280586
-division	kaluga	54.5101087	36.2598115
-division	kemerovo	54.5335781	87.342861
-division	khabarovsk	48.481403	135.076935
-division	kirov	58.6035257	49.6639029
-division	leningrad	59.938732	30.316229
-division	komi	63.9881421	54.3326073
-division	kostroma	57.7679158	40.9269141
-division	krasnoyarsk	63.3233807	97.0979974
-division	kurgan	55.7655302	64.5632681
-division	kursk	51.739433	36.179604
-division	lipetsk	52.6041877	39.5936899
-division	magadan	52.6041877	39.5936899
-division	dagestan	43.0574916	47.1332224
-division	mari el	56.5767504	47.8817512
-division	mordovia	54.3376037	44.7729228
-division	moscow	55.4792046	37.3273304
-division	murmansk	68.970665	33.07497
-division	naryan- mar	67.637993	53.006863
-division	nizhny novgorod	56.328571	44.003506
-division	novosibirsk	55.0282171	82.9234509
-division	yamalia	67.1471631	74.3415488
-division	omsk	54.991375	73.371529
-division	oryol	52.9685433	36.0692477
-division	orenburg	51.767452	55.097118
-division	ossetia alania	42.9920711	44.2636348
-division	penza	53.200001	45.0
-division	perm	58.5951603	56.3159546
-division	karelia	62.6194031	33.4920267
-division	podporozhie	60.914291	34.162354
-division	pskov	60.914291	34.162354
-division	rostov	47.2213858	39.7114196
-division	russia	64.6863136	97.7453061
-division	ryazan	54.6295687	39.7425039
-division	samara	53.198627	50.113987
-division	saransk	54.18671	45.18383
-division	saratov	51.530018	46.034683
-division	voronezh	51.6605982	39.2005858
-division	smolensk	54.7814057	32.0461261
-division	st petersburg	59.938732	30.316229
-division	stavropol	45.0433245	41.9690934
-division	khanty mansia	45.0433245	41.9690934
-division	tambov	52.72879	41.45536
-division	tomsk	52.72879	41.45536
-division	tula	54.1930321	37.61754
-division	tver	56.858675	35.9208284
-division	tyumen	57.153534	65.542274
-division	bashkortostan	54.8573563	57.1439682
-division	ulyanovsk	54.3107593	48.3642771
-division	novgorod	58.5209862	31.2757862
-division	north ossetia	58.5209862	31.2757862
-division	vladimir	56.1288899	40.4075203
-division	primorsky	48.566204	43.543739
-division	volgograd	48.7081906	44.5153353
-division	vologda	59.218876	39.893276
-division	sakha	59.218876	39.893276
-division	yaroslavl	57.6263877	39.8933705
-division	sverdlovsk	56.839104	60.60825
-division	mari el republic	56.5767504	47.8817512
-division	vastra gotaland	58.20302695	12.6497319822317
-division	sodermanland	58.95868325	17.539918109268
-division	dalarna	61.06037785	14.2150873169591
-division	gavleborgs	61.26138005	16.6987101121522
-division	halland	56.96045925	12.807325812324
-division	skane	55.84694095	13.6358312123795
-division	jonkoping	57.7825634	14.165719
-division	kalmar	57.02784235	16.5752680106162
-division	varmland	59.89054465	13.294924808071
-division	ostergotland	58.36782395	16.0504272038854
-division	orebro	59.2747287	15.2151181
-division	jamtland	63.3452222	14.1249859844512
-division	stockholm	59.3251172	18.0710935
-division	vasternorrland	63.05896925	18.1058682647265
-division	sweden	59.6749712	14.5208584
-division	vasterbottens	64.7196392	18.5697083396957
-division	uppsala	59.8586126	17.6387436
-division	vastmanland	59.6965639	16.184653591596
-division	kronoberg	56.80067805	14.4111609951087
-division	gotland	57.6783173	18.6384635860988
-division	aichi	34.9991645	137.254574
-division	akita	39.6898802	140.342608
-division	aomori	40.886943	140.590121
-division	saitama	35.9754168	139.4160114
-division	busan	35.1799528	129.0752365
-division	gyeongsangnam	35.2382	128.6925
-division	seoul	37.5666791	126.9782914
-division	chungcheongnam	36.6593	126.6729
-division	jeollanam	34.8159	126.4629
-division	chiba	35.549399	140.2647303
-division	south korea	36.5581914	127.9408564
-division	chungcheongbuk	36.6357	127.4915
-division	daegu	35.8713	128.6018
-division	daejeon	36.3496	127.3848
-division	ehime	33.6013646	132.8185275
-division	fukui	35.9263502	136.6068127
-division	fukuoka	33.6251241	130.6180016
-division	fukushima	34.692104	135.474812
-division	gangwon	37.885	127.7297
-division	gifu	35.7867449	137.0460777
-division	gunma	36.52198	139.033483
-division	gwangju	35.1595775	126.8515089
-division	gyeongsangbuk	36.5754	128.5058
-division	gyeonggi	37.2752	127.0095
-division	shizuoka	34.9332488	138.0955398
-division	hiroshima	34.9332488	138.0955398
-division	hokkaido	43.4603175	143.330715792837
-division	hyogo	34.914934	134.860666
-division	ibaraki	36.2869536	140.4703384
-division	ishikawa	36.9888678	136.8163563
-division	iwate	39.5713763	141.4253574
-division	japan	36.5748441	139.2394179
-division	jeju	33.3939924	126.5626653
-division	kagawa	34.2480104	134.0586579
-division	kagoshima	31.521587	130.5474077
-division	tokyo	35.6828387	139.7594549
-division	kanagawa	35.4342935	139.374753
-division	kochi	33.6569018	133.5606241
-division	kumamoto	32.7833323	130.7333361
-division	honam	35.00734465	126.494310725124
-division	kyoto	35.021041	135.7556075
-division	mie	34.7339685	136.5154489
-division	miyagi	38.3880155	140.9761025
-division	miyazaki	32.097681	131.294542
-division	nagano	36.1143945	138.0319015
-division	nagasaki	33.1154683	129.7874339
-division	nara	34.2963089	135.8816819
-division	niigata	37.6452283	138.7669125
-division	oita	33.1819875	131.4270217
-division	okayama	34.8581334	133.7759256
-division	okinawa	26.5707754	128.0255901
-division	osaka	34.6198813	135.490357
-division	saga	33.311473	130.126593242292
-division	shiga	35.247154	136.109385
-division	shimane	34.9418212	132.537439
-division	tochigi	36.6782167	139.8096549
-division	tokushima	33.9196418	134.2509634
-division	tottori	35.3555075	133.8678525
-division	toyama	36.6468015	137.2183531
-division	ulsan	35.5391697	129.3119136
-division	wakayama	33.8070292	135.5930743
-division	yamagata	38.4746705	140.083237
-division	yamaguchi	34.2379614	131.5873845
-division	yamanashi	35.6399328	138.6380495
-division	anhui	32.0	117.0
-division	liaoning	40.9975197	122.9955469
-division	beijing	39.906217	116.3912757
-division	fujian	26.5450001	117.842778
-division	sichuan	30.5000001	102.4999999
-division	china	35.000074	104.999927
-division	chongqing	29.5585712	106.5492822
-division	neimenggu	43.2443242	114.3251664
-division	gansu	38.0000001	101.9999999
-division	guangdong	23.1357694	113.1982688
-division	guangxi	24.0	109.0
-division	guizhou	27.0	107.0
-division	hainan	19.2000001	109.5999999
-division	zhejiang	29.0000001	119.9999999
-division	heilongjiang	48.0000047	127.999992
-division	hebei	39.0000001	116.0
-division	henan	34.0000001	113.9999999
-division	hong kong	22.2793278	114.1628131
-division	hunan	27.6662087	111.7487063
-division	jiangsu	33.0000001	119.9999999
-division	hubei	31.15172525	112.87832224656
-division	jiangxi	28.0	116.0
-division	jilin	42.9995032	125.9816054
-division	keelung	25.1317232	121.744652
-division	kinmen	25.0214781	121.5230884
-division	shanghai	31.2322735	121.4691749
-division	yunnan	25.0	102.0
-division	linkou	25.0775308	121.3916021
-division	macau	22.1757605	113.5514142
-division	ningxia	37.0000001	105.9999999
-division	pingtung	22.6828017	120.487928
-division	shandong	36.0000001	118.9999999
-division	qinghai	35.40709525	95.9521157324195
-division	shaanxi	36.0	109.0
-division	shanxi	37.0	112.0
-division	taiwan	23.59829785	120.835363138175
-division	taipei	25.0375198	121.5636796
-division	taoyuan	24.8541777	121.257242268334
-division	tianjin	39.3032619	117.4163641
-division	xinjiang	41.7574769	87.167384230469
-division	jiangxia	23.2138044	113.27789855
-division	yilan	24.7519538	121.7533344
-division	american samoa	-14.289304	-170.692511
-division	canterbury	-43.49417615	171.809844758414
-division	auckland	-36.852095	174.7631803
-division	australia	-24.7761086	134.755
-division	bay of plenty	-37.9503756	176.938287361554
-division	queensland	-21.9182856	144.4588889
-division	canberra	-35.2975906	149.1012676
-division	wellington	-41.2887953	174.7772114
-division	chuuk	7.4393793	151.8515538
-division	cook islands	-16.0492781	-160.3554851
-division	northern territory	-19.8516101	133.2303375
-division	otago	-45.1299859	169.5248818
-division	new south wales	-31.8759835	147.2869493
-division	nelson	-41.2710849	173.2836756
-division	fiji	-18.1239696	179.0122737
-division	eastern highlands	-6.5	145.583333
-division	guam	13.4501257	144.757551029721
-division	hawkes bay	-39.4343279	176.7652742
-division	kiribati	0.4483283	-171.6645388
-division	micronesia	5.5600565	150.1982846
-division	new zealand	-41.5000831	172.8344077
-division	morobe	-7.0	147.0
-division	nauru	-0.5252306	166.9324426
-division	new caledonia	-20.940436	164.9786537
-division	northern mariana islands	13.4501257	144.757551029721
-division	palau	6.097367	133.313631
-division	french polynesia	-16.31	-151.81
-division	papua new guinea	-5.6816069	144.2489081
-division	western australia	-25.2303005	121.0187246
-division	pohnpei	6.8917101	158.2327877
-division	national capital district	-9.4405382	147.1803219
-division	solomon islands	-9.7354344	162.8288542
-division	south australia	-30.5343665	135.6301212
-division	southland	-45.7255555	168.2936808
-division	gisborne	-38.661326	178.0206487
-division	tasmania	-42.035067	146.6366887
-division	north island	-38.00353045	175.957852608357
-division	tonga	-19.9160819	-175.2026424
-division	tuvalu	-7.768959	178.1167698
-division	victoria	-36.5986096	144.6780052
-division	vanuatu	-16.5255069	168.1069154
-division	waikato	-37.77922725	175.201032324659
-division	west coast	-42.9945669	170.7100413
-division	sandaun	-3.5	142.0
-division	manawatu wanganui	-39.7001275	175.4986325
-division	yap	7.556	146.12854124
-division	acores	37.2577796	-28.030992
-division	alba	46.02363835	23.5504791118137
-division	albania	41.000028	19.9999619
-division	greece	38.9953683	21.9877132
-division	valencia	39.4699014	-0.3759513
-division	marche	39.4699014	-0.3759513
-division	spain	39.3262345	-4.8380649
-division	aragon	39.3262345	-4.8380649
-division	arges	44.99499355	24.8486324401499
-division	peloponnese	37.36332825	22.2395373439955
-division	asturias	43.2710211	-5.85390630021359
-division	central greece	38.9953683	21.9877132
-division	austria	47.2000338	13.199959
-division	castile and leon	41.8037172	-4.7471726
-division	bacau	46.5560493	26.9153557
-division	balearic islands	39.6134018	2.88043053264008
-division	banskobystricky	48.5004495	19.4196737447151
-division	catalonia	41.8523094	1.5745043
-division	apulia	40.9842539	16.6210027
-division	basel	47.5581077	7.5878261
-division	belarus	53.4250605	27.6971358
-division	belgium	50.6402809	4.6667145
-division	belgrade	44.8178131	20.4568974
-division	bihor	46.9959233	22.1956740372362
-division	trentino alto adige	46.441472	11.282121
-division	minsk	53.902334	27.5618791
-division	bosnia herzegovina	44.3053476	17.5961467
-division	botosani	47.85234105	26.7595119265934
-division	braila	45.2716092	27.9742932
-division	brasov	45.6523093	25.6102746
-division	bratislava	48.1516988	17.1093063
-division	brest	52.093751	23.6851851
-division	brussels	50.8436709	4.36743669338796
-division	romania	45.9852129	24.6859225
-division	bulgaria	42.6073975	25.4856617
-division	castilla la mancha	39.4177902	-2.6232332
-division	calarasi	44.3291102	27.133836265703
-division	italy	42.6384261	12.674297
-division	canary islands	28.2935785	-16.6214471211441
-division	cantabria	43.135837	-4.26363267814683
-division	castellon	40.25185675	-0.0615051101057482
-division	ceuta	35.888361	-5.304138
-division	central macedonia	37.9714428	23.7699608
-division	north aegean	37.6627595	25.52576007659
-division	cluj	46.769379	23.5899542
-division	constanta	44.1767161	28.6507598
-division	croatia	45.5643442	17.0118954
-division	pomoravlje	44.0218986	21.4400567096861
-division	czech republic	49.8167003	15.4749544
-division	dambovita	44.9267662	25.4830982474974
-division	dnipropetrovsk	48.4680221	35.0417711
-division	dolj	44.2141283	23.6692349082031
-division	donetsk	48.0158753	37.8013407
-division	eastern macedonia and thrace	40.7229687	22.9238097
-division	estonia	58.7523778	25.3319078
-division	basque country	42.9911816	-2.5543023
-division	extremadura	39.1748426	-6.1529891
-division	flanders	51.0962462	4.17985128926016
-division	tuscany	43.4586541	11.1389204
-division	friuli venezia giulia	46.151042	13.055904
-division	trnava	48.3767652	17.5858175
-division	galati	45.4338215	28.0549395
-division	galicia	42.61946	-7.863112
-division	geneva	46.2017559	6.1466014
-division	liguria	44.4777617	8.7026296
-division	giurgiu	43.897743	25.9568978380832
-division	gomel	52.4238936	31.0131698
-division	crete	35.3084749	24.4633207242029
-division	hungary	47.1817585	19.5060937
-division	ireland	47.1817585	19.5060937
-division	iasi	47.161494	27.5840504
-division	iceland	64.9841821	-18.1059013
-division	western greece	64.9841821	-18.1059013
-division	epirus	39.6497663	20.6909779867291
-division	western macedonia	40.38709185	21.4412445059553
-division	ionian islands	39.4850043	19.9251625
-division	kharkiv	49.9902794	36.2303893
-division	khmelnitsky	49.4009359	24.3159178
-division	khmilnyk	49.556175	27.9491205
-division	kiev	50.4500336	30.5241361
-division	nitra	48.31295	18.0894593
-division	kosice	48.7172272	21.2496774
-division	kosovo	42.5869578	20.9021231
-division	sumadija	44.786355	20.4716065
-division	kyiv	50.4500336	30.5241361
-division	la rioja	42.2814642	-2.48280497507047
-division	thessaly	39.582817	22.1338218821037
-division	latvia	56.8406494	24.7537645
-division	jablanica	42.9772938	20.4985999
-division	nitriansky	48.222978	18.3437852603221
-division	lisbon	38.7077507	-9.1365919
-division	lithuania	55.3500003	23.7499997
-division	presov	48.99594245	21.2462787922124
-division	luxembourg	49.6112768	6.129799
-division	macedonia	41.6171214	21.7168387
-division	madeira	32.75174875	-16.9817520488474
-division	madrid	32.75174875	-16.9817520488474
-division	malta	35.8885993	14.4476911
-division	maramures	47.6723414	24.1964160621993
-division	melilla	35.2918698	-2.9409026
-division	lombardy	45.6209	9.768893
-division	mitrovica	44.9710135	19.6155802
-division	mogilev	53.60664785	31.9541913725091
-division	moldova	47.286747	28.5110236
-division	montenegro	42.7728491	19.2408586
-division	murcia	37.9923795	-1.1305431
-division	mures	46.606563	24.6254035723877
-division	navarra	42.61254875	-1.83078768299155
-division	nisava	43.219581	22.472093
-division	odessa	46.4873195	30.7392776
-division	olt	44.29140195	24.4661079259738
-division	veneto	45.6476663	11.8665254
-division	sicily	37.587794	14.155048
-division	vojvodina	45.41012265	19.9766606131123
-division	emilia romagna	44.525696	11.039437
-division	trencin	44.525696	11.039437
-division	umbria	42.965916	12.490236
-division	plzen	49.7477415	13.3775249
-division	poland	52.215933	19.134422
-division	portalegre	39.2911347	-7.4333887
-division	porto	41.1494512	-8.6107884
-division	portugal	40.033265	-7.8896263
-division	branicevo	44.6997846	21.5363159
-division	bohemia	49.8167003	15.4749544
-division	prahova	45.10868095	26.0341161456952
-division	south aegean	37.6627595	25.52576007659
-division	lazio	41.9808038	12.7662312
-division	macva	44.52031515	19.5035878465163
-division	santarem	39.2363637	-8.6867081
-division	federation of bosnia and herzegovina	43.92028845	17.5461930990211
-division	sardinia	40.06160405	9.09775380655307
-division	serbia	44.1534121	20.55144
-division	sibiu	45.7973912	24.1519202
-division	skopje	41.9960924	21.4316495
-division	slovakia	48.7411522	19.4528646
-division	slovenia	45.8133113	14.4808369
-division	sofia	42.6978634	23.3221789
-division	suceava	47.5327387	25.8173527992344
-division	switzerland	46.7985624	8.2319736
-division	ternopil	49.5557716	25.591886
-division	timis	45.6890988	21.6304672159715
-division	tirane	41.3279457	19.8185323
-division	piedmont	33.547545	-86.902243
-division	ukraine	49.4871968	31.2718321
-division	kolubara	44.299382	20.058501
-division	vaslui	46.496847	27.8033209957248
-division	vienna	48.2083537	16.3725042
-division	vila real	41.2966556	-7.74678
-division	vitebsk	55.1930197	30.2070437
-division	vrancea	45.7891291	26.8820889725246
-division	wallonia	50.1545331	5.39918216716456
-division	zagreb	45.813177	15.977048
-division	zaporizhia	47.8507859	35.1182867
-division	zhytomyr	50.2598298	28.6692345
+location	's Gravenhage	52.0799838	4.3113461
+location	's-Gravenwezel	51.2624856	4.5556038
+location	's Herenelderen	50.8064756	5.5030479
+location	'S-Hertogenbosch	51.6889351	5.3031044
+location	18 de Octubre	-0.2761667	-79.4607036
+location	24 De Diciembre	9.0987181	-79.3627883
+location	25 de Mayo	-37.28940505	-59.109341950278974
+location	9 de Julio	-35.4444122	-60.8842325
+location	A Coruna	43.361494	-8.411483
+location	A Pobra do Caramiñal	42.6046249	-8.9402045
+location	Aalsmeer	52.2658344	4.766170039669312
+location	Aalter	51.079810	3.459957
+location	Aarburg	47.3206417	7.8993599
+location	Aarschot	50.986584	4.868284
+location	Aarsele	50.9972799	3.4220978
+location	Aartrijke	51.1191622	3.090309
+location	Aartselaar	51.133297	4.3870241
+location	Abadia de Goias	-16.7572644	-49.4412205
+location	Abaetetuba	-1.721828	-48.878843
+location	Abaiara	-7.3607808	-39.0487878
+location	Abakan	53.7209024	91.442435
+location	Abangares	10.24908185	-85.02203523765189
+location	Abbeville County	34.2264946	-82.4364036
+location	Abbotsford	49.0521162	-122.329479
+location	Abcoude	52.270281	4.9710427
+location	Abla	37.1416926	-2.7792318
+location	Abmangol	35.6729716	51.4379804
+location	Abondant	48.790785	1.420178
+location	Abrest	46.0980139	3.4450434
+location	Abtenau	47.5642319	13.3460333
+location	Abtwil SG	47.4225145	9.3210357
+location	Abuakwa North	6.184758698861353	-0.3712078166589552
+location	Abuakwa South	6.3139040216180575	-0.5927778023511372
+location	Acadia Parish	30.2740735	-92.3957036
+location	Accra	5.591875	-0.184552
+location	Acebal	-33.2417179	-60.8365105
+location	Acegua	-31.8695131	-54.1615593
+location	Achel	51.2548442	5.4802209
+location	Achêne	50.2668644	5.0458772
+location	Achenkirch	47.5276244	11.7056026
+location	Acosse	50.5945676	5.0485902
+location	Acosta	9.7417044	-84.24363805804293
+location	Açu	-5.5836157	-36.9139541
+location	Ada County	43.4136539	-116.2367421
+location	Adajan	21.2651204	72.84991282218647
+location	Adamantina	-21.6866517	-51.0762975
+location	Adamow	52.2666667	19.2833333
+location	Adamowo	53.8686359	20.9900989
+location	Adams County CO	39.8714085	-104.2701374
+location	Adams County IL	39.9787786	-91.2110065
+location	Adams County MS	31.4904067	-91.3297733
+location	Adams County OH	38.853370039120996	-83.46724817007629
+location	Adams County WA	46.985877	-118.480355
+location	Adams County WI	43.973540	-89.755486
+location	Adeje	28.1219416	-16.7241893
+location	Adilabad	19.5	78.5
+location	Adolfow	51.9288315	19.3672643
+location	Adra	36.748834	-3.0203617
+location	Aesch	47.4682447	7.5980395
+location	Aetolia Acarnania	38.70333835	21.249005544410082
+location	Affligem	50.9035063	4.1174675
+location	Afonso Claudio	-20.077841	-41.12606
+location	Aftabnagar	23.788563	90.4444251
+location	Agaete	28.1008499	-15.7023479
+location	Agam	-0.2634005	100.17201627524973
+location	Agargaon	23.7792	90.3737
+location	Agen	44.2015827	0.6176112
+location	Agoncillo	42.4451704	-2.2913654
+location	Agra	27.1752554	78.0098161
+location	Agramunt	41.7876693	1.0986828
+location	Agrestina	-8.4558021	-35.9442663
+location	Agronomica	-27.2660744	-49.7104753
+location	Água Branca	-7.5151046	-37.6394034
+location	Agua Clara	-20.4385757	-52.8797496
+location	Água Nova	-6.2063221	-38.2912678
+location	Aguacaliente	9.8417704	-83.9169998
+location	Aguadulce	8.20938495	-80.60333320420929
+location	Aguadulce ES	37.2530195	-4.9906167
+location	Aguadulce PA	8.20938495	-80.60333320420929
+location	Agualva	38.7712545	-9.291961378935335
+location	Aguaray	-22.2448504	-63.7353213
+location	Aguarico	-0.9846231999999999	-75.98915334608697
+location	Águas Belas	-9.1113156	-37.1225218
+location	Aguas Buenas	18.25041825	-66.13012947319635
+location	Aguas Buenas County	18.25041825	-66.13012947319635
+location	Aguas de Santa Barbara	-22.8821912	-49.2383956
+location	Aguas de Sao Pedro	-22.6000681	-47.8750887
+location	Aguas livres	38.7077507	-9.1365919
+location	Agudo	38.9820148	-4.8698279
+location	Agudos	-22.4719836	-48.9884476
+location	Aguia Branca	-18.9847265	-40.7391844
+location	Aguiar	-7.0928404	-38.1727215
+location	Aguilares	-27.43116315	-65.61863562270807
+location	Ahmedabad	23.024605	72.570805
+location	Ahmednagar	19.162772500000003	74.85802430085195
+location	Ahome	25.924049099999998	-109.20753958902344
+location	Aichi	35.067543	137.334061
+location	Aigen Im Ennstal	47.520529	14.1431493
+location	Aigen-Voglhub	47.716015379625155	13.548374392179618
+location	Aiguafreda	41.7692525	2.2517162
+location	Aiguavivia	41.93775487813436	2.7623831155149223
+location	Aigueperse	46.0219319	3.20189
+location	Aiken	33.5598586	-81.721952
+location	Aiken County	33.5723191	-81.6182086
+location	Ain Aouda	33.803077	-6.79413
+location	Aiseau	50.404827	4.576191
+location	Aiseau-Presles	50.40228075	4.575366574303365
+location	Aisemont	50.404382	4.651832
+location	Aisen	-46.37351572733574	-74.29275707552019
+location	Aitona	41.4939531	0.4591083
+location	Aix-en-Provence	43.5298424	5.4474738
+location	Aizawl	23.7435236	92.7382905
+location	Ajaccio	41.9263991	8.7376029
+location	Akhtubinsk	48.2877616	46.1744879
+location	Akko	32.8485145	35.0925179
+location	Akola	20.7618624	77.19217162524623
+location	Aktau	43.652058	51.157997
+location	Aktobe City	50.2796448	57.2124606
+location	Akyemansa	6.1662871895408164	-1.1500985790775784
+location	Al Amrat	23.5223356	58.5002366
+location	al-Arroub	31.6232237	35.136928
+location	Al Awabi	23.3	57.52
+location	Al-Khalil	31.5336282	35.0979762
+location	Al Matariyyah	30.123764	31.317953
+location	Alachua County	29.675568	-82.3640109
+location	Alagoa Grande	-7.0415212	-35.6285322
+location	Alagon	41.7711121	-1.1188807
+location	Alajuela	10.012782	-84.215404
+location	Alajuelita	9.88904325	-84.10610329208212
+location	Alamance County	36.04728285	-79.40037521708493
+location	Alameda County	37.6017	-121.7195
+location	Alamedilla	37.5816	-3.2439
+location	Alaquas	39.4572928	-0.46098
+location	Alaska	61.3999	-148.874
+location	Albacete	38.9943	-1.8585
+location	Albal	39.3964	-0.4137
+location	Albalat De La Ribera	39.2012627	-0.3866468
+location	Albalat dels Sorells	39.5436955	-0.3461912
+location	Albalate de Zorita	40.3087162	-2.8427164
+location	Albany County	42.601369	-73.973601
+location	Albanya	42.3046915	2.7193001
+location	Albbruck	47.5943254	8.1336893
+location	Albelda de Iregua	42.3560509	-2.4736796
+location	Alberic	39.1164369	-0.5201838
+location	Alberite	42.4060734	-2.4392907
+location	Albi	43.9277552	2.147899
+location	Albocasser	40.3571915	0.0245058
+location	Albolote	37.2283	-3.6544
+location	Alboraia	39.5009954	-0.34948
+location	Alboraya	39.4990	-0.3510
+location	Albrechtice	49.784998	18.529067
+location	Albuixech	39.5448	-0.3248
+location	Albunol	36.7913663	-3.2035944
+location	Alcacer do Sal	38.365989299999995	-8.531313383677643
+location	Alcala de Henares	40.4820	-3.3635
+location	Alcala la Real	37.4645	-3.9241
+location	Alcalde Díaz	9.118995	-79.559360
+location	Alcanadre	42.405104	-2.1198668
+location	Alcanar	40.5438634	0.4808409
+location	Alcaniz	41.0510	-0.1335
+location	Alcantara	39.7205221	-6.8879981
+location	Alcarras	41.5632578	0.5240396
+location	Alcasser	39.3677124	-0.4446741
+location	Alceda	43.1924	-3.91586
+location	Alcinópolis	-18.3264121	-53.7094463
+location	Alcobaca	39.5519199	-8.9763396
+location	Alcobaca PT	39.5519199	-8.9763396
+location	Alcobendas	40.527225	-3.637649
+location	Alcochete	38.7560499	-8.9608437
+location	Alcolea De Calatrava	38.9861733	-4.1152469
+location	Alcoletge	41.6472222	0.6944444
+location	Alcorn County	34.8734817	-88.5667345
+location	Alcudia	39.8533	3.1240
+location	Aldea Del Rey	38.7380137	-3.8391468
+location	Aldeanueva de Ebro	42.2293469	-1.8880858
+location	Aldeanueva del Camino	40.2584265	-5.9300309
+location	Aldeire	37.160375	-3.0715949
+location	Alderetes	-26.8132129	-65.1411367
+location	Aldrans	47.250725	11.445815
+location	Alegre	-20.7625787	-41.5318886
+location	Alegrete	-29.790166	-55.794862
+location	Aleksandrow	52.3385258	20.6309521
+location	Aleksandrow Kujawski	52.87646465	18.6940709811346
+location	Alella	41.4952867	2.2942758
+location	Alem do Paraiba	-21.8804238	-42.6919837
+location	Alem Paraiba	-21.8760576	-42.6810473
+location	Alesanco	42.414271	-2.8171672
+location	Aleson	42.4054779	-2.6904851
+location	Alexander Bay	-28.594787	16.482647
+location	Alexander County	37.1801529	-89.3502834
+location	Alexandria	38.8051095	-77.0470229
+location	Alexandria BR	-6.414779	-38.0135516
+location	Alexandria VA	38.8051095	-77.0470229
+location	Alfacar	37.2383551	-3.5663721
+location	Alfafar	39.4200749	-0.3891355
+location	Alfaro	42.1785741	-1.7492454
+location	Alfarras	41.8311403	0.5692934
+location	Alfas del Pi	38.6007401	-0.1305054
+location	Alfenas	-21.4297405	-45.9479419
+location	Alfondeguilla	39.8376893	-0.2690126
+location	Alfredo Chaves	-20.624970400000002	-40.75006690147988
+location	Alfredo Marcondes	-21.9527	-51.413956
+location	Algadefe	42.2196382	-5.5851273
+location	Algeciras	36.138633	-5.455967
+location	Algemesi	39.190758	-0.4357471
+location	Algerri	41.8151794	0.6371437
+location	Alginet	39.2651129	-0.4716912
+location	Alguaire	41.7361463	0.585933
+location	Algueirão-Mem Martins	38.7999099	-9.3397834
+location	Alhaurin de la Torre	36.657013	-4.560975
+location	Alhendin	37.1078115	-3.6456986
+location	Alhue	-34.037086200000005	-71.08449862068355
+location	Alianca	-7.6026425	-35.2263514
+location	Alicante	38.353738	-0.4901846
+location	Alicun de Ortega	37.6079308	-3.1373517
+location	Aligandí	9.233243	-78.016640
+location	Aligarh	27.8974	78.0880
+location	Alija Del Infantado	42.1417869	-5.8372442
+location	Alipurduar	26.4851573	89.5246926
+location	Alken	50.877283	5.289834
+location	Alkmaar	52.600853799999996	4.817099446443963
+location	Allamakee County	43.286290	-91.352362
+location	Alle	49.8421207	4.9726784
+location	Allee Brillant	-20.2974153	57.5110044
+location	Allegany County NY	42.2446061	-78.0419281
+location	Allegheny County	40.4597204	-79.9760405
+location	Allen	-40.8102633	-65.0894866
+location	Allen Parish	30.6558242	-92.8598049
+location	Allendale County	32.9635006	-81.3400056
+location	Allschwil	47.5510799	7.5365611
+location	Almacelles	41.7294989	0.4404763
+location	Almada	38.6764302	-9.1649974
+location	Almaden	38.7742489	-4.832835
+location	Almagro	38.888238	-3.7118218
+location	Almansa	38.8703	-1.0993
+location	Almargem do Bispo	38.8491202	-9.264334778649605
+location	Almassera	39.5105	-0.3572
+location	Almassora	39.9435743	-0.0634783
+location	Almaty	43.23199509134073	76.89056928806868
+location	Almeirim	39.16800295	-8.572597770930125
+location	Almelo	52.3567956	6.66725277634109
+location	Almenara	-16.1797	-40.6953
+location	Almenara BR	-16.1740678	-40.6904907
+location	Almenara ES	39.7521228	-0.2251286
+location	Almere	52.3657098	5.2210432
+location	Almeria	36.844270	-2.450766
+location	Almirante Brown	-34.57917795	-60.968090100555806
+location	Almirante Tamandare	-25.3133048	-49.2997838
+location	Almoguera	40.2976304	-2.9833702
+location	Almunecar	36.7328699	-3.68968
+location	Almuradiel	38.5129637	-3.4967642
+location	Almussafes	39.2924334	-0.4138577
+location	Alovera	40.5965393	-3.2485828
+location	Alp	42.3736381	1.8871916
+location	Alpena County	45.0176181	-83.6670019
+location	Alpes Maritimes	43.9210587	7.1790785
+location	Alphen Aan Den Rijn	52.1131403	4.6408411999450685
+location	Alpicat	41.6651189	0.5560656
+location	Alsemberg	50.7419942	4.3383125
+location	Alta Gracia	-34.8164164	-58.2171115
+location	Altamira	-3.204065	-52.209961
+location	Altea	38.6028245	-0.0472059
+location	Altenhof Am Hausruck	48.134291	13.686464
+location	Altet	41.6839879	1.1437558
+location	Altinopolis	-21.021364	-47.3712
+location	Altkirch	47.6238204	7.2401542
+location	Altmünster	47.9016069	13.7652213
+location	Altnau	47.61241	9.260705
+location	Alto Alegre	-21.5820592	-50.1661976
+location	Alto Feliz	-29.3785943	-51.3123751
+location	Alto Hospicio	-20.2700478	-70.1009162
+location	Altos	-25.2617324	-57.2492898
+location	Altstatten	47.3783471	9.5412765
+location	Alumim	31.4521295	34.5137154
+location	Alushta	44.677112	34.4095393
+location	Alvalade	-8.8307726	13.235761
+location	Alvarado	9.94319685	-83.80198292263356
+location	Alvares Machado	-22.076415	-51.47224
+location	Alvaro de Carvalho	-22.0787992	-49.7194861
+location	Alveringem	51.0150603	2.722044376111538
+location	Alvorada	-29.9981184	-51.0772509
+location	Alvorada de Minas	-18.7318587	-43.3641479
+location	Alwar	27.639077049999997	76.6144524902045
+location	Alzira	39.1512424	-0.4346133
+location	Amador County	38.449089	-120.5911018
+location	Amadora	38.7595162	-9.223677009460125
+location	Amagá	6.0358169	-75.7009108125
+location	Amajuba	-27.7351566	29.961884968271626
+location	Amalfi	7.0204002	-74.95047583580163
+location	Amambai	-23.1082701	-55.2284854
+location	Amargosa	-13.0302189	-39.6040692
+location	Amathole	-32.5	 27.5
+location	Amatitlán	14.4792381	-90.6195248
+location	Amay	50.5497761	5.3240992
+location	Ambato	-1.2422461	-78.6292567
+location	Ambite	40.3284	-3.1824
+location	Ambon	-3.6959434	128.178785
+location	Ambriz	-8.8486764	13.2603948
+location	Amden	47.1496317	9.1411228
+location	Amelia Denis de Icaza	9.041001	-79.516947
+location	Americana	-22.7392463	-47.3306032
+location	Americo Brasiliense	-21.7297099	-48.1052092
+location	Amersfoort	52.163773899999995	5.3965879493517015
+location	Ames	42.9038	-8.6584
+location	Amiens	49.8941708	2.2956951
+location	Amilly	48.4418021	1.3930652
+location	Amneville	49.2603613	6.1420739
+location	Ampara	7.2978118	81.6790194
+location	Amparo	-22.70111	-46.76444
+location	Amparo (Paraiba)	-7.56394725	-37.04652873235175
+location	Amparo (São Paulo)	-22.70111	-46.76444
+location	Ampflwang Im Hausruckwald	48.0924656	13.5661129
+location	Ampuero	43.3440563	-3.4151482
+location	Amravati	21.15454115	77.64429617998744
+location	Amstelveen	52.2862177	4.852649259746028
+location	Amsterdam	52.3727598	4.8936041
+location	Amsterdam West	52.37454030000001	4.897975505617977
+location	Amsterdam-Zuidoost	52.2996522	4.9474716
+location	Amstetten	48.1203262	14.8752424
+location	Anadia	-9.6830208	-36.3052699
+location	Anama	-3.5797356	-61.4049996
+location	Anand	22.5584995	72.9625629
+location	Ananindeua	-1.374035	-48.4016623
+location	Ananthapur	14.5482705	77.6571234
+location	Anapa	44.894272	37.316887
+location	Anapolis	-16.3332828	-48.9525756
+location	Anapurus	-3.6751298	-43.1046001
+location	Anastacio	-20.4832458	-55.8048448
+location	Anaz	43.362544	-3.7539036
+location	Anchieta	-20.8057672	-40.6454564
+location	Anchorage	61.203109	-149.888095
+location	Anchorage and Matanuska-Susitna	61.2902	-149.7073
+location	Anchorage Municipality	61.2163129	-149.894852
+location	Ancón	9.065597	-79.613801
+location	Ancona	43.480120400000004	13.218790609151764
+location	Ancud	-41.8682162	-73.8287225
+location	Andalucia	4.173863	-76.164864
+location	Andel	51.7851	5.0549
+location	Andenne	50.487207	5.056619
+location	Anderlecht	50.829058	4.29586
+location	Anderlues	50.4042058	4.264332649553593
+location	Anderson County	34.5258335	-82.652962
+location	Anderson County SC	34.5258335	-82.652962
+location	Anderson County TX	31.7819242	-95.6258199
+location	Andes	5.627871750000001	-75.94516744951865
+location	Andosilla	42.3776047	-1.9434186
+location	Andovce	47.9950053	18.1042136
+location	Andrade Marin	0.3219959	-78.2098351
+location	Andradina	-20.896505	-51.3742765
+location	Andres de Vera	-1.0632943	-80.45681529999999
+location	Andrews County TX	32.2690953	-102.6042447
+location	Andrézieux-Bouthéon	45.5351545	4.279901648257095
+location	Andros	37.8408347	24.862385531158715
+location	Androscoggin County	44.1402839	-70.196395
+location	Anelo	-38.35428	-68.7875804
+location	Anero	43.39724	-3.65293
+location	Angatuba	-23.4938938	-48.4110675
+location	Angelina County	31.2544545	-94.6181177
+location	Angers	47.6781742	2.4367044
+location	Anglards de Salers	45.203454	2.4401267
+location	Angles	41.9559224	2.6359493
+location	Anglet	43.4813927	-1.5149935
+location	Angoda	6.9360192	79.9257199
+location	Angol	-37.798787	-72.7086097
+location	Angouleme	45.6512748	0.1576745
+location	Angra Dos Reis	-23.0063966	-44.316326
+location	Anguciana	42.5752687	-2.9027969
+location	Anne Arundel County	38.9722583	-76.573454
+location	Annecy	45.8992348	6.1288847
+location	Annemasse	46.1934005	6.2341093
+location	Annonay	45.2399639	4.6675475
+location	Anoka County	45.2710195	-93.2827625
+location	Anori	-3.7435254	-61.6605203
+location	Ans	50.671731	5.510231
+location	Anserma	5.238746	-75.782888
+location	Antananarivo	-18.9100122	47.5255809
+location	Antella	39.080713	-0.5909714
+location	Antequera	37.017136	-4.561986
+location	Antheit	50.548353	5.240102
+location	Antibes	43.5836	7.10905
+location	Antigua Guatemala	14.5589875	-90.7333258
+location	Antofagasta	-23.6463741	-70.3980033
+location	Anton	8.473513	-80.1990243839517
+location	Antonan del Valle	42.5248122	-5.9499103
+location	Antonina do Norte	-6.7754187	-39.9879345
+location	Antonio Ante	0.3316022	-78.219615
+location	Antoniowka	51.42515	21.57653
+location	Antsiranana	-12.2779134	49.2913394
+location	Antuco	-37.3298086	-71.6742409
+location	Anuradhapura	8.334985	80.4106096
+location	Anykščiai	55.5257935	25.1061247
+location	Anzegem	50.830817	3.452651
+location	Apache County	35.214632	-109.4786676
+location	Aparecida de Goiania	-16.8226769	-49.2452546
+location	Apartado	7.8849011	-76.6227461
+location	Apatou	5.1554261	-54.3425142
+location	Apchat	45.3887558	3.1451084
+location	Apeldoorn	52.2156457	5.9639485
+location	Aperibe	-21.6211928	-42.1028167
+location	Appelterre-Eichem	50.8191641	3.965528
+location	Appenzell	47.3446384	9.343829
+location	Appingedam	53.3203563	6.8577654
+location	Appling County	31.7771435	-82.2996274
+location	Apucarana	-23.5525327	-51.4610764
+location	Aquidaba	-10.2837579	-37.0188687
+location	Aquidauana	-20.473969	-55.7821375
+location	Ar Rustaq	23.3899385	57.4201142
+location	Aracagy	-2.48621595	-44.19442598299658
+location	Aracaju	-10.9162061	-37.0774655
+location	Aracariguama	-23.438611	-47.061389
+location	Aracati	-4.558259	-37.767894
+location	Araçatuba	-21.207992	-50.4390225
+location	Aracoiaba	-7.7856903	-35.0898881
+location	Aracoiaba Da Serra	-23.5045367	-47.6168158
+location	Aracruz	-19.8245218	-40.2735025
+location	Aracuai	-16.8484451	-42.0661868
+location	Arad	31.2612199	35.214581
+location	Aragoncillo	40.9347198	-2.0452525
+location	Araguaiana	-7.194251345353305	-48.209816034583845
+location	Araguaina	-7.193241	-48.2018597
+location	Araguapaz	-15.0937927	-50.626417
+location	Araguatins	-5.6522925	-48.1158973
+location	Aranda de Duero	41.6715067	-3.6851172
+location	Aransas County	28.1987876	-96.947708
+location	Arapahoe County	39.6416781	-104.3628567
+location	Arapiraca	-9.754866	-36.661471
+location	Arapongas	-23.4152862	-51.4293961
+location	Araquari	-26.3703324	-48.7210994
+location	Ararangua	-28.945496	-49.50595870518586
+location	Araraquara	-21.7886713	-48.1773096
+location	Araras	-22.3569477	-47.3838889
+location	Araripina	-7.5768582	-40.5038509
+location	Araruama	-22.8733203	-42.3428897
+location	Arauca	6.7940425	-70.49616220398214
+location	Araucaria	-25.5861107	-49.4051209
+location	Araxa	-19.5928536	-46.940241
+location	Arbesbach	48.4939841	14.955296
+location	Arbon	47.5149257	9.4304026
+location	Arbre	50.611772	3.817121
+location	Arbúcies	41.8160629	2.5141453
+location	Arce	42.88939555	-1.378048832858842
+location	Arcoverde	-8.415192	-37.057748
+location	Ardooie	50.97120755	3.2046502804624204
+location	Areal	-22.2314922	-43.1056264
+location	Aregua	-25.3129449	-57.3852339
+location	Areia	-6.9680243	-35.6994783
+location	Arenas del Rey	36.9577036	-3.8944117
+location	Arendonk	51.3202315	5.0864557
+location	Arenys de Mar	41.5797031	2.5491562
+location	Arenys de Munt	41.6095429	2.5400513
+location	Arequipa	-16.3988667	-71.5369607
+location	Ares	-6.1969216	-35.1642968
+location	Argamasilla De Calatrava	38.7268428	-4.0792825
+location	Arganda del Rey	40.3064	-3.4479
+location	Argelia	5.70531055	-75.0921269896775
+location	Argentan	48.7428859	-0.0223695
+location	Argenteuil	48.9479069	2.2481797
+location	Argentona	41.5554326	2.4002787
+location	Argolida	37.566266150000004	22.85593894780862
+location	Arica	-18.4785288	-70.3211394
+location	Ariege	42.9455368	1.4065544156065486
+location	Ariel	32.10328222703244	35.174615499721995
+location	Ariranha	-21.18716	-48.790418
+location	Ariyalur	11.076035950000001	79.11745538182738
+location	Arkadia	37.42908855	22.427377699353286
+location	Arkhara	49.4224283	130.0858308
+location	Arlesheim	47.4931125	7.6202048
+location	Armacao Dos Buzios	-22.7597805	-41.8875267
+location	Armavir	44.9993585	41.1294061
+location	Armazem	-28.2624996	-49.0190126
+location	Armellada	42.5521399	-5.8631437
+location	Armenia	4.539019	-75.680551
+location	Armentieres	50.6867281	2.882169
+location	Armilla	37.1431197	-3.6277259
+location	Arnedo	42.2273401	-2.0995697
+location	Arneiro	38.7531926	-9.4531076
+location	Arneiroz	-6.3235099	-40.1603859
+location	Arnhem	51.984257	5.9108573
+location	Arnuero	43.4725591	-3.5664118
+location	Arnulfo Arias	8.9517794	-79.5563299
+location	Arpajon	48.5902899	2.2477303
+location	Arpajon sur Cere	44.9034428	2.4570176
+location	Arraba	32.8486132	35.3358268
+location	Arradon	47.62798	-2.8229152
+location	Arraial do Cabo	-22.9662839	-42.024427
+location	Arraias	-12.9287788	-46.9437231
+location	Arraiján	8.98985635	-79.6793266702984
+location	Arras	50.291048	2.7772211
+location	Arroio do Meio	-29.4020392	-51.9444993
+location	Arroio do Tigre	-29.255037	-53.042588697411446
+location	Arroyito	-34.7823762	-58.3869233
+location	Arroyo de la Luz	39.4840338	-6.5845773
+location	Arroyo Seco	-33.154614	-60.5082223
+location	Arrufo	-30.233745353225927	-61.72967590535503
+location	Arsimont	50.4273479	4.6388177
+location	Artajona	42.5876058	-1.7644227
+location	Artes	41.7986735	1.9548856
+location	Artesa De Segre	41.8962914	1.0471121
+location	Arti	56.4255703	58.5326906
+location	Arucas	28.1184492	-15.5232237
+location	Aruja	-23.396266	-46.3175449
+location	Arvorezinha	-28.87369	-52.17808
+location	Arzua	42.9279921	-8.1605667
+location	As	51.000539599999996	5.572202585246233
+location	As Seeb	23.6821956	58.1843842
+location	Asbest	57.0052746	61.4580765
+location	Ascension Parish	30.2116442	-90.9186104
+location	Aserri	9.865508	-84.091553
+location	Ashdod	31.7977314	34.6529922
+location	Ashkelon	31.6644874	34.5730157
+location	Ashkona	23.8467179	90.4219459
+location	Ashland County	46.2062319	-90.6802594
+location	Asnières-sur-Seine	48.911508	2.284362
+location	Asotin County	46.1460	-117.2085
+location	Aspang Markt	47.55210945	16.091602470349354
+location	Aspe	38.3459902	-0.7692125
+location	Asper	50.915644	3.652577
+location	Asse	50.9094	4.2005
+location	Assebroek	51.201322	3.255146
+location	Assen	52.99037165	6.553377770642328
+location	Assendelft	52.4681109	4.7449605
+location	Assenede	51.2275942	3.7532864
+location	Assent	50.9520834	5.0177512
+location	Assesse	50.3718261	5.0217639
+location	Assis	-22.6620892	-50.420623
+location	Assis Chateaubriand	-24.4054826	-53.5120468
+location	Assumption Parish	29.912050	-91.042405
+location	Astillero	43.4001931	-3.8185789
+location	Astolfo Dutra	-21.3132636	-42.8624102
+location	Astorga	42.4553555	-6.0529025
+location	Astorga BR	-23.2350184	-51.6647074
+location	Astorga ES	42.4553555	-6.0529025
+location	Astrakhan	46.3498308	48.0326203
+location	Atalanta	-27.421916	-49.778863
+location	Atalaya	8.019231399999999	-80.9087970995583
+location	Atarfe	37.2212	-3.6902
+location	Atascosa County	28.8554434	-98.5316314
+location	Atenas	9.9795178	-84.39917334151181
+location	Atescatempa	14.1802628	-89.71880136073969
+location	Atibaia	-23.1177393	-46.5547861
+location	Atiwa West	6.322083326551894	-0.5894367297794426
+location	Atlanta	33.7490987	-84.3901849
+location	Attala County	33.0777868	-89.5680661
+location	Attenhoven	50.7670965	5.0927876
+location	Attenrode	50.877424	4.9262551
+location	Attersee	47.9113862	13.537790421084743
+location	Attnang-Puchheim	48.0114566	13.7210848
+location	Atuntaqui	0.32810055	-78.21502288833759
+location	Atxuri	43.254073	-2.9217107
+location	Au	47.1297411	9.2287259
+location	Aubagne	43.2924385	5.5703031
+location	Aubange	49.5671953	5.8044993
+location	Aubenas	44.6205476	4.3902399
+location	Aubiat	45.9769261	3.1683548
+location	Aubiere	45.7512575	3.1144195
+location	Aubiet	43.6465589	0.783188
+location	Auby-sur-Semois	49.824580850000004	5.18097627510917
+location	Auckland	-36.8314	174.7606
+location	Audanzas Del Valle	42.1682012	-5.7134103
+location	Aude	43.0542733	2.512471457499548
+location	Auderghem	50.808473	4.439214
+location	Augerolles	45.7235278	3.6186684
+location	Augsburg	48.3668041	10.8986971
+location	Augst	47.5338077	7.7206018
+location	Augusto Correa	-1.0229335	-46.6404029
+location	Augustow	53.8437331	22.9802357
+location	Aulago	37.1604047	-2.6261429
+location	Aulnat	45.793	3.17143
+location	Aulnay Sous Bois	48.934231	2.499789
+location	Aumont Aubrac	44.67192715	3.1734450839533306
+location	Aurach Am Hongar	47.952313	13.6727183
+location	Aurangabad	19.877263	75.3390241
+location	Auribeau-sur-Siagne	43.6001505	6.9105552
+location	Auriflama	-20.6840418	-50.5554616
+location	Aurillac	44.9285441	2.4433101
+location	Aurora	-27.3166417	-49.6368502
+location	Ausejo	42.3447755	-2.1690484
+location	Austin County	29.8916488	-96.2443467
+location	Autauga County	32.5165255	-86.6319403
+location	Autazes	-3.5833283	-59.1301518
+location	Autol	42.2130714	-2.0057815
+location	Autonomous Province of Bolzano	46.4981125	11.3547801
+location	Autonomous Province of Trento	46.0664228	11.1257601
+location	Autre-Église	50.6631583	4.9249295
+location	Autun	46.9510313	4.2989478
+location	Auxerre	47.7961287	3.570579
+location	Avanhandava	-21.4603331	-49.9465156
+location	Avare	-23.1045215	-48.9259103
+location	Avelgem	50.781406	3.450563
+location	Avellaneda	-34.6648394	-58.3628061
+location	Avellaneda AR	-33.0784898	-60.5710583
+location	Averbode	51.0300217	4.9797369
+location	Avermes	46.5881392	3.3102105
+location	Aveyron	44.315857449999996	2.5065697302419823
+location	Avia Terai	-26.68602945	-60.72834013831401
+location	Avila	40.656478	-4.7002172
+location	Avinyo	41.8630096	1.9707409
+location	Avissawella	6.9522325	80.2125947
+location	Avoyelles County	31.0471604	-92.0019698
+location	Avoyelles Parish	31.0471604	-92.0019698
+location	Awa Reserve	0.450000	-77.450000
+location	Axarquia	36.86647765	-4.111017160388603
+location	Aydat	45.6609027	2.9757079
+location	Ayerbe	42.2764391	-0.6892389
+location	Ayna	40.4637	-3.7492
+location	Azadinos	42.6360005	-5.6217893
+location	Azamgarh	26.02269675	83.02887343114848
+location	Azimpur	23.727786193992728	90.38448981547175
+location	Azogues	-2.63172915	-78.70089340640921
+location	Azovo	54.70385	73.026871
+location	Azuqueca de Henares	40.5684256	-3.2621585
+location	Baal	50.9956319	4.7523911
+location	Baardegem	50.9558958	4.1425196
+location	Baarle-Hertog	51.4383589	4.9316995
+location	Baarn	52.2002549	5.269143393313942
+location	Bab	48.310611	17.8668225
+location	Babahoyo	-1.802318	-79.524709
+location	Babol	36.24011285	52.64449387236175
+location	Baborow	50.1563566	17.9859393
+location	Babruysk	53.1449683	29.2281209
+location	Bacares	37.261184	-2.453323
+location	Bachórzec	49.8233371	22.3327855
+location	Backa Palanka	45.2502498	19.3960842
+location	Backa Topola	45.8121657	19.6304705
+location	Backowice	50.7950478	21.2328522
+location	Baco	8.3593797	-82.7542493
+location	Bad Aussee	47.6094315	13.7832771
+location	Bad Camberg	50.299603	8.2673122
+location	Bad Gams	46.8699336	15.2230077
+location	Bad Gastein	47.109942	13.127594
+location	Bad Goisern	47.640622	13.6148009
+location	Bad Goisern Am Hallstättersee	47.6272899	13.621019584669174
+location	Bad Homburg	50.2227094	8.6287451
+location	Bad Ischl	47.7115299	13.6239333
+location	Bad Krozingen	47.9118288	7.7033313
+location	Bad Mitterndorf	47.5553729	13.9323276
+location	Bad Ragaz	47.0025282	9.5016438
+location	Bad Säckingen	47.5525538	7.9495387
+location	Bad Soden Am Taunus	50.1429142	8.5029259
+location	Bad Vilbel	50.1804837	8.7410776
+location	Bad Vöslau	47.9655519	16.2148073
+location	Badalona	41.4493539	2.248254
+location	Badames	43.3547822	-3.4968286
+location	Badaran	42.3677057	-2.8083919
+location	Baden	48.0085749	16.2334951
+location	Badhoevedorp	52.3388803	4.7844704
+location	Badia del Valles	41.5078201	2.1153392
+location	Badlapur	19.1561967	73.2660724
+location	Badulla	6.9898202	81.0569425
+location	Badung	-8.60458525	115.17859408310957
+location	Bady Bassitt	-20.9178969	-49.4517911
+location	Bättwil	47.4899611	7.5093058
+location	Baga	42.2527659	1.8625903
+location	Bagaces	10.515753	-85.28523203582515
+location	Bagamoio	-25.8964552	32.5648535
+location	Bage	-31.3314264	-54.1062808
+location	Bagerhat	22.6554187	89.7971746
+location	Bagno	53.51573	19.53343
+location	Bahia Blanca	-38.7183	-62.2663
+location	Bahla	22.970025	57.2986957
+location	Baiao	-2.7903479	-49.6702845
+location	Bailey County	34.0349194	-102.8149372
+location	Bailleul	50.6689214	3.3176015
+location	Bairro Azul	-8.8258862	13.22189
+location	Baixo Guandu	-19.5138322	-41.0182089
+location	Baja California (Chiapas)	16.7657698	-93.1889836
+location	Baja Verapaz	14.9139596	-90.5232808
+location	Bajc	47.9235482	18.2081404
+location	Bajina Basta	43.9714028	19.5659497
+location	Baker County OR	44.7259637	-117.6204818
+location	Bakow	49.9008987	18.7374167
+location	Balaguer	41.7897204	0.8054914
+location	Balakovo	52.01812	47.819141
+location	Balashikha	55.8036225	37.9646488
+location	Balata	32.2054798	35.2864958
+location	Balazote	38.8849	-2.1523
+location	Baldersheim	47.8007333	7.378094
+location	Baldwin County	30.5677527	-87.7324392
+location	Balen	51.155143	5.184431
+location	Balneario Arroio do Silva	-28.9815269	-49.4189932
+location	Balneario Barra do Sul	-26.459842	-48.6061471
+location	Balneario Camburiu	-26.9924395	-48.6339782
+location	Balneario Picarras	-26.7638889	-48.6716667
+location	Balneario Pinhal	-30.2482978	-50.234585
+location	Balsa Nova	-25.5842234	-49.6312741
+location	Balsamo	-20.7343722	-49.5807484
+location	Balsas	-7.53214	-46.037163
+location	Baltimore	39.2908816	-76.610759
+location	Baltym	56.99664260265946	60.60594308208412
+location	Bamberg County	33.2130154	-81.0166235
+location	Banani	23.790321	90.4076959
+location	Banaskantha	24.172056	72.431134
+location	Bandar	22.2927496	91.7790556
+location	Bandaragama	6.7145129	79.9889673
+location	Bandarban	22.1963002	92.2198872
+location	Bandeirantes	-23.107788	-50.370407
+location	Bandera County	29.7643475	-99.234526
+location	Bandung	-6.9344694	107.6049539
+location	Baney	3.7014833	8.9094224
+location	Banfora	10.642703	-4.752639
+location	Banga	-8.741975627819714	15.156698050455937
+location	Bangabaria	24.82071382184098	88.94325876883276
+location	Bangkok	13.803139	100.491612
+location	Banie	53.1005796	14.6622817
+location	Banjaluka	44.7720845	17.1917651
+location	Bankura	23.13195425	87.20739720367507
+location	Bannock County	42.6936188	-112.2506044
+location	Baños	-2.9232797	-79.0659048
+location	Banos de Rio Tobia	42.3348282	-2.7612306
+location	Banov	48.0487885	18.191583
+location	Banovce nad Bebravou	48.7216671	18.2598263
+location	Banska Stiavnica	48.4580926	18.8988414
+location	Banyoles	42.1180477	2.7653607
+location	Baqa Al-Gharbiyye	32.4197144	35.0428311
+location	Barabanki	26.93823105	81.38609761204991
+location	Baracaldo	43.29548	-2.9900933
+location	Baranain	42.804918	-1.682891
+location	Baranow	52.12305	20.47315
+location	Baranowo	52.2135664	16.9218226
+location	Barao	-29.372474	-51.494908
+location	Barao de Cocais	-19.9452437	-43.4870298
+location	Barasoain	42.604612	-1.645399
+location	Barbacena	-21.2254524	-43.7735087
+location	Barbacoas	9.857006	-84.3487717
+location	Barbençon	50.221079952133415	4.28443738101593
+location	Barbera del Valles	41.5172534	2.1265942
+location	Barberena	14.302152	-90.39390932015499
+location	Barbosa	6.438483250000001	-75.33912589828495
+location	Barbosa Ferraz	-24.0287182	-52.00811
+location	Barbour County	31.8589311	-85.4032078
+location	Barcelona	41.403267	2.151855
+location	Barcena	14.547669	-90.6223913
+location	Barcena De Cicero	43.41935	-3.50618
+location	Barcenilla	43.3889333	-3.9547549
+location	Barcin	52.8632346	17.9472463
+location	Barco De Valdeorras	42.4161908	-6.983967
+location	Bardejov	49.2926871	21.2756031
+location	Bardejovska Nova Ves	49.3031143	21.3177277
+location	Bardiya	28.3714635	81.45154306402392
+location	Bardoli	21.127394	73.105201
+location	Bardoňovo	48.1116805	18.4213303
+location	Bardyny	54.1781318	19.9394205
+location	Bari	41.1257843	16.8620293
+location	Baridhara	23.8032197	90.4194794
+location	Barillas	15.8162861	-91.2969017
+location	Bariri	-22.0746355	-48.7394852
+location	Barisal	22.7046314	90.3711417
+location	Barka	23.7079666	57.89278
+location	Barletta-Andria-Trani	41.180172	16.1466408
+location	Barlinek	52.9920762	15.2166391
+location	Barnaul	53.347402	83.7784496
+location	Barnim	53.23727	15.01103
+location	Barnislaw	53.3648894	14.4085897
+location	Barnstable County	41.6718684	-70.3499234
+location	Barnwell County	33.2641009	-81.4190808
+location	Barra Bonita	-22.490859	-48.558349
+location	Barra de Guabiraba	-8.4173522	-35.6626669
+location	Barra de Sao Miguel	-9.8261357	-35.8837777
+location	Barra do Pirai	-22.4703403	-43.8263256
+location	Barra do Sao Francisco	-18.676588016104702	-40.81472396531672
+location	Barra Dos Coqueiros	-10.9075694	-37.0386249
+location	Barra Mansa	-22.5394843	-44.1735129
+location	Barra Velha	-26.6338203	-48.6835001
+location	Barracas	-34.6452854	-58.3875619
+location	Barrancabermeja	7.067561	-73.848406
+location	Barranqueras	-27.4850978	-58.9308766
+location	Barranquilla	10.987216	-74.805576
+location	Barreda	43.3687232	-4.0424538
+location	Barreiras	-12.1440031	-44.9967406
+location	Barreirinha	-2.798863	-57.067897
+location	Barreiro	38.6340657	-9.047856727251068
+location	Barretos	-20.5531437	-48.5697509
+location	Barrio Balboa	8.8793696	-79.7937017
+location	Barrio Colon	8.8919047	-79.7679238
+location	Barrio Norte	9.361907	-79.89987429981319
+location	Barrio Sur	9.3530093	-79.89550241930797
+location	Barrios Unidos	8.2048321	-80.5156335
+location	Barron County	45.423557	-91.8454099
+location	Bartag	53.7164273	20.4691839
+location	Bartenheim	47.6354901	7.4766365
+location	Bartosova Lehotka	48.650737899999996	18.91107723135121
+location	Bartoszewo	53.5189388	14.4581951
+location	Bartoszycki	54.2124185	20.568447369148576
+location	Barueri	-23.5114	-46.8729
+location	Barut	50.5534397	18.4263422
+location	Barutkhana	24.8938248	91.8722085
+location	Barva	10.07634855	-84.10922100765933
+location	Basel	47.5581077	7.5878261
+location	Bassecourt	47.3380057	7.2399967281483555
+location	Bassenge	50.7583596	5.6094772
+location	Bassersdorf	47.4435706	8.6299131
+location	Bassevelde	51.2311917	3.6789952
+location	Bassilly	50.675907	3.933169
+location	Bášť	50.2049402	14.4771151
+location	Bastia	42.7065505	9.452542
+location	Bastrop County	30.110758949999997	-97.32192613278204
+location	Basundhara Residential Area	23.819229131951772	90.44757464291318
+location	Bat Yam	32.0154565	34.7505283
+location	Bata	1.8650897	9.768665
+location	Batam	1.1061034	104.0378246
+location	Batié	9.9401553	-2.876993868400155
+location	Batizovce	49.0734666	20.1843029
+location	Bátka	48.3684107	20.151485995528255
+location	Batorove Kosihy	47.8279363	18.4088219
+location	Batsheers	50.7381794	5.2807989
+location	Batticaloa	7.7356027	81.6941956
+location	Battignies	50.4165125	4.1685575
+location	Baudour	50.482837	3.838083
+location	Bauen	46.9353529	8.5795457
+location	Bauffe	50.569209	3.853564
+location	Baulers	50.617247199999994	4.358648257037174
+location	Bauru	-22.3218102	-49.0705863
+location	Bavegem	50.9445843	3.866374
+location	Bavikhove	50.8754034	3.3113418
+location	Bawshar	23.56	58.41
+location	Bayad	23.2298	73.2205
+location	Bayamon	18.344958249999998	-66.16837400269127
+location	Bayet	46.2476257	3.2687241
+location	Bayeux	-7.1301631	-34.936532
+location	Bayfield County	46.4710241	-91.1983175
+location	Bayonne	43.4933379	-1.475099
+location	Bayreuth	49.9427202	11.5763079
+location	Bayside	43.1806	-87.9006
+location	Baza	37.4888637	-2.7709805
+location	Bazel	51.146864	4.298358
+location	Bazenheid	47.4106386	9.0683537
+location	Beacon Falls	41.4426	-73.0618
+location	Beadle County	44.4157764	-98.2751583
+location	Beas De Granada	37.2188678	-3.4807267
+location	Beaufort County	32.3850708	-80.6923169
+location	Beaufort West	-32.353611	22.580556
+location	Beaulieu	45.1925411	5.3920415
+location	Beaumont	45.7538477	3.0870638
+location	Beaumont BE	50.2355294	4.2383115
+location	Beaumont FR	45.7538477	3.0870638
+location	Beauraing	50.1101971	4.9567402
+location	Beauregard l Eveque	45.5415036	4.9029214
+location	Beauregard Parish	30.6144496	-93.3416829
+location	Beauregard Vendon	45.9603	3.1111
+location	Beauvais	49.4300997	2.0823355
+location	Beauvechain	50.7808981	4.7717304
+location	Beaverhead County	45.1708403	-112.9537553
+location	Beaverton	45.4871723	-122.80378
+location	Bebedouro	-20.949077	-48.479083
+location	Becej	45.6153745	20.0490085
+location	Beckov	48.7882419	17.8964776
+location	Bedargowo	53.02122	15.36883
+location	Bedford County TN	35.5099479	-86.4507189
+location	Bedon Przykoscielny	51.7386094	19.6354333
+location	Bedon-Wies	51.7472146	19.6392637
+location	Bee County	28.3871179	-97.7191838
+location	Beek	50.92685255	5.811426689120637
+location	Beekdaelen	50.93449595	5.88869051100548
+location	Beer-Sheva	31.2525238	34.7905787
+location	Beernem	51.127743949999996	3.314506749873283
+location	Beerot-Itzhak	32.04648615	34.90895558285108
+location	Beerse	50.753018	4.305199
+location	Beersel	50.7669	4.3085
+location	Beerst	51.058103	2.886961
+location	Beerzel	51.0586177	4.6698925
+location	Begijnendijk	51.02422075	4.782642226258016
+location	Begumganj	22.9421436	91.0996725
+location	Beijing	40.071320	116.406908
+location	Beilen	52.8611395	6.5122831
+location	Beira	-19.828707	34.841782
+location	Beit Shemesh	31.746214	34.9886825
+location	Beit Shikma	31.6374791	34.6104564
+location	Beitar Ilit	31.71631535	35.120090993465396
+location	Bekasi	-6.2349858	106.9945444
+location	Bekegem	51.1605026	3.0455765
+location	Bekkevoort	50.9338977	4.98461697152198
+location	Beko'A	31.8294277	34.9270405
+location	Bela	49.0026226	18.9782612
+location	Bela - Ledec Na Sazavou	49.693369	15.277533
+location	Bela nad Cirochou	48.974421	22.1072708
+location	Bela Vista do Paraiso	-22.9948493	-51.1907996
+location	Belas	-9.1033375	13.174545441548965
+location	Belchatow County	51.3686224	19.276131823300723
+location	Belém	-1.45056	-48.4682453
+location	Belém de Maria	-8.6242497	-35.8388934
+location	Belem do Para	-1.45056	-48.4682453
+location	Belen	9.98396	-84.178354
+location	Belford Roxo	-22.7645	-43.3996
+location	Belfort	47.6379599	6.8628942
+location	Belgorod	50.59770013489837	36.57244052999764
+location	Belgrade	45.773279	-111.184535
+location	Belgrano	-47.85641952765958	-72.15271582082718
+location	Belisario Frías	9.0771648	-79.48888901107873
+location	Belisario Porras	9.054304	-79.499527
+location	Belk	53.2397139	19.8678277
+location	Bell County	31.0081659	-97.4314413
+location	Bell County TX	31.0081659	-97.4314413
+location	Bell-lloc d'Urgell	41.6321157	0.7769267
+location	Bella Union	-30.2612301	-57.6059002
+location	Bella Vista	8.984259	-79.525189
+location	Bellavista	41.7193944	1.8124954
+location	Bellcaire d'Emporda	42.0810857	3.0944347
+location	Belle Ville	-32.62159101426397	-62.69776089058405
+location	Bellecourt	50.4843145	4.254013
+location	Bellegarde-sur-Valserine	46.1073321	5.830749559824268
+location	Bellenaves	46.1992438	3.0781699
+location	Bellerive sur Allier	46.1156244	3.4063997
+location	Belleville	42.863312	-89.535472
+location	Bellingwolde	53.1180114	7.1659885
+location	Bellmund	47.1071376	7.2467743
+location	Bello	6.337338	-75.551569
+location	Bellpuig	41.6254383	1.0117111
+location	Belluno	46.2805407	12.078913722504204
+location	Bellvis	41.6721394	0.8176989
+location	Belmiro Braga	-21.9486291	-43.413564
+location	Belmonte	39.5592831	-2.7038117
+location	Belo Horizonte	-19.9227318	-43.9450948
+location	Belo Oriente	-19.2232523	-42.4807033
+location	Beloeil	50.535799	3.698624
+location	Belogorsk	50.921326	128.47287
+location	Beloit	42.519007	-89.018844
+location	Belton	31.0560132	-97.464453
+location	Ben Arous	36.7515997	10.224547
+location	Benadovo	49.4307982	19.33899
+location	Benahadux	36.9251533	-2.460209
+location	Benajarafe	36.716604	-4.195416
+location	Benalmadena	36.594519	-4.572284
+location	Benalua	37.3499272	-3.1690217
+location	Benalua de las Villas	37.4317716	-3.6823181
+location	Benamaurel	37.6084683	-2.6970148
+location	Benátky nad Jizerou	50.291767	14.8260014
+location	Benavente	38.9741643	-8.8120694
+location	Benavides de Orbigo	42.5595764	-5.895921692946511
+location	Benešov	49.7818921	14.6869121
+location	Benetusser	39.4228928	-0.3974783
+location	Benevento	41.247642600000006	14.705466481850998
+location	Benevides	-1.3555577	-48.252235
+location	Benewah County	47.2162961	-116.6654616
+location	Benfica	-8.944328	13.1639942
+location	Bengaluru Urban	12.94514225	77.55364499971128
+location	Benguela	-8.8120807	13.2532494
+location	Beni Brak	32.0849	34.8352
+location	Béni Khiar	36.469353	10.7809723
+location	Benicassim	40.0554964	0.0644165
+location	Benidorm	38.5406255	-0.1290929
+location	Benifaio	39.2854089	-0.426264
+location	Beniganim	38.9431	-0.4439
+location	Benirredra	38.9612	-0.1928
+location	Benlloc	40.2112756	0.0270647
+location	Benningbroek	52.7043188	5.0130447
+location	Bento Goncalves	-29.1654014	-51.5197627
+location	Benton County	46.190531	-119.520720
+location	Benton County OR	44.494937	-123.4065679
+location	Benton County TN	36.0345286	-88.101285
+location	Benton County WA	46.1691702	-119.5286424
+location	Beranga	43.41547	-3.57624
+location	Berazategui	-34.7632677	-58.2116604
+location	Berchem	50.789509	3.509630
+location	Berchem-Sainte-Agathe	50.865005	4.292878
+location	Berchtesgaden	47.63108	13.0021634
+location	Bercianos del Paramo	42.3809862	-5.7038921
+location	Berdsk	54.75795	83.1068095
+location	Berea	-29.8505556	31.0019444
+location	Berendrecht - Zandvliet - Lillo	51.3344879	4.306783717280721
+location	Berezovsky	56.90979	60.812012
+location	Berg	50.931302	4.537617
+location	Berga	42.1011456	1.8454758
+location	Bergamo	45.6983	9.6773
+location	Bergeijk	51.3211501	5.3569427
+location	Bergen	60.3943055	5.3259192
+location	Bergen County	40.9263	-74.0770
+location	Bergerac	44.8534568	0.487531
+location	Bergheim	47.8408541	13.0221612
+location	Beringen	51.064162	5.224601
+location	Berisso	-34.8688565	-57.8828667
+location	Berkeley County	33.1595951	-79.9070461
+location	Berks County	40.4113762	-75.9433305
+location	Berkshire County	42.3999954	-73.2322639
+location	Berlaar	51.103037349999994	4.664038763459683
+location	Berlare	51.0301606	4.011347029715423
+location	Berlicum	51.6789	5.4012
+location	Berlin	52.5034002	13.3386373
+location	Berloz	50.703886	5.202112
+location	Bermeo	43.418493	-2.730537
+location	Bern	46.9482713	7.4514512
+location	Bernalillo County	35.0349239	-106.6870693
+location	Bernieres-le-Patry	48.8111563	-0.7406050429408393
+location	Bernolakovo	48.198971	17.3008589
+location	Beroun	49.9640292	14.0733907
+location	Berovo	41.706668	22.8535559
+location	Berrien County	41.9838614	-86.3985714
+location	Bertamirans	42.8594847	-8.6501713
+location	Bertem	50.8659846	4.6306262
+location	Bertioga	-23.848568	-46.139586
+location	Bertogne	50.0843345	5.6676137
+location	Beruwala	6.4755668	79.9834173
+location	Besalu	42.1986443	2.6959559
+location	Besancon	47.2380222	6.0243622
+location	Bescano	41.9670349	2.7389937
+location	Besenov	48.0447635	18.2634183
+location	Besse Et St Anastaise	45.5115738	2.9329614
+location	Best	51.510017	5.398661990056466
+location	Bestwinka	49.9291282	19.0663839
+location	Betania	9.011641	-79.527928
+location	Betania PA	9.012685000000001	-79.52920651978945
+location	Betekom	50.9861112	4.7808123
+location	Bethany	41.427181	-72.993597
+location	Bethlehem	31.703183199999998	35.194854545710655
+location	Bethune	50.5223438	2.6385601
+location	Betim	-19.968056	-44.198333
+location	Betren	42.6979727	0.8059505
+location	Bettincourt	50.7099793	5.235361
+location	Bettingen	47.5714149	7.6639831
+location	Betton	48.1817122	-1.6414898
+location	Betxi	39.9288302	-0.1974253
+location	Beuzet	50.533144	4.745754
+location	Bevel	51.137253	4.680380
+location	Bevere	51.248887	4.235716
+location	Beveren	51.244589	4.229537
+location	Beveren-Leie	50.8748081	3.3452412
+location	Beverlo	51.086108	5.218808
+location	Beverst	50.889411	5.475428
+location	Beverwijk	52.478626	4.6732036218509
+location	Bexar County	29.4263987	-98.5104781
+location	Bezannes	49.2195271	3.9864282
+location	Bezerros	-8.2372132	-35.7558262
+location	Beziers	43.3426562	3.2131307
+location	Bhaktapur	27.6720657	85.428171
+location	Bhandara	21.12304765	79.79390882119336
+location	Bharuch	21.720731	72.999163
+location	Bhavnagar	21.7718836	72.1416449
+location	Bhedarganj Upazila	23.1988139	90.447782
+location	Bhilai	21.2120677	81.3732849
+location	Bhola	22.33654225	90.84390156623374
+location	Bhuj	23.247885	69.666857
+location	Biała	50.3853609	17.6599107
+location	Biala Nyska	50.4359728	17.306159
+location	Biała Podlaska	52.029700649999995	23.149702442345337
+location	Bialczyn	54.3205136	20.052609
+location	Bialka Tatrzanska	49.3946417	20.1050528
+location	Bialobrzegi	51.6482305	20.9497458
+location	Bialogard	54.0145099	15.969118723805451
+location	Bialy Bor	53.39116	18.7406371
+location	Biały Grunt	53.51071	21.20237
+location	Białystok	53.127505049999996	23.147050870161664
+location	Biarritz	43.471143749999996	-1.552726590666314
+location	Bibb County	32.971079	-87.1227088
+location	Bibice	50.1240692	19.955275
+location	Bidziny	50.87	21.3019444
+location	Biedkowo-Osada	54.3174077	19.7802429
+location	Biel	47.1402077	7.2439029
+location	Biel-Bienne	47.1402077	7.2439029
+location	Bielawa	50.675389800000005	16.607192643781275
+location	Bielefeld	52.0191005	8.531007
+location	Bieliny	50.8492374	20.9370523
+location	Bielsk Podlaski	52.764915	23.188210662123517
+location	Bielsko-Biała	49.81207845	19.029198802013944
+location	Bienville Parish	32.340169	-93.050187
+location	Bierbeek	50.836502	4.771272
+location	Bierghes	50.6955911	4.1172805
+location	Bierset	50.656953	5.454009
+location	Biertowice	49.8772932	19.7926553
+location	Bierutow	51.1252738	17.5400351
+location	Bierzow	50.8203617	17.344138
+location	Biesheim	48.0408514	7.5448609
+location	Biez	50.7267076	4.7033973
+location	Big Horn County	45.4608548	-107.5152896
+location	Big Sky	45.2589644	-111.308725
+location	Biguacu	-27.4961277	-48.6542432
+location	Bigues I Riells	41.68296785	2.2083885790461197
+location	Bikaner	28.024421	73.311641
+location	Bilac	-21.403962	-50.47464
+location	Bilaspur	22.383333	82.133333
+location	Bilbao	43.2630051	-2.9349915
+location	Bilcza	50.7873121	20.6198282
+location	Bilczyce	49.9286421	20.1826154
+location	Bildstein	47.4580056	9.7722409
+location	Bilgoraj	50.53881485	22.712481052013736
+location	Billom	45.7220503	3.3390575
+location	Billy	46.2362521	3.4300974
+location	Bilten	47.1521563	9.0280293
+location	Bilzen	50.8707787	5.5181089
+location	Bimenes	43.325206449999996	-5.56708326368729
+location	Binche	50.404183	4.193398
+location	Binderveld	50.8609613	5.1672786
+location	Bindura	-17.2425182	31.299578189883434
+location	Bingham County	43.1881598	-112.3598354
+location	Binjai	3.6063964	98.4899865
+location	Binkom	50.8721329	4.8840011
+location	Binningen	47.53656	7.570077
+location	Biot	43.6280001	7.0966644
+location	Birbhum	24.0	87.583333
+location	Birigui	-21.2908491	-50.34144
+location	Biritiba Mirim	-23.5697765	-46.0407456
+location	Birjand	33.074492649999996	59.14352632243029
+location	Birmensdorf	47.357448	8.4373921
+location	Birmingham	33.5206824	-86.8024326
+location	Birsfelden	47.5542152	7.6304739
+location	Bischheim	48.6148396	7.7523716
+location	Bischofshofen	47.4168029	13.2170933
+location	Bischofszell	47.4937698	9.2409168
+location	Bishnupur	24.562463649999998	93.8012483746545
+location	Bishop Lavis	-33.94820678844967	18.583836754257852
+location	Bissegem	50.8227711	3.2285861
+location	Bitola	41.0319586	21.3308466
+location	Bitou	-33.7682357	20.1506611
+location	Bitsingen	50.7583596	5.6094772
+location	Bituruna	-26.161281	-51.5533319
+location	Bizkaia	43.2204	-2.6984
+location	Blaasveld	51.055289	4.377447
+location	Black Hawk County	42.4607526	-92.3030235
+location	Bladel	51.37121075	5.234630644566941
+location	Blagoveshchensk	50.290527	127.527161
+location	Blaine County	48.4023938	-108.9664413
+location	Blanchardville	42.809498	-89.860021
+location	Blandain	50.624503	3.303954
+location	Blanden	50.824873	4.709589
+location	Blanes	41.6756178	2.7932391
+location	Blankenberge	51.301443	3.139196
+location	Blansko	49.36021865	16.652847141110076
+location	Blantyre	-15.7862543	35.0035694
+location	Blanzat	45.8283549	3.0771704
+location	Blaricum	52.2727	5.2481
+location	Blatné Remety	48.7083688	22.1046309
+location	Blaton	50.5004369	3.6608809
+location	Blauen	47.4489135	7.51876
+location	Blaye	45.1271231	-0.6635964
+location	Blazejow	50.6667056	16.0492058
+location	Blazkowa	50.7356742	15.9834678
+location	Blegny	50.676412	5.704849
+location	Bleiswijk	52.0109579	4.5310837
+location	Bleszno	51.5930147	20.862774
+location	Blicquy	50.5878005	3.6857513
+location	Bloemendaal	52.3742917	4.591534676879699
+location	Bloemfontein	-29.116395	26.215496
+location	Blois	47.5876861	1.3337639
+location	Blokker	52.6614915	5.0899615
+location	Blomard	46.2893	2.97642
+location	Bloomfield	40.806767	-74.1854226
+location	Blount County	33.9510169	-86.5702002
+location	Blount County AL	33.9510169	-86.5702002
+location	Blount County TN	35.6719722	-83.9314465
+location	Bludenz	47.153037	9.8219314
+location	Blumenau	-26.9195567	-49.0658025
+location	Bnei Ayish	31.7891954	34.7605995
+location	Bnei Brak	32.0873899	34.8324376
+location	Boa Esperanca do Iguacu	-25.6362851	-53.2139114
+location	Boa Esperanca do Sul	-21.9930206	-48.3917372
+location	Boa Vista	2.8208478	-60.6719582
+location	Bobigny	48.906387	2.4452231
+location	Bobo Dioulasso	11.1757783	-4.2957591
+location	Bobolice	50.62242	16.85783
+location	Bobot	48.8063918	18.1896039
+location	Bobowicko	52.4430284	15.6437744
+location	Bobrek Kolonia	51.6143693	21.0618628
+location	Bobrov	49.4291733	19.5421527
+location	Bobrovsky	56.6759359254465	60.97261002179681
+location	Bobrowo	53.289117	19.2733496
+location	Boca Da Mata	-9.6452054	-36.2116658
+location	Boca do Acre	-8.7553487	-67.3930873
+location	Bocaina	-22.1421831	-48.522276
+location	Bocaina do Sul	-27.745494	-49.942279
+location	Bochnia	49.974684249999996	20.425329198706468
+location	Bocholt	51.183426	5.558851
+location	Bochotnica	51.3397608	21.9925412
+location	Boćki	52.6512834	23.0426375
+location	Bodeli	22.2749233	73.7165607
+location	Bodensdorf	46.6860885	13.9725749
+location	Bodzanow	50.3366022	17.3839717
+location	Bodzechow	50.90995	21.44274
+location	Boechout	51.1597261	4.509867483882227
+location	Boezinge	50.8961176	2.8556799
+location	Bogaarden	50.7398062	4.1367803
+location	Bogarra	38.5815065	-2.2129227
+location	Bogdanka	51.7705204	19.7847685
+location	Bogdanki	51.85	16.8833333
+location	Bogdanowice	50.1653277	17.8318902
+location	Bogdany	53.7826817	20.6385221
+location	Bogdaszowice	51.085896	16.78349
+location	Bogor	-6.5962986	106.7972421
+location	Bogor Regency	-6.3578472	107.9299121
+location	Bogota	4.6533326	-74.083652
+location	Boguslawice	51.2038732	17.4566184
+location	Boignée	50.5018413	4.6119938
+location	Boiro	42.6475	-8.8834
+location	Bois-de-Villers	50.389973	4.823377
+location	Boiska-Kolonia	51.1885736	21.7474732
+location	Boituva	-23.2838893	-47.6738231
+location	Bojanice	50.7742806	16.4996754
+location	Bojano	54.4716206	18.3835121
+location	Bojano (Molise)	41.485724	14.472927
+location	Bojano (Pomorskie)	54.4716206	18.3835121
+location	Bojnice	48.7799591	18.5821986
+location	Bojnicky	48.3902415	17.801758273369714
+location	Bokaro	23.699127949999998	85.99106894165021
+location	Bolanos de Calatrava	38.9062533	-3.6629811
+location	Boleraz	48.4645308	17.4927358
+location	Bolesławice	54.44729	16.95203
+location	Bolesov	48.9854933	18.1565106
+location	Bolivar (Antioquia)	5.850170374360093	-76.02236228267127
+location	Bolivar County	33.7702263	-90.8519798
+location	Bolkow	50.9219695	16.1006519
+location	Bollene	44.2803882	4.7484092
+location	Bolligen	46.9755611	7.4983298
+location	Bolongongo	-8.4395288	15.0197799
+location	Bolszewo	54.61685	18.17654
+location	Bom Despacho	-19.7375242	-45.2517288
+location	Bom Jardim	-22.1515328	-42.4186683
+location	Bom Jardim (Pernambuco)	-7.7961572	-35.5871696
+location	Bom Jardim (Rio de Janeiro)	-22.1515328	-42.4186683
+location	Bom Jardim de Minas	-21.9476466	-44.1906033
+location	Bom Jesus	-5.9887544	-35.5821149
+location	Bom Jesus Da Lapa	-13.250571	-43.410754
+location	Bom Jesus de Goias	-18.2174587	-49.739721
+location	Bom Jesus do Itabapoana	-21.1341025	-41.680095
+location	Bom Principio	-29.489788	-51.3566782
+location	Bom Retiro do Sul	-29.6000007	-51.9359243
+location	Bommershoven	50.7868481	5.3796092
+location	Bon-Secours	50.4976184	3.607483
+location	Boncelles	50.5742979	5.5355698
+location	Boncourt	47.4979359	7.0127433
+location	Bond County	38.8630331	-89.4391416
+location	Bondy	48.9031	2.48291
+location	Bone Bolango	0.5479880354104765	123.26829265468324
+location	Bonfim	3.3613818	-59.8427241
+location	Bongara	-5.6745697	-77.901939
+location	Bonheiden	51.01931	4.568699
+location	Bonin	53.19553	15.35478
+location	Boninne - Gelbressée	50.5094834	4.9541659
+location	Bonito	-21.1264766	-56.4902208
+location	Bonner County	48.2663565	-116.5952716
+location	Bonneville County	43.3993844	-111.4752257
+location	Bonrepos i Mirambell	39.5178	-0.3647
+location	Boo de Pielagos	43.43049	-3.94551
+location	Booischot	51.0524068	4.7784936
+location	Boom	51.0873789	4.3667216
+location	Boone County	42.321246	-88.8235511
+location	Boone County IL	42.321246	-88.8235511
+location	Boone County IN	40.0459913	-86.4650842
+location	Boorsem	50.948071549999995	5.728082611825254
+location	Boortmeerbeek	50.978285850000006	4.575800524999997
+location	Boqueixón	42.8118	-8.4147
+location	Boqueron	8.9814597	-79.5693211
+location	Boquim	-11.1450175	-37.6204228
+location	Bora	-22.2703347	-50.5442675
+location	Boralesgamuwa	6.8410598	79.9017028
+location	Borborema	-21.6212706	-49.074135
+location	Borchtlombeek	50.8486371	4.1371467
+location	Bordeaux	44.841225	-0.5800364
+location	Bordils	42.0440682	2.9116018
+location	Borebi	-22.5700178	-48.9714871
+location	Borgerhout	51.2128453	4.4462406
+location	Borgloon	50.80033615	5.3568152017626245
+location	Borgo	42.5541524	9.4277361
+location	Borkowo	52.8376423	18.1986992
+location	Borne	52.3004342	6.754922548726859
+location	Bornem	51.095382	4.243244
+location	Boromo	11.7447567	-2.9300274
+location	Borovichi (Novgorod)	58.389009	33.9068275
+location	Borovichi (Pskov)	57.954006803447776	29.64510631065277
+location	Borowo-Mlyn	52.4775606	17.2075263
+location	Borrazopolis	-23.9399295	-51.5842203
+location	Borreda	42.1355536	1.9941054
+location	Borriol	40.0422215	-0.0714919
+location	Borsa	48.3921319	21.7063716
+location	Borsbeek	51.1928907	4.488953
+location	Borsbeke	50.9047179	3.8945771
+location	Borsky Mikulas	48.6283537	17.2059357
+location	Bort-les-Orgues	45.4010305	2.4992935
+location	Borucin	53.9636684	14.829363
+location	Borzytuchom	54.20028	17.36823
+location	Borzęta	49.8622568	19.9797338
+location	Bosque County	31.8778358	-97.6561014
+location	Bossier County	32.5369356	-93.6952689
+location	Bossier Parish	32.684186	-93.609166
+location	Bossuit	50.7480205	3.4079085
+location	Bossòst	42.7859893	0.69312
+location	Bost	50.789681	4.9406443
+location	Boston	42.354750	-71.061299
+location	Botad	22.1723	71.6636
+location	Bottelare	50.962494	3.753962
+location	Bottmingen	47.5234501	7.5748727
+location	Botucatu	-22.8879628	-48.4410712
+location	Bouchoucha	36.810561899999996	10.146874570226128
+location	Bouffioulx	50.390213	4.5151961
+location	Bouilladisse	43.3934248	5.5955308
+location	Boulogne Billancourt	48.8356649	2.240206
+location	Boulogne sur Mer	50.7259985	1.6118771
+location	Bourg-en-Bresse	46.206861	5.229144
+location	Bourg Lastic	45.6476261	2.5575506
+location	Bourg-Lès-Valence	44.9528222	4.8953847
+location	Bourges	47.0805693	2.398932
+location	Bourgoin-Jallieu	45.5872259	5.2828123
+location	Bousbecque	50.7720856	3.076757
+location	Boussu	50.425366	3.797692
+location	Boutersem	50.833781	4.839596
+location	Bouwel	51.1695534	4.7428091
+location	Bouzel	45.7793795	3.3159982
+location	Bovensmilde	52.9760223	6.4814495
+location	Bovesse	50.5143641	4.779285182968074
+location	Bowie County	33.4198886	-94.4479626
+location	Bozeman	45.6794293	-111.044047
+location	Bozen	46.4981125	11.3547801
+location	Bąkowice	50.93141	17.6995762
+location	Bra	50.3244046	5.7337839
+location	Brackenfell	-33.877398609128875	18.69249068258294
+location	Braco do Norte	-28.2728633	-49.1622712
+location	Braffe	50.551795	3.582031
+location	Bragado	-35.1155766	-60.489771
+location	Braganca	-0.9892329	-46.783178998153524
+location	Braganca Paulista	-22.9520235	-46.5418586
+location	Brahmanbaria	23.9675	91.1119
+location	Brahmanbaria Sadar	23.941088703451182	91.12454209357917
+location	Braine-l'Alleud	50.671286	4.358875
+location	Braine-le-Château	50.677854	4.267574
+location	Braine-le-Comte	50.612409	4.149466
+location	Braives	50.6300711	5.1435257
+location	Brakel	50.7979739	3.762778
+location	Brampton	43.6858146	-79.7599337
+location	Branc	48.20815035	18.148432198659382
+location	Brandsen	-35.1679404	-58.2373799
+location	Brandýs N. Labem	50.19002437021099	14.659124252450454
+location	Branford	41.286635	-72.801979
+location	Branice	50.048726099999996	17.792128569631622
+location	Braniewo	54.3791637	19.82216309198983
+location	Braniewski	54.277761999999996	19.955522341865752
+location	Branquinha	-9.2478057	-36.0152009
+location	Bras	49.9760182	5.3877654
+location	Brasil Novo	-3.3055853	-52.539198
+location	Brasilia	-15.814189	-47.875543
+location	Brassac Les Mines	45.4130887	3.3294831
+location	Brasschaat	51.308911	4.497508
+location	Braszewice	51.4986133	18.4493107
+location	Bratian	53.4574342	19.6103236
+location	Brazoria County	29.18161	-95.4993375
+location	Brazos County	30.65231335	-96.38058014696412
+location	Brazuelo	42.4971632	-6.1571714
+location	Breaza	45.1810934	25.668582
+location	Brebes	-7.053619299999999	108.88799436568738
+location	Brecht	51.3495582	4.6393435
+location	Breclav	48.7594008	16.8813137
+location	Breda	41.7484044	2.5613326
+location	Breda ES	41.7484044	2.5613326
+location	Breda NL	51.5820246	4.7443967
+location	Bredene	51.23890495	2.972576946828359
+location	Bree	51.138202	5.631877
+location	Breede Valley	-33.63565065	19.358449645517894
+location	Breendonk	51.042441	4.321611
+location	Bregenz	47.5025779	9.7472924
+location	Breitenbach	47.4078339	7.5442563
+location	Brekov	48.9056816	21.8380892
+location	Bremer County	42.7669649	-92.3099856
+location	Brentwood County	37.9317766	-121.6960266
+location	Brescia	45.77958045	10.4258729694612
+location	Bressoux	50.639339	5.605728
+location	Bressuire	46.8425572	-0.4929017
+location	Brest	48.398586	-4.493766
+location	Brestov nad Laborcom	49.1112025	21.9392388
+location	Brestovany	48.384943	17.685776369423195
+location	Breves	-1.68036	-50.479085
+location	Brewster County	29.8462742	-103.2400734
+location	Brezno	48.8053349	19.6409612
+location	Brezovica	49.1442996	20.8546707
+location	Brezovica (Prešov)	49.1442996	20.8546707
+location	Bridgeport	41.1792	-73.1894
+location	Brielen	50.8689046	2.8475388
+location	Brihuega	40.7592489	-2.8703477
+location	Brindisi	40.629964	17.937041
+location	Brinkmann	-30.8643586	-62.0470794
+location	Brioude	45.293897	3.3853711
+location	Brisbane	-27.484246	153.026118
+location	Brislach	47.4181317	7.5433687
+location	Bristol	41.6718	-72.9493
+location	Bristol County	41.7425538	-71.0856545
+location	Bristol County MA	41.7425538	-71.0856545
+location	Britania	-15.2427599	-51.1602061
+location	Brives Charensac	45.0474	3.92197
+location	Brixen	46.7165491	11.657851
+location	Brno	49.1922443	16.6113382
+location	Broadwater County	46.3252827	-111.4969303
+location	Brobo	7.966667	-4.833333
+location	Broczyno	53.5241057	16.3084821
+location	Brodnica	53.2580224	19.405433708150433
+location	Brodno-Warszawa	52.288533	21.0310084
+location	Broechem	51.180793	4.602098
+location	Broek In Waterland	52.432523	4.9957461
+location	Brognard	47.5292	6.8626
+location	Brommat	44.829995195310836	2.6986931912343994
+location	Bron	45.7337532	4.9092352
+location	Bronislawow	51.7722383	20.4485518
+location	Bronnitsy	55.4219938	38.2590612
+location	Bronowice	51.563445	14.7555322
+location	Bronx	40.858846	-73.864979
+location	Bronx County	40.8506558	-73.8665241
+location	Brookfield	43.066515	-88.129450
+location	Brooklyn	40.6782	-73.9442
+location	Brooklyn WI	42.854602	-89.371662
+location	Brooks County	26.9879856	-98.2071041
+location	Broome County	42.136164	-75.832955
+location	Brotas	-22.2840884	-48.1267265
+location	Broward County	26.1598074	-80.4623642
+location	Brown County IL	39.9498214	-90.7485656
+location	Brown County TX	31.7525184	-98.9904722
+location	Brown County WI	44.4383498	-88.0167093
+location	Brown Deer	43.1633	-87.9645
+location	Bruck An Der Leitha	48.030394799999996	16.75801830741043
+location	Bruck-Mürzzuschlag	47.4121987	15.2721668
+location	Brudzew	51.6138889	18.5122222
+location	Bruere Allichamps	46.76782	2.43129
+location	Brütten	47.4731491	8.6753241
+location	Brüttisellen	47.4242579	8.6307734
+location	Brugelette	50.602225	3.869806
+location	Brumath	48.7309406	7.708107
+location	Brummen	52.110649800000004	6.1258772929109675
+location	Brunehaut	50.528143	3.394669
+location	Brunssum	50.943821549999996	5.974825084719281
+location	Brusque	-27.0964628	-48.9136323
+location	Bruty	47.9236648	18.5789655
+location	Bruxelles	50.844766	4.351355
+location	Bry sur Marne	48.8352872	2.5193322
+location	Bryansk	53.2423778	34.3668288
+location	Brzeg	50.8588648	17.464124493778538
+location	Brzesko	49.9678396	20.6068496
+location	Brzezie	50.1276855	19.8249971
+location	Brzezie (Malopolskie)	50.1276855	19.8249971
+location	Brzezie (Swietokrzyskie)	50.9359159	21.0533424
+location	Brzezina	50.4643927	18.5389275
+location	Brzeziny	51.80066075	19.74462059147693
+location	Brzeznio	51.4947378	18.6228605
+location	Brzezno Szlacheckie	54.01964	17.24506
+location	Brzezowka	50.2674678	21.0920824
+location	Brzozow	49.6950395	22.0196537
+location	Brzączowice	49.8734411	20.0314522
+location	Brzuchania	50.3880108	20.089882
+location	Bubendorf	47.446684	7.73535
+location	Buc	47.8077245	18.4421897
+location	Bucaramanga	7.112728	-73.129549
+location	Buchanan County	42.4566	-91.9099
+location	Buchkirchen	48.2241613	14.0226453
+location	Buchlovice	49.0862718	17.3385196
+location	Buchs	47.1687116	9.4787656
+location	Buchs SG	47.1627634	9.4764086
+location	Bucks County	40.3451668	-75.1263909
+location	Budapest	47.482728	19.084269
+location	Budeliere	46.21961	2.46811
+location	Budkovce	48.6343517	21.9274867
+location	Budzow Kolonia	50.56013	16.70897
+location	Buehl	48.6945066	8.134423
+location	Büllingen	50.395004	6.308021
+location	Buena Vista	9.2747092	-79.6940798
+location	Buenos Aires	9.0825228	-83.23600189459881
+location	Buerarema	-14.9571177	-39.3008035
+location	Büsserach	47.3915791	7.5405238
+location	Bütschwil	47.354551900000004	9.075321167715813
+location	Buffalo City	-32.983333	27.866667
+location	Buffalo County	44.4073658	-91.7547858
+location	Buga	3.903723	-76.300764
+location	Bugaba	8.581595100000001	-82.69366785299674
+location	Buggenhout	51.010966	4.197976
+location	Buin	-33.7319741	-70.7419619
+location	Buissenal	50.663713	3.655885
+location	Buitenland	51.1152348	4.2314405
+location	Buitenpost	53.2540233	6.1443119
+location	Buizingen	50.7412271	4.2493488
+location	Bujaru	-1.5169239	-48.0410699
+location	Buk	52.352840975584776	16.521408270210564
+location	Bukit Bintang	3.1471068	101.7086011
+location	Bukittinggi	-0.3051954	100.3694921
+location	Bukovec (Kosice)	48.7142937	21.1372932572862
+location	Bukow	50.9847124	16.5848346
+location	Bukowiec	51.6915426	19.6671596
+location	Bukowno	51.5435562	20.841584
+location	Bulhon	45.8940685	3.3850936
+location	Bulnes	-36.7422507	-72.2987216
+location	Bulowice	49.8773139	19.2805376
+location	Buniewice	53.97312	14.72237
+location	Bunkovce	48.7236079	22.1186035
+location	Bunnik	52.039151849999996	5.220319799249577
+location	Bunsbeek	50.8425529	4.9454461
+location	Buraca	38.7437889	-9.2082841
+location	Buraimi	24.25919	55.783763
+location	Burcht	51.2028046	4.3416362
+location	Burdinne	50.585698	5.092629
+location	Bureau County	41.4016294	-89.5341179
+location	Burgdorf	47.0571316	7.6237466
+location	Burgos	42.343926	-3.696977
+location	Burhanpur	21.318288	76.220760
+location	Burjassot	39.5090599	-0.4108581
+location	Burke County	35.7270403	-81.6632108
+location	Burlada	42.8230299	-1.614076
+location	Burleson	32.535768554050875	-97.32722170343142
+location	Burleson County	30.4764878	-96.6353488
+location	Burlington County	39.9325409	-74.7226665
+location	Burlington County NJ	39.9325409	-74.7226665
+location	Burnet County	30.7763939	-98.1700016
+location	Burnett County	45.8652437	-92.2673161
+location	Burriana	39.8873342	-0.0838341
+location	Burruyacu	-26.499131900000002	-64.74324085284465
+location	Burunga	8.9708564	-79.6721541
+location	Bury	50.541909	3.593710
+location	Busince	48.1839466	19.49184498254887
+location	Busko-Zdrój	50.46759	20.71919
+location	Busseol	45.6919916	3.2543275
+location	Bussum	52.2774207	5.1627465
+location	Bustablado	43.280662	-3.6506137
+location	Butia	-30.1256795	-51.9692224
+location	Butler County	31.7340713	-86.6754793
+location	Butler County AL	31.7340713	-86.6754793
+location	Butler County OH	39.4233043	-84.5936897
+location	Butte County	39.6519275	-121.5858444
+location	Butte County CA	39.6519275	-121.5858444
+location	Butte County ID	43.6989304	-113.2210324
+location	Buus	47.5055264	7.8650401
+location	Buzet	50.419853	4.773861
+location	Byczen	50.5220162	16.9047412
+location	Bydgoszcz	53.12974625	18.029369658534854
+location	Bysina	49.8278203	19.8934693
+location	Byšta	48.5298268	21.5445553
+location	Bystra	49.75125280062039	19.021541823171674
+location	Bystricany	48.6589444	18.5177264
+location	Bystricka	49.05	18.8833333
+location	Byszyce	49.9268529	20.0140791
+location	Bytca	49.2235748	18.5586825
+location	Bytom	50.3657432	18.87153251609449
+location	Bytom Odrzanski	51.7308267	15.826918
+location	Bytow	54.168855	17.4922953
+location	Bzenica	48.5294028	18.741535
+location	Ca N'Amat	41.5284255	1.9821373
+location	Caapiranga	-3.3188884	-61.2096404
+location	Cabanes	40.1564567	0.0437829
+location	Cabanillas del Campo	40.6372767	-3.2364049
+location	Cabarrus County	35.4045503	-80.564371
+location	Cabedelo	-6.97324	-34.8351609
+location	Cabezon de la Sal	43.3080667	-4.2358532
+location	Cabildo	-32.4265909	-71.0663299
+location	Cabo de Santo Agostinho	-8.2838945	-35.0320984
+location	Cabo Frio	-22.8804369	-42.0189227
+location	Caborca	30.8974875	-112.60800114389396
+location	Cabralia Paulista	-22.4562909	-49.3385645
+location	Cabrera de Mar	41.5276986	2.3925117
+location	Cabrero	-37.0358293	-72.4026797
+location	Cabreros Del Rio	42.4020776	-5.5420111
+location	Cabrils	41.5262354	2.3676258
+location	Cabrobo	-8.5083701	-39.3106961
+location	Cabuya	8.5484301	-80.1651767
+location	Cacak	43.8913319	20.3501125
+location	Cacao	3.1640499	-52.3352667
+location	Cacapava	-23.099204	-45.707645
+location	Cacapava do Sul	-30.5113286	-53.4916761
+location	Cacem	38.7704429	-9.30908972918529
+location	Caceres	39.4745175	-6.3716761
+location	Cachoeira	-12.5998256	-38.9665918
+location	Cachoeira do Arari	-1.0143572	-48.9621089
+location	Cachoeira do Sul	-30.0474778	-52.8905413
+location	Cachoeira Grande	-2.9290492	-44.0573223
+location	Cachoeira Paulista	-22.666498	-45.015384
+location	Cachoeiras de Macacu	-22.4626861	-42.6534414
+location	Cachoeirnha	-29.923692965696514	-51.096138478209106
+location	Cachoeiro de Itapemirim	-20.848084	-41.11129
+location	Cacimba de Dentro	-6.6425101	-35.7929304
+location	Cacuaco	-8.83118705	13.433123108926477
+location	Cadca	49.4375146	18.7896041
+location	Caddo Parish	32.618244	-93.832261
+location	Cadiz	36.524659	-6.285386
+location	Cadreita	42.2181824	-1.6930439
+location	Cadrete	41.5556662	-0.9611928
+location	Caen	49.1810037	-0.3698915
+location	Caetanopolis	-19.2947496	-44.4138386
+location	Caetanos	-14.3387456	-40.9085971
+location	Cagnes-sur-Mer	43.6612012	7.1513834
+location	Caguas	18.2345399	-66.0351316
+location	Cahoeira Paulista	-22.666498	-45.015384
+location	Cahors	44.4495	1.4364999
+location	Caicó	-6.4594544	-37.0971911
+location	Caieiras	-23.375719	-46.723472
+location	Caimitillo	9.161041	-79.5419184
+location	Cairns	-16.890992	145.724483
+location	Caiua	-21.8319357	-51.9887179
+location	Cajamar	-23.3561111	-46.8769444
+location	Cajapio	-2.8778715	-44.6746871
+location	Cajar	37.1342232	-3.5712824
+location	Cajati	-24.7272376	-48.1077914
+location	Cajazeiras	-6.8897849	-38.5570389
+location	Cajica	4.919830	-74.024182
+location	Cajobi	-20.8776238	-48.8106972
+location	Cajuru	-21.2759978	-47.3046035
+location	Calaf	41.7323852	1.5150275
+location	Calafell	41.2014639	1.5680321
+location	Calahorra	42.307900	-1.966751
+location	Calais	50.9524769	1.8538446
+location	Calama	-22.4623917	-68.9272181
+location	Calamba City	14.2066364	121.1550511
+location	Calatayud	41.3527628	-1.6422977
+location	Calaveras County	38.2558181	-120.4981492
+location	Calbuco	-41.7712143	-73.1275379
+location	Calcasieu County	30.2232015	-93.3434067
+location	Calcasieu Parish	30.2232015	-93.3434067
+location	Calceta	-0.8480934	-80.1640382
+location	Caldas	6.05168765	-75.63035824143908
+location	Caldas (Antioquia)	6.05168765	-75.63035824143908
+location	Caldas Da Rainha	39.40051785	-9.0804786871297
+location	Caldera	-27.0675545	-70.8222047
+location	Caldes d'Estrac	41.5719788	2.5277607
+location	Caldes de Malavella	41.8398684	2.8099845
+location	Caldes de Montbui	41.632265	2.1676442
+location	Caldwell	30.5305813	-96.6969703
+location	Caldwell County	29.85270629203218	-97.61444189927661
+location	Caldwell Parish	32.0820785	-92.1130105
+location	Calella	41.6132925	2.6576102
+location	Calemba	-8.8386404	13.2497256
+location	Calemba 2	-8.90124805	13.269624199316441
+location	Calera de Tango	-33.6308224	-70.7592987
+location	Calgary	51.0460954	-114.065465
+location	Calhoun County	28.5031572	-96.6736551
+location	Calhoun County AL	33.7514505	-85.8315666
+location	Calhoun County IL	39.1397507	-90.6506113
+location	Calhoun County MS	33.9253624	-89.3231269
+location	Calhoun County SC	33.6567769	-80.7603948
+location	Calhoun County TX	28.5031572	-96.6736551
+location	Cali	3.4516	-76.5320
+location	Calidonia	7.959520	-81.390275
+location	California	36.357039	-119.690182
+location	Calilegua	-24.1984872	-65.2935747
+location	Callao	-12.0522626	-77.1391133
+location	Calldetenes	41.9257651	2.2834318
+location	Calle Larga	-32.8552685	-70.6260407
+location	Callenelle	50.5297342	3.5253447
+location	Callosa de Sarria	38.65517425	-0.11941501019896383
+location	Callus	41.7824664	1.7837664
+location	Caloocan City	14.6513225	120.9722957
+location	Calpulalpan	19.55201735	-98.61129267708826
+location	Calumet County	44.0751086	-88.2144321
+location	Calvia	39.5650931	2.5046323
+location	Calvinia	-31.469444	19.777222
+location	Calzada De Calatrava	38.7043087	-3.7766972
+location	Camacan	-15.4166631	-39.4930088
+location	Camacari	-12.6998188	-38.3260762
+location	Camama	-8.9402366	13.2647271
+location	Camanducaia	-22.755278	-46.144444
+location	Camapua	-19.5291747	-54.0434641
+location	Camaquã	-30.8524752	-51.8075619
+location	Camaragibe	-8.0213832	-34.9810768
+location	Camarasa	41.8756649	0.8778945
+location	Camargo	43.40794	-3.88487
+location	Cambara	-23.042273	-50.075281
+location	Cambará do Sul	-29.0489517	-50.145412
+location	Cambe	-23.2782035	-51.2779583
+location	Camboriu	-27.0273601	-48.6535657
+location	Cambrai	50.1759602	3.2356613
+location	Cambrils	41.0679423	1.0657579
+location	Cambuci	-21.5749919	-41.9107833
+location	Cambuquira	-21.853056	-45.2953619
+location	Camden County	39.814507	-74.986182
+location	Camden County NJ	39.8014709	-74.968553
+location	Cameron County	26.1291189	-97.4134281
+location	Cameron Parish	29.888055	-93.1843025
+location	Cametá	-2.242949	-49.497885
+location	Camocim de Sao Felix	-8.3616757	-35.7638903
+location	Camopi	3.1660034	-52.3340169
+location	Camos	42.0938831	2.7674256
+location	Camp County	32.97775740004426	-94.9774820211259
+location	Campana	-34.1636631	-58.9586837
+location	Campbellsport	43.596732	-88.280763
+location	Campdevànol	42.2230582	2.1680717
+location	Campillo de Arenas	37.5552182	-3.6353369
+location	Campillos	37.0470137	-4.8621698
+location	Campina Grande	-7.2246743	-35.8771292
+location	Campina Grande do Sul	-25.3046032	-49.0545355
+location	Campinas	-22.90556	-47.06083
+location	Campins	41.7250261	2.4640701
+location	Campo Alegre	-26.1941684	-49.2657484
+location	Campo Belo do Sul	-27.8987563	-50.7586887
+location	Campo Bom	-29.678418	-51.0572268
+location	Campo do Tenente	-25.9814143	-49.684518
+location	Campo Grande	-20.4640173	-54.6162947
+location	Campo Largo	-25.4597726	-49.5270851
+location	Campo Limpo Paulista	-23.207791	-46.788919
+location	Campo Lugar	39.1952574	-5.7718708
+location	Campo Mourao	-24.046329	-52.37802
+location	Campo Real	40.3390	-3.3833
+location	Campobasso	41.717264799999995	14.826226697820019
+location	Campodipietra	41.557028	14.746032
+location	Campohermoso	36.9357485	-2.1336526
+location	Campolieto	41.6324794	14.7654374
+location	Campomarino	41.9562688	15.034344
+location	Campos	39.4313098	3.0197912
+location	Campos do Jordao	-22.7395263	-45.5912829
+location	Campos Dos Goytacazes	-21.7558619	-41.3326895
+location	Camprodon	42.3127896	2.364926
+location	Camprovin	42.3544752	-2.7220509
+location	Campuzano	43.339676	-4.05821
+location	Can Parellada	41.5384149	2.0422606
+location	Can Pastilla	39.5371206	2.7164955
+location	Can Tries	41.5829824	2.2785017
+location	Canaa Doa Carajas	-6.5296837	-49.8516592
+location	Canals	38.9623954	-0.5832175
+location	Canarana	-11.6870151	-41.7683675
+location	Cañas	10.446361	-85.09342257148143
+location	Canaveral	8.51957065	-80.40798483211454
+location	Candamo	43.52549	-5.9143896
+location	Candeias	-12.6693806	-38.5406462
+location	Candelaria	-24.7506106	-53.7249794
+location	Candido de Abreu	-24.5747463	-51.3432207
+location	Candido Mota	-22.7434964	-50.38924
+location	Candido Rodrigues	-21.3255615	-48.6308798
+location	Candoi	-25.5711951	-52.051107
+location	Candos	-20.27620758365396	57.479395845815944
+location	Canela	-29.3624657	-50.8134204
+location	Canelinha	-27.2660341	-48.7666708
+location	Canet d'en Berenguer	39.6806	-0.2192
+location	Canet de Mar	41.5900933	2.5777998
+location	Cañete	-12.8209798	-76.3594255
+location	Cangas del Narcea	43.1774374	-6.5499784
+location	Canhoba	-10.1373681	-36.9710796
+location	Canillas de Rio Tuerto	42.3994057	-2.8412029
+location	Caninde de Sao Francisco	-9.6597475	-37.7904456
+location	Cannes	43.5515198	7.0134418
+location	Cannon County	35.8044159	-86.0512075
+location	Canoas BR	-29.9216045	-51.1799525
+location	Canoas CR	8.56429535	-82.88464012507875
+location	Canobbio	46.0349781	8.9670996
+location	Canoinhas	-26.1755121	-50.3949592
+location	Canot	-20.220644	57.4289695
+location	Canovanas	18.333020050000002	-65.8873070135487
+location	Canovelles	41.6173948	2.28288
+location	Canoves i Samalus	41.7072824	2.338253622217338
+location	Cantagalo	-21.9811325	-42.3682522
+location	Canto do Buriti	-8.1112473	-42.944844
+location	Cantonment	23.8010141	90.40376679778268
+location	Cañuelas	-35.0540248	-58.7617379
+location	Canyon County	43.6435692	-116.7017144
+location	Capao Bonito	-24.0048759	-48.3489848
+location	Capao Da Canoa	-29.7508278	-50.0210729
+location	Cape Agulhas	-34.8332036	19.9999325
+location	Cape Coast	5.107467	-1.2430793
+location	Cape Town	-33.928992	18.417396
+location	Cape Town Metro	-33.970973	18.510306
+location	Cape Winelands	-33.6357743	19.4574432
+location	Capela	-10.50494	-37.0552566
+location	Capela (Alagoas)	-9.415041	-36.082583
+location	Capela (Sergipe)	-10.50494	-37.0552566
+location	Capela do Alto	-23.4704798	-47.7352309
+location	Capiata	-25.3548171	-57.4427315
+location	Capital and Coast	-41.168408	174.867814
+location	Capitan Bermudez	-32.8166653	-60.7166716
+location	Capitao Leonidas Marques	-25.481645	-53.611238
+location	Capivari	-22.9999295	-47.5031066
+location	Capivari de Baixo	-28.449773	-48.963144
+location	Capixaba	-10.5741345	-67.6759719
+location	Capoeiras	-8.7386788	-36.6268109
+location	Capolo 2	-8.8701961	13.2911894
+location	Capracotta	41.833903	14.2642443
+location	Caraguatatuba	-23.62028	-45.41306
+location	Carahue	-38.7115852	-73.1648209
+location	Caraman	43.5292631	1.7600805
+location	Carambei	-24.9513298	-50.1171293
+location	Carandia	43.33684	-3.97495
+location	Carapebus	-22.1869969	-41.6633764
+location	Caratinga	-19.7900887	-42.140533
+location	Carauari	-4.8766426	-66.8961433
+location	Carazinho	-28.2981634	-52.7942363
+location	Carbon County	45.2050058	-109.1434792
+location	Carboneras	36.9968699	-1.8946552
+location	Carcaixent	39.1218973	-0.4467128
+location	Carcaraña	-32.8563501	-61.148729
+location	Carcassonne	43.2130358	2.3491069
+location	Cardedeu	41.6385167	2.3558408
+location	Cardenas	42.3743627	-2.767099
+location	Cardiff	51.476291	-3.178964
+location	Cardona	41.9142758	1.68133
+location	Cardoso	-20.080447	-49.9139767
+location	Cardoso Moreira	-21.4894916	-41.6152776
+location	Careiro	-3.8185277	-60.3616505
+location	Carentan	49.302133	-1.250938
+location	Carentoir	47.81775695	-2.1362362244234725
+location	Carepa	7.7977584	-76.74551461791256
+location	Cariacica	-20.263202	-40.416549
+location	Carlet	39.2251696	-0.5202051
+location	Carlos Barbosa	-29.2978372	-51.5005613
+location	Carlos Casares	-35.6232368	-61.3650016
+location	Carlos Pellegrini	-32.9327025	-60.7550878
+location	Carlos Santana Avila	8.3077411	-81.0614044
+location	Carmen	9.9576303	-83.7181339
+location	Carmen de Viboral	5.98195145	-75.26078014254009
+location	Carmo	-21.9341749	-42.6091737
+location	Carmo do Paranaiba	-18.9992327	-46.306916
+location	Carnaiba	-7.805964	-37.7947314
+location	Carnières	50.4431586	4.2548832
+location	Caroebe	0.8808696	-59.6963796
+location	Carolina	18.3794415	-65.957695
+location	Carouge	46.1846369	6.1440809
+location	Carpina	-7.8459151	-35.2538861
+location	Carrapateira	-7.0395225	-38.3432281
+location	Carrillo	10.4820011	-85.65078665782394
+location	Carrion De Calatrava	39.0183225	-3.8168257
+location	Carrizo De La Ribera	42.58374896112132	-5.8291968830878265
+location	Carroll County IL	42.0647352	-89.9556785
+location	Carson	39.1649125	-119.7666496
+location	Carson City	39.1649125	-119.7666496
+location	Cartagena	10.400866	-75.503036
+location	Cartago CO	4.7465494	-75.9121234
+location	Cartago CR	9.8642435	-83.9204377
+location	Cartes	43.3243805	-4.069902
+location	Caruaru	-8.2829702	-35.9722852
+location	Carver County	44.807118	-93.7871792
+location	Casa Branca	-21.7743137	-47.0852175
+location	Casablanca	-33.3205864	-71.4100762
+location	Casal de Cambra	38.8005207	-9.2307698
+location	Casalarreina	42.5479528	-2.911077
+location	Casas de Millan	39.8175504	-6.3290452
+location	Cascade County	47.3271465	-111.3281242
+location	Cascais	38.72240025	-9.396909171649877
+location	Cascavel	-24.9554996	-53.4560544
+location	Cascavel CE	-4.129666	-38.241178
+location	Cascavel PR	-24.9554996	-53.4560544
+location	Caserta	41.20348345	14.117057688141852
+location	Casilda	-33.0443368	-61.1641779
+location	Casimiro de Abreu	-22.4809932	-42.2039976
+location	Casma	-9.472866	-78.2136837
+location	Caspe	41.2368333	-0.0394819
+location	Cass County	33.0560857	-94.3510366
+location	Cass County IA	41.3122834	-94.9215151
+location	Cass County IL	39.9682127	-90.250722
+location	Cass County TX	33.0560857	-94.3510366
+location	Cassa de la Selva	41.8874685	2.8742461
+location	Castanhal	-1.2927031	-47.9223903
+location	Casteau	50.515333	4.013682
+location	Castel	-20.2925042	57.5186544
+location	Casteljaloux	44.3135784	0.0882703
+location	Castell-Platja D'Aro	41.8184693	3.0687997
+location	Castellar del Valles	41.6138122	2.0875963
+location	Castellar-oliveral	39.4296067	-0.3626211
+location	Castellbell I El Vilar	41.640276799999995	1.847203496119266
+location	Castellbisbal	41.4765136	1.9832978
+location	Castelldefels	41.2861022	1.9824173
+location	Castello D'Empuries	42.2591074	3.0746425
+location	Castello de la Plana	39.9860347	-0.0377354
+location	Castellón	40.25185675	-0.061505110105748245
+location	Castellon de la Plana	39.9860347	-0.0377354
+location	Castellsera	41.7461952	0.9885816
+location	Castellterçol	41.7503071	2.1230793
+location	Castelnaudary	43.3192021	1.9533495
+location	Castilho	-20.8695636	-51.4877792
+location	Castillo de Ferran	42.2739927	2.946129818149471
+location	Castillo de Locubin	37.5279563	-3.9422486
+location	Castkov	48.7465252	17.3540711
+location	Castril	37.7957	-2.7802
+location	Castrillo de San Pelayo	42.4279844	-5.8689705
+location	Castro	-24.794072	-49.9972914
+location	Castro County	34.4952536	-102.2592314
+location	Castro de Cepeda	42.6567254	-6.0281647
+location	Castro Urdiales	43.3843347	-3.2162576
+location	Cataguases	-21.387426	-42.6957219
+location	Catalao	-18.1702546	-47.9447082
+location	Catamayo	-3.9911481	-79.40388215708711
+location	Catambor	-8.8329085	13.2278913
+location	Catanduva	-21.1331035	-48.9712817
+location	Catarroja	39.4033747	-0.4028759
+location	Catawba County	35.6740563	-81.2107215
+location	Catende	-8.6900588	-35.748470825
+location	Catigua	-21.0491485	-49.0578923
+location	Cativá	9.3634008	-79.8349538
+location	Catole do Rocha	-6.340625	-37.746967
+location	Catriel	-37.8794088	-67.7932024
+location	Catrilo	-36.4107472	-63.4209353
+location	Catron County	33.9026943	-108.3800825
+location	Cattaraugus County	42.2234823	-78.6477096
+location	Caucaia	-3.7300563	-38.6593082
+location	Caucasia	7.82747905	-75.04521491490272
+location	Cauquenes	-37.1193665	-72.0188531
+location	Cavite City	14.6451165	121.026289
+location	Caxias	-4.8654201	-43.353664
+location	Caxias do Sul	-29.1684951	-51.1796197
+location	Cayambe	-0.0038813	-78.04818008344479
+location	Cayastá	-30.3554502	-60.4098547
+location	Cayenne	48.4250604	-2.1951293
+location	Cayenne BRE	48.4250604	-2.1951293
+location	Cayenne GF	4.9371143	-52.3258307
+location	Cayey	18.1126889	-66.1662772
+location	Cayey County	18.1126889	-66.1662772
+location	Cayuga County	42.900990	-76.575649
+location	Cazenga	-8.82357525	13.308092850527997
+location	Cazengo	-9.2984831	14.9144981
+location	Cazis	46.7223183	9.4300095
+location	Ceasaria	32.5114971	34.9057861
+location	Cebazat	45.832966	3.0999391
+location	Cecil County	39.5729428	-75.9381806
+location	Cedar Park	30.5217116	-97.827833
+location	Cederberg	-32.5005556	19.2569444
+location	Cedro	-7.7186318	-39.2363385
+location	Cedro de Sao Joao	-10.2506778	-36.8816067
+location	Cedynia	52.8785605	14.202564
+location	Cee	42.9555564	-9.1900013
+location	Celerina/Schlarigna	46.5132296	9.8586248
+location	Celinac	44.7241731	17.319359
+location	Celje	46.2264628	15.2649315
+location	Cellettes	47.5277413	1.3852205
+location	Centelles	41.7981296	2.2218056
+location	Centenario	-38.9365022	-69.1991719
+location	Centenario do Sul	-22.821497	-51.5951456
+location	Centla	18.353676200000002	-92.65219864326909
+location	Central Jakarta	-6.18233995	106.84287153600738
+location	Čerčany	49.8529293	14.7029875
+location	Cerdanya	42.3927235	1.803466566982073
+location	Cerdanyola del Valles	41.4910324	2.1374969
+location	Cerecedas	43.4552528	-3.4956281
+location	Ceres	-29.8820632	-61.9464975
+location	Ceres AR	-29.883125326125036	-61.94565875297064
+location	Ceres BR	-15.3103568	-49.6032054
+location	Cergy	49.0356	2.0603
+location	Cergy Pontoise	49.04064581583677	2.066247228825597
+location	Cerignola	41.2648121	15.8996651
+location	Cernik	48.1534962	18.2251815
+location	Cernina	49.2962865	21.4730524
+location	Černošice	49.9605466	14.3197051
+location	Céroux-Mousty	50.6607536	4.5343881
+location	Cerrillos	-33.5025026	-70.71591828411766
+location	Cerro Grande do Sul	-30.5962963	-51.7517196
+location	Cerro Navia	-33.42514465	-70.74395178833444
+location	Cerro Silvestre	8.9386536	-79.6810222
+location	Červený Kostelec	50.479920750000005	16.099193438783008
+location	Cervera	41.6730667	1.2729426
+location	Cervera Del Rio Alhama	42.0058319	-1.9554794
+location	Cesário Lange	-23.226035	-47.954453
+location	České Budějovice	48.9747357	14.474285
+location	Český Brod	50.0744692	14.8607574
+location	Český Krumlov	48.810678	14.3149994
+location	Cesky Tesin	49.734614	18.585272
+location	Cesson Sevigne	48.1197799	-1.6038829
+location	Ceyrat	45.7328967	3.0668817
+location	Cha Grande	-8.238271	-35.457148
+location	Cha Preta	-9.255605	-36.298334
+location	Chacabuco	-34.6423582	-60.4708815
+location	Chacara	-21.6727567	-43.2206851
+location	Chachapoyas	-6.3718272	-77.8093378
+location	Chadpur	23.3062581	90.9483774
+location	Chaineux	50.6317	5.8344
+location	Challans	46.83320341025406	-1.8617289769611034
+location	Challes-Les-Eaux	45.5491669	5.9826968
+location	Chalon sur Saone	46.7808	4.8539
+location	Chaltura	0.3546703	-78.1950495
+location	Chałupki	49.9251425	18.3179213
+location	Chamalieres	45.7732	3.06115
+location	Chambaron sur Morge	45.9566189	3.1453968751576475
+location	Chambers County	32.8901658	-85.3866953
+location	Chambers County AL	32.8901658	-85.3866953
+location	Chambers County TX	29.7191125	-94.5412295
+location	Chambery	45.5662672	5.9203636
+location	Chamblet	46.3342903	2.7010351
+location	Chambly	49.1662774	2.2444986
+location	Chambon sur Lac	45.5712859	2.8980689
+location	Chambray Les Tours	47.3390872	0.714368
+location	Chambrey Les Tours	47.3390872	0.714368
+location	Chamoli	30.499632300000002	79.61879245944404
+location	Champagnac	45.357288	2.3984303
+location	Champagne Ardenne	48.74077518849922	4.420081057126004
+location	Champaign County	40.1346857	-88.1975558
+location	Champaign County IL	40.1346857	-88.1975558
+location	Champaign County OH	40.1726987	-83.7701999
+location	Champeix	45.5903244	3.1310341
+location	Champfer	46.4778216	9.8122415
+location	Champhai	23.6317319	93.34931854269607
+location	Champion	50.495161	4.902091
+location	Champs sur Tarentaine	45.4042837	2.6026191342930742
+location	Chanaral	-26.347934	-70.6223617
+location	Chanava	48.3333333	20.3
+location	Chandauli	25.1265777	83.2496557733391
+location	Chandpur	23.2321	90.6631
+location	Chandrapur	20.030975599999998	79.35813866691342
+location	Changde	29.034552	111.6928724
+location	Changuinola	9.342004150000001	-82.70426106046781
+location	Changzhou	31.774498	119.919839
+location	Chaniat	45.3168447	3.4850587
+location	Chanonat	45.6943025	3.0945482
+location	Chanteloup-en-Brie	48.8555777	2.7395512
+location	Chapadao do Sul	-18.7949051	-52.6199512
+location	Chapai	24.69272	88.26109140951274
+location	Chapainawabgonj	24.59695585	88.27286214016199
+location	Chapdes Beaufort	45.890485	2.8660381
+location	Chapeco	-27.0922364	-52.6166878
+location	Chapelle-Lez-Herlaimont	50.4713265	4.2804202
+location	Chaponost	45.7107025	4.7469158
+location	Chappes	45.8682621	3.2226312
+location	Charata	-27.2178115	-61.1873712
+location	Charbice Dolne	51.7906541	19.1597421
+location	Charbice Gorne	51.7940508	19.1284011
+location	Charbonniere Les Vieilles	45.9953282	2.9988448
+location	Charbonnieres Les Varenne	45.9089024	3.0004231
+location	Charbonnieres Les Vieilles	45.9955609	2.9992181
+location	Charensat	45.9859155	2.6373315
+location	Charleston County	32.8152646	-79.7996814
+location	Charleville-Mezieres	49.7735712	4.7206939
+location	Charlotte County	26.9013269	-81.9156799
+location	Charolles	46.435311	4.2743162
+location	Charqueadas	-29.955012	-51.6249195
+location	Chartres	48.4438601	1.4881434
+location	Chascomus	-35.5786869	-58.0138252
+location	Chaspin	32.8450731	35.7928356
+location	Chastre	50.6103813	4.6441773
+location	Chateau-Gontier	47.8263058	-0.7066665
+location	Chateau-Thierry	49.048053	3.390023
+location	Chateaugay	45.8502246	3.0850695
+location	Chateaulin	48.1968026	-4.0916875
+location	Chateauneuf Les Bains	46.0263601	2.8963288
+location	Chatel Guyon	45.9205	3.06111
+location	Châtelet	50.400026	4.521491
+location	Châtelineau	50.4155938	4.5179328
+location	Chatham County	35.7151316	-79.2533035
+location	Chauchina	37.2014921	-3.7724726
+location	Chaumont-Gistoux	50.6839808	4.6974182
+location	Chauray	46.3606879	-0.3745955
+location	Chauriat	45.7509162	3.2791858
+location	Chausseterre	45.8964	3.78453
+location	Chautauqua County	42.2894671	-79.421728
+location	Chavannes-Renens	46.5339199	6.578038
+location	Chazemais	46.4829631	2.5259702
+location	Cheatham County	36.2444954	-87.0967857
+location	Cheboksary	56.1307195	47.2449597
+location	Chelan County	47.8012197	-120.6276904
+location	Chełm	51.13558825	23.493936945891463
+location	Chelmek	50.1003348	19.2542585
+location	Chełmno	53.35250284999999	18.440424707276136
+location	Chemin Grenier	-20.4892003	57.474182068307826
+location	Chemung County	42.1384667	-76.7725493
+location	Chenango County	42.4972	-75.6208
+location	Chenerailles	46.1450162	2.6774761
+location	Chengalpattu	12.6840886	79.9836371
+location	Chengdu	30.640989	104.067518
+location	Chennai	13.0801721	80.2838331
+location	Chepo	9.1741164	-79.0900045
+location	Cherbourg-Octeville	49.6343543	-1.6285770868661507
+location	Chercq	50.588930	3.422219
+location	Cherepovets	59.128696	37.916389
+location	Cherkessk	44.2285229	42.048257
+location	Cherlak	54.154067	74.7974987
+location	Cherokee	30.9809367	-98.7088377
+location	Cherokee County	34.1142554	-85.6004514
+location	Cherokee County AL	34.1142554	-85.6004514
+location	Cherokee County SC	35.0372626	-81.6480755
+location	Chesapeake	36.7183708	-76.2466798
+location	Cheshire	41.5084	-72.9106
+location	Chester County	39.9829308	-75.7652424
+location	Chester County PA	39.9829308	-75.7652424
+location	Chester County SC	34.6859896	-81.1545073
+location	Chesterfield County	37.3859982	-77.578509
+location	Chesterfield County SC	34.6500578	-80.1417843
+location	Chesterfield County VA	37.3859982	-77.578509
+location	Chhota Udaipur	22.3048651	74.0126114
+location	Chia	4.8704614500000005	-74.03632158198437
+location	Chicago	41.858966	-87.637242
+location	Chickasaw County	43.05994	-92.316679
+location	Chickasaw County IA	43.05994	-92.316679
+location	Chickasaw County MS	33.9137474	-88.9357382
+location	Chiclana de la Frontera	36.407163	-6.153590
+location	Chiclayo	-6.766417	-79.8408308
+location	Chicoana	-25.16839555	-65.57358375138564
+location	Chigorodo	7.612413549999999	-76.6359403826695
+location	Chiguayante	-36.9295866	-73.0242909
+location	Chiguiri Arriba	8.6748095	-80.189382
+location	Chihuahua	28.6523808	-106.0902046
+location	Chikkaballapura	13.4358702	77.7312434
+location	Chilches	36.726129	-4.224430
+location	Chilibre	9.1643168	-79.6191005
+location	Chililabombwe	-12.3680056	27.8350811
+location	Chillan	-36.6063	-72.1023
+location	Chillan Viejo	-36.6230032	-72.1317093
+location	Chiloeches	40.5732118	-3.1627206
+location	Chilton County	32.8522565	-86.7032845
+location	Chimalhuacan	19.41865739086373	-98.95701848240644
+location	Chimaltenango	14.6613043	-90.8193493
+location	Chimay	50.0358705	4.321416517933619
+location	Chimeneas	37.1312258	-3.8235177
+location	Chimoio	-19.110921	33.476659
+location	Chinautla	14.7422136	-90.48305542101491
+location	Chinchinales	-39.11282445467734	-66.94023390054608
+location	Chinsali	-10.549972	32.0660837
+location	Chippewa County WI	45.0740585	-91.2947258
+location	Chippewa Falls	44.931261	-91.389704
+location	Chiquimula	14.8005605	-89.547135
+location	Chirundu	-16.02937074830482	28.84883842000355
+location	Chisago County	45.4758877	-92.8849411
+location	Chitre	7.98012775	-80.4489823725464
+location	Chittagong	22.3307998	91.8412863
+location	Chittoor	13.1601048	79.15555061803596
+location	Chiuta	-15.5096702	33.44035583404886
+location	Chlumec	50.699992	13.9397526
+location	Chmielnik	50.6145952	20.7510406
+location	Chocielewko	54.537536	17.6357496
+location	Choconta	5.146017	-73.683678
+location	Choctaw County MS	33.3569348	-89.2390212
+location	Chodorówka Stara	53.5315077	23.1278556
+location	Chodzież	52.994997749999996	16.919925663627275
+location	Chojne	51.53796	18.8122
+location	Chojnice	53.6999165	17.570344138115953
+location	Chojnicki	53.80103495	17.72776527658926
+location	Cholchol	-38.6025592	-72.8476626
+location	Cholet	47.0617293	-0.8801349
+location	Chomutov	50.4606456	13.4178324
+location	Chone	-0.38280985	-80.07215992860299
+location	Chongqing	29.858721	107.375623
+location	Chonkovce	48.7794862	22.2409193
+location	Choragwica	49.958621	20.0869851
+location	Choroszcz	53.143925	22.9884588
+location	Chorvatsky Grob	48.2277565	17.2904997
+location	Choryasi	21.309529	72.957233
+location	Choszczno	53.1704801	15.4167349
+location	Chouteau County	47.8835499	-110.367651
+location	Chrast nad Hornadom	48.91725605	20.697426808256548
+location	Chrášťany	50.064666	14.929982
+location	Chris Hani	-31.5796424	28.7239077
+location	Christian County	39.5212598	-89.2829783
+location	Christian County IL	39.5212598	-89.2829783
+location	Christian County MO	36.9586087	-93.1692896
+location	Chroberz	50.422448	20.5558784
+location	Chroscice	50.783878	17.8153199
+location	Chroscina	50.6654559	17.8139394
+location	Chrzanow	50.1411926	19.4028502
+location	Chrzaszczewo	53.9584215	14.7392286
+location	Chtelnica	48.5691084	17.623391
+location	Chuadanga	23.6450761	88.8465767
+location	Chuarrancho	14.8605006	-90.46292340092779
+location	Chuchelna	50.6022869	15.3003417
+location	Chuda	22.4806	71.6879
+location	Chudovo	59.1194805	31.6665918
+location	Chungcheongnam	36.685948	126.799198
+location	Chur	46.855515	9.5254066
+location	Churchill County	39.6136309	-118.4191948
+location	Churriana de la Vega	37.1457	-3.6449
+location	Chuy	-33.6937948	-53.4561114
+location	Chwalkowo	52.1918312	17.2634923
+location	Chwarstnica	53.2213402	14.6111529
+location	Chybie	49.8968955	18.8151974
+location	Chýně	50.0606462	14.2272998
+location	Chyorny Yar	48.0576901	46.1152785
+location	Cianorte	-23.662036	-52.6103989
+location	Cibola County	34.8722771	-107.9398474
+location	Ciborz	53.256891	19.8683185
+location	Cicava	48.9237326	21.66352
+location	Cidade Ocidental	-16.1000758	-47.9445014
+location	Cidra County	18.1757164	-66.1609235
+location	Ciechanow	52.871204399999996	20.606245921754713
+location	Ciecierowka	51.171767	21.3765252
+location	Cienaga	11.006697	-74.244529
+location	Cienaga de Oro	8.8746769	-75.6210036
+location	Ciepielow	51.2477252	21.5747338
+location	Cieplowody	50.6765949	16.9073025
+location	Cieradz Koscielny	52.43779	16.59244
+location	Cierna Voda	48.1305218	17.6509752
+location	Čierne	49.4977488	18.8220684
+location	Cieszyn	49.7557676	18.65623134091032
+location	Cieza	43.2230443	-4.124873387159046
+location	Cifuentes	40.7854746	-2.6220894
+location	Cigla	49.3609939	21.3965393
+location	Cijuela	37.1998748	-3.8105099
+location	Cilacap	-7.46202885	108.80476219169329
+location	Cillorigo de Liebana	43.20767765	-4.612256863602484
+location	Cimhova	49.3626394	19.694684
+location	Cincinnati	39.122033	-84.515918
+location	Ciney	50.269588	5.122431
+location	Cintruenigo	42.078227	-1.805927
+location	Ciply	50.4192687	3.9438128
+location	Cipolletti	-38.9278173	-67.9925103
+location	Ciricito	9.0276616	-80.0832231
+location	Cirilo Guaynora	8.2752225	-77.5239486
+location	Ciruena	42.4117511	-2.8955322
+location	Cisie	52.21984	21.38848
+location	Cistierna	42.8031443	-5.1255563
+location	Cite Lóiseau	-20.301906013804143	57.511609154718506
+location	City of Tshwane	-25.6798828	28.2730697
+location	Ciudad Juarez	31.7097961	-106.455581
+location	Ciudad Quetzal	14.6989331	-90.5765304
+location	Ciudad Real	38.95975095	-3.88284645910809
+location	Ciudad Vieja	14.512764350000001	-90.7698852760732
+location	Cizur Menor	42.786144	-1.677269
+location	Clabecq	50.6893737	4.2214131
+location	Clackamas County	45.1608821	-122.2305038
+location	Claiborne County MS	31.9640367	-90.9141968
+location	Claiborne Parish	32.8218607	-93.0097229
+location	Clallam County	47.9998383	-123.7373472
+location	Clamart	48.800368	2.2630292
+location	Clamecy	47.4598895	3.5187552
+location	Clarendon County	33.6653463	-80.2277002
+location	Clark County IL	39.3260541	-87.7838526
+location	Clark County MO	40.3962004	-91.7362195
+location	Clark County NV	36.3467726	-115.0907378
+location	Clark County OH	39.9229676	-83.7905959
+location	Clark County WA	45.7669047	-122.4940866
+location	Clark County WI	44.7188146	-90.6214928
+location	Clarke County	31.659134	-87.8192486
+location	Clarke County AL	31.659134	-87.8192486
+location	Clarke County GA	33.9597677	-83.376398
+location	Clatsop County	45.980728	-123.6687499
+location	Clavier	50.4119432	5.3576794
+location	Clavijo	42.3494671	-2.4262521
+location	Clay County	33.2423393	-85.819651
+location	Clay County AL	33.2423393	-85.819651
+location	Clay County IL	38.7340694	-88.4910693
+location	Clay County MS	33.6393012	-88.7957063
+location	Clayton AU	-37.9173212	145.1304242
+location	Clayton County	42.8547706	-91.3667151
+location	Clayton PA	9.01106725	-79.57271645992734
+location	Cleburne County	33.6506958	-85.5017359
+location	Clerlande	45.9192	3.1922
+location	Clermont-Ferrand	45.7774551	3.0819427
+location	Cleveland County	35.330702	-81.5507523
+location	Clevelandia	-26.404065	-52.3513972
+location	Clinton County	44.703277	-73.705166
+location	Clinton County IL	38.5896187	-89.420064
+location	Clinton County MI	42.9435238	-84.6125345
+location	Clinton County NY	44.7278943	-73.6686982
+location	Cluses	46.0603171	6.5804218
+location	Cmielow	50.8918364	21.5100875
+location	Cminsk	50.9844445	20.5405892
+location	Coahoma County	34.1931314	-90.5653906
+location	Coamo	18.0807012	-66.3565542
+location	Coamo County	18.0807012	-66.3565542
+location	Coatepeque	14.7026327	-91.8656361
+location	Cobán	15.4702001	-90.3735065
+location	Cobb	33.9373948	-84.5732006
+location	Cobb County	33.9373948	-84.5732006
+location	Coca	-0.4721804	-76.9837216
+location	Cochamo	-41.4925628	-72.3079293
+location	Cochise County	31.8514532	-109.8181858
+location	Cochrane	-47.2541656	-72.5732128
+location	Coconino County	35.9363252	-111.6948197
+location	Codegua	-34.0377	-70.6565422
+location	Coelemu	-36.4876004	-72.7023316
+location	Coevorden	52.6614	6.7411
+location	Coffee County	31.3629619	-85.9870669
+location	Coffee County AL	31.3629619	-85.9870669
+location	Coffee County TN	35.4906115	-86.069633
+location	Cogollos De Guadix	37.2241755	-3.1610634
+location	Cogollos de la Vega	37.2755727	-3.572149
+location	Cogolludo	40.9470672	-3.0887458
+location	Coihueco	-36.628802	-71.8319077
+location	Coimbatore	11.0018115	76.9628425
+location	Coinco	-34.2699359	-70.9515801
+location	Colares	-0.936423	-48.280254
+location	Colatina	-19.5346732	-40.6287836
+location	Colbert County	34.6473396	-87.7921769
+location	Colbun	-35.6960057	-71.4060907
+location	Coles County IL	39.5266741	-88.2184999
+location	Colfax County	36.5571762	-104.6118941
+location	Colfontaine	50.40777	3.846237
+location	Colina	-33.202472	-70.6749147
+location	Colindres	43.3949637	-3.449786
+location	Colle d'Anchise	41.506325	14.516827
+location	College Station	30.5955289	-96.3071042
+location	Colleton County	32.8620726	-80.677114
+location	Colletorto	41.6629186	14.9733645
+location	Collier County	26.087964	-81.3794941
+location	Collin County	33.1609629	-96.6060984
+location	Collingsworth County	34.9487017	-100.2669137
+location	Collipulli	-37.9566312	-72.4374375
+location	Colmar	48.0777517	7.3579641
+location	Colmenar Viejo	40.6587901	-3.7663207
+location	Cologne	50.938361	6.959974
+location	Colombes	48.9221	2.2533
+location	Colombo	-25.2925439	-49.2243472
+location	Colon	-1.1089917	-80.4165447
+location	Colon AR	-32.2182804	-58.1356171
+location	Colon EC	-1.1089917	-80.4165447
+location	Colonia Benitez	-27.3166014	-58.95024163694664
+location	Colonia Caroya	-31.0217601	-64.0648895
+location	Colonia Leopoldina	-8.9144649	-35.7220255
+location	Colonia Margarita	-31.685948	-61.6477453
+location	Colonia Santa Rosa	-23.3940062	-64.425791
+location	Colorado County	29.6099609	-96.5478826
+location	Colorado County TX	29.6099609	-96.5478826
+location	Colorado Springs	38.8339	-104.8214
+location	Coltauco	-34.2862794	-71.0825729
+location	Columbia County	45.956622	-123.082332
+location	Columbia County AR	33.1938586	-93.2344337
+location	Columbia County GA	33.5313102	-82.2563979
+location	Columbia County NY	42.2415027	-73.6723456
+location	Columbia County OR	45.968079	-123.064474
+location	Columbia County WA	46.2947665	-117.9174697
+location	Columbia County WI	43.461844	-89.293554
+location	Columbia SC	34.0007493	-81.0343313
+location	Columbus County	34.2814497	-78.666593
+location	Columbus OH	39.973143	-82.993618
+location	Columbus WI	43.337556	-89.023979
+location	Colusa County	39.1465578	-122.2209563
+location	Comal County	29.7979704	-98.2690787
+location	Comanche County	31.9130171	-98.527388
+location	Combinado	-12.8136581	-46.5461041
+location	Combronde	45.9819	3.0889
+location	Comilla	23.4610615	91.1808748
+location	Comillas	43.3855344	-4.2901505
+location	Comines	50.749249	3.221643
+location	Comines-Warneton	50.7683055	3.0001175
+location	Commentry	46.290103	2.74398
+location	Comodoro Rivadavia	-45.8632024	-67.4752615
+location	Companigonj	22.87168325	91.27743143154504
+location	Compans	48.9936994	2.6623623
+location	Compiègne	49.408175	2.842839
+location	Con-Con	-32.9300229718223	-71.5183296900732
+location	Conceicao de Macabu	-22.0849986	-41.8679947
+location	Conceição do Araguaia	-8.2696905	-49.2676864
+location	Conceicao do Mato Dentro	-19.037222	-43.425278
+location	Concepción	14.861778	-91.9366098
+location	Concepcion AR	-27.344708949999998	-65.59997257793145
+location	Concepcion CL	-36.8270795	-73.0502399
+location	Concepcion CR	9.9257177	-83.9999025
+location	Conchal	-22.337512	-47.172927
+location	Conchali	-33.3843185	-70.67473607839639
+location	Concordia	-29.5385362	17.9462783
+location	Concordia AR	-31.3972539	-58.0173305
+location	Concordia BR	-27.2312011	-52.0231024
+location	Concórdia do Pará	-1.9924056	-47.9450474
+location	Concordia SA	-29.5385362	17.9462783
+location	Condado	-7.587868	-35.09994
+location	Condat	45.3410973	2.757778
+location	Condat Les Montboissier	45.5502359	3.4993455
+location	Conde	-7.2600359	-34.9053524
+location	Condor	-28.2058277	-53.4844696
+location	Conecuh County	31.3966783	-86.9437104
+location	Confins	-19.6278749	-43.9912311
+location	Congonhinhas	-23.5497241	-50.5520182
+location	Conguaco	14.048676	-90.034499
+location	Conil de la Frontera	36.277924	-6.088770
+location	Conselheiro Lafaiete	-20.6596107	-43.785743
+location	Conselheiro Pena	-19.1720883	-41.471995
+location	Constitucion	-35.3318306	-72.4118998
+location	Contamine-sur-Arve	46.1274947	6.3395716
+location	Contamines	45.820585	6.727730
+location	Contra Costa County	37.871082	-121.872678
+location	Cooch Behar	26.3223696	89.4592445
+location	Cook County	41.8197385	-87.756525
+location	Cook County IL	41.8197385	-87.756525
+location	Cooke County	33.582486	-97.2055298
+location	Coos County	43.2184144	-124.109621
+location	Coosa County	32.9181762	-86.2327497
+location	Copacabana	6.3600462	-75.49786997389143
+location	Copenhagen	55.6867243	12.5700724
+location	Copiah County	31.8563532	-90.4798717
+location	Copiapo	-27.372842	-70.320323
+location	Copperas Cove	31.124062	-97.9030785
+location	Coquelles	50.9280223	1.8144759
+location	Coquimbo	-29.9531928	-71.3379884
+location	Corbel	45.4293708	5.8247577
+location	Corbera	39.1580768	-0.3540631
+location	Corca	41.9893624	3.0170799
+location	Cordeiro	-22.0287681	-42.3607442
+location	Cordeiropolis	-22.4768324	-47.4550551
+location	Cordeiros	-15.0397219	-41.9314228
+location	Cordoba AR	-31.414964174855218	-64.1902257589077
+location	Cordoba ES	36.1412992	-5.6994821
+location	Cordoba Villa El Libertador	-31.4767681	-64.220012
+location	Cordovin	42.3848664	-2.8153541
+location	Corduente	40.8426955	-1.9783744
+location	Corfu	39.591337	19.859618918733858
+location	Cork	51.899	-8.460
+location	Cormoz	46.4484	5.2327
+location	Cornebarrieu	43.6479976	1.3225828
+location	Cornelio Procopio	-23.1825218	-50.6499263
+location	Cornella de Llobregat	41.355724	2.0706225
+location	Cornella de Terri	42.0898363	2.8157343
+location	Corniche	37.3009937	9.8655949
+location	Coromandel	-18.473889	-47.200278
+location	Coronda	-31.2370791	-60.5291251
+location	Coronel	-37.0164712	-73.1561953
+location	Coronel Arnold	-33.1059019	-60.9667135
+location	Coronel Du Graty	-27.6821132	-60.9045554
+location	Coronel Fabriciano	-19.5200067	-42.6282686
+location	Coronel Pacheco	-21.5878865	-43.2615975
+location	Coronel Portillo	-8.6867272	-73.9320879
+location	Corral de Bustos	-33.2832106	-62.1863973
+location	Corral de Calatrava	38.8573077	-4.0807008
+location	Corredor	8.60833575	-82.93062156032784
+location	Corredores	8.53889485	-82.9467215619332
+location	Corrientes	-27.4687004	-58.8312304
+location	Corro D'Amunt	41.67055895	2.329288533592615
+location	Corro d'Avall	41.632553	2.2982986
+location	Corroios	38.6415327	-9.1522335
+location	Corte	42.3052904	9.1511935
+location	Cortes de Baza	37.6539109	-2.7699007
+location	Cortes y Graena	37.2870853	-3.245263385876749
+location	Cortijos Nuevos	38.2471	-2.7259
+location	Cortland County	42.5842136	-76.0704906
+location	Corumba	-19.0016365	-57.6534316
+location	Coryell County	31.3689333	-97.8184077
+location	Cosmopolis	-22.6437398	-47.1972086
+location	Cota	4.8093624	-74.1015739
+location	Cotia	-23.603889	-46.918889
+location	Cotipora	-28.9950719	-51.696359
+location	Coto Brus	8.8892463	-82.91898427298493
+location	Cottage Grove	43.090480	-89.205111
+location	Couillet	50.391184	4.459113
+location	Coulandon	46.5503419	3.2579428
+location	Coulounieix Chamiers	45.1872222	0.6922222
+location	Counties Manukau	-37.1984291	174.9087676
+location	Cour-sur-Heure	50.2974701	4.3868963
+location	Courcelles	50.469378	4.34449
+location	Cournon	45.739114	3.1961893
+location	Cournon D Auvergne	45.739114	3.1961893
+location	Courpiere	45.7559617	3.5325463
+location	Courrendlin	47.3392989	7.3735698
+location	Court-Saint-Étienne	50.6443208	4.5685766
+location	Courtemautruy	47.3940088	7.1391362
+location	Courtetelle	47.3418687	7.3162671
+location	Couthuin	50.5315	5.1225
+location	Couvin	50.035063	4.485139
+location	Cova da Moura	38.9114419	-9.428262
+location	Covington County	31.196549	-86.4597236
+location	Cowlitz County	46.186419	-122.679487
+location	Cox's Bazar	21.16587175	92.03996424949702
+location	Coxim	-18.504915	-54.7450251
+location	Coxixola	-7.6272915	-36.606013
+location	Coyhaique	-45.5711804	-72.0684863
+location	Cozumel	20.4320599	-86.92069058377268
+location	Craiova	44.3190159	23.7965614
+location	Crandelles	44.9600183	2.3425106
+location	Cranendonck	51.286919	5.5810952873530475
+location	Craon	46.9948441	2.6823941
+location	Craponne	45.743476	4.7231057
+location	Crateus	-5.1782451	-40.6696545
+location	Crato	-7.2369112	-39.4149236
+location	Cravinhos	-21.340278	-47.729444
+location	Crawford County	42.0347	-95.3103
+location	Crawford County IL	39.0131644	-87.7291001
+location	Crawford County WI	43.2271639	-90.8938474
+location	Crenshaw County	31.6809362	-86.3244009
+location	Crépy en Valois	49.234399	2.888491
+location	Crespin	50.4177989	3.6613971
+location	Creteil	48.7771486	2.4530731
+location	Creuzier le Vieux	46.1593352	3.4382924
+location	Crevant Laveine	45.913535	3.3772684
+location	Criciuma	-28.6789941	-49.3695627
+location	Crimea	44.4974557	34.1705001
+location	Cristalina	-16.7680599	-47.6133427
+location	Cristinapolis	-11.4757019	-37.7555212
+location	Cristobal	9.3530018	-79.9045593
+location	Crocq	45.8682471	2.3676577
+location	Crook County	44.1460291	-120.3839476
+location	Crook County OR	44.1460291	-120.3839476
+location	Crosby	33.5778818	-101.2855737
+location	Crosby County	33.5778818	-101.2855737
+location	Cross Plains	43.115305	-89.646827
+location	Crouy en Thelle	49.213817	2.320688
+location	Crucita	-1.7063836	-80.5745459
+location	Cruise_Ship_1	35.4494305991609	-122.69846089824118
+location	Cruise_Ship_2	37.44646442694522	-124.08273825216106
+location	Crusnes	49.4344038	5.9154872
+location	Cruz Alta	-28.645056	-53.6058047
+location	Cruz Das Almas	-12.6722649	-39.1053665
+location	Cruzeiro	-22.5783685	-44.9642044
+location	Cruzeiro do Sul	-7.6307956	-72.6703869
+location	Cruzilia	-21.838333	-44.808056
+location	Cuanhama	-17.06512955	15.705433192527241
+location	Cubatao	-23.8857982	-46.4241869
+location	Cucuta	7.907734	-72.507857
+location	Cudahy	42.946879	-87.861992
+location	Cuddalore	11.7564329	79.7634644
+location	Cudon	43.41729	-4.01113
+location	Cuenca EC	-2.8968286	-79.0175358
+location	Cuenca ES	39.9705171	-3.4421805
+location	Cuenca Lago San Pablo	0.20788154166300882	-78.22304248554036
+location	Cuesmes	50.435127	3.923209
+location	Cueto	43.3445887	-3.1528643
+location	Cuevas Del Campo	37.6086165	-2.9316473
+location	Cuiaba	-15.5986686	-56.0991301
+location	Cuite	-6.4855072	-36.1478606
+location	Culhat	45.8633402	3.336213
+location	Culiacán	24.7978965	-107.393395
+location	Cullar Vega	37.1535419	-3.6703193
+location	Cullera	39.1647217	-0.2542313
+location	Cullman County	34.1335332	-86.8779268
+location	Cumberland County	39.2744299	-88.2423795
+location	Cumberland County IL	39.2744299	-88.2423795
+location	Cumberland County ME	43.8506432	-70.4001498
+location	Cumberland County NC	35.0461723	-78.8394255
+location	Cumberland County NJ	39.3183341	-75.1623239
+location	Cumberland County TN	35.953805	-84.9748195
+location	Cunco	-38.9328331	-72.0320492
+location	Cunha	-23.07753	-44.9567436
+location	Cupira	-8.6053148	-35.9530366
+location	Cuprija	43.9335612	21.3712355
+location	Curacavi	-33.4022289	-71.1293733
+location	Curepipe	-20.31872345	57.5264416
+location	Curepto	-35.0936167	-72.0177844
+location	Curico	-34.985368	-71.2393705
+location	Curitiba	-25.4295963	-49.2712724
+location	Currais Novos	-6.2626676	-36.5173039
+location	Curridabat	9.916215	-84.035009
+location	Curry County	42.4265426	-124.216879
+location	Curua	-1.887754	-55.116842
+location	Curuca	-0.7276792	-47.856568
+location	Curundú	8.979600699999999	-79.53767981960621
+location	Cusset	46.1324239	3.4602736
+location	Custer County	46.2426088	-105.5692958
+location	Cutias	0.9708625	-50.8000608
+location	Cutral Co	-38.9350862	-69.23884548141301
+location	Cutris	10.693809900000002	-84.32793748889281
+location	Cuyahoga County	41.4301347	-81.6905558
+location	Cuzcurrita de Rio Tiron	42.540534	-2.9636152
+location	Cybinka	52.403273	17.334667
+location	Cyganka	52.2247571	21.5024129
+location	Cyganka MZ	52.3158188	20.738102363361676
+location	Cyganka PM	54.2282139	19.1161773
+location	Czajkow	51.9071181	18.5869968
+location	Czaniec	49.84875	19.26204
+location	Czaplinek	53.560673	16.2319428
+location	Czapury	52.3248844	16.9113654
+location	Czarna Białostocka	53.2982835	23.2851013
+location	Czarna Woda	53.8441983	18.0984293
+location	Czarnków	52.90107245	16.572584219404398
+location	Czarnochowice	50.006516	20.0687187
+location	Czarnowo	52.0352107	14.9584601
+location	Czarny Bor	50.769924	16.133781
+location	Czaslaw	49.8554949	20.1183474
+location	Czechowice-Dziedzice	49.9112146	19.007564
+location	Czepino	53.28591	14.51694
+location	Czerlejno	52.3517476	17.2134437
+location	Czerniejewo	52.4296119	17.489398
+location	Czersk	53.796196	17.9756228
+location	Czerwiensk	52.0130585	15.4211463
+location	Czluchow	53.6634472	17.358074774000176
+location	Czyzowice	49.9800037	18.4107698
+location	Czyżew	52.7975512	22.3123475
+location	Da Serra	-23.7442	-46.3975
+location	Dabeiba	6.9428173	-76.37737085731695
+location	Dabroszyn	52.09573	18.1417
+location	Dabrowa	52.4009606	16.7449434
+location	Dabrowa (Warminsko-Mazurskie)	53.40802735	20.2072225551886
+location	Dabrowa (Wielkopolskie)	52.4009606	16.7449434
+location	Dabrowa Gornicza	50.3308692	19.2078918
+location	Dabrowice	50.61971	18.08595
+location	Dabrowka	52.0274029	15.8186
+location	Dabrowka (Lubuskie)	52.0274029	15.8186
+location	Dabrowka (Mazowieckie)	52.45019	19.36263
+location	Dachau	48.2592477	11.4354419
+location	Dadizele	50.8517979	3.0971782
+location	Dahegam	23.1637	72.8102
+location	Dahieh	33.8533	35.509
+location	Dahod	22.836899	74.251376
+location	Daimiel	39.072196	-3.6143611
+location	Dakota County	44.666655	-93.044911
+location	Dakshin Dinajpur	25.38703085	88.50471505
+location	Dale County	31.3940969	-85.623763
+location	Daleiden	50.070314	6.1839637
+location	Dalen	52.6994	6.7568
+location	Daleszyce	50.801991	20.8066334
+location	Daleszyn	51.9100616	16.9698623
+location	Dalhem	50.71948	5.758129
+location	Dalian	38.9181714	121.6282945
+location	Dalki	52.51255	17.5614023
+location	Dallas County	32.7620405	-96.7790069
+location	Dallas County AL	32.3117968	-87.1046643
+location	Dallas County TX	32.7620405	-96.7790069
+location	Dallet	45.772468950000004	3.238898480982826
+location	Damaia de Cima	38.7469973	-9.2202393
+location	Dambulla	7.8742031	80.6510917
+location	Damme	51.2553021	3.2920911130761956
+location	Damolandia	-16.2548322	-49.3675277
+location	Dampicourt	49.55507315	5.475324290832722
+location	Dampremy	50.4177243	4.428180523734177
+location	Damudya	23.1419299	90.44230730763083
+location	Damudya Upazila	23.13983025	90.44031160051017
+location	Dande	-8.9217683	13.1668451
+location	Dane County	43.0186	-89.5498
+location	Daniec	50.62028	18.13765
+location	Daniels County	48.7710629	-105.5123296
+location	Dankowice	50.8571693	16.8714051
+location	Danli	14.0324698	-86.5682844
+location	Dano	11.1435597	-3.0637939
+location	Dardilly	45.8064992	4.7537701
+location	Dargikowo	54.0157761	16.0632151
+location	Darjeeling	27.028909	88.260898
+location	Darlington County	34.3609331	-79.9438572
+location	Darnius	42.3665352	2.8337409
+location	Darrang	26.4365974	92.0342718
+location	Darro	37.3491909	-3.2933648
+location	Dasa	22.9435788	73.9334142
+location	Dashrath	22.3877702	73.1513259
+location	Daskroi	22.95840725	72.71852429515411
+location	Dasman	29.386491	47.999895
+location	Daule	-1.0447171	-79.6366882
+location	Dauphin County	40.398036	-76.8115168
+location	Dausa	26.80486585	76.44374569929329
+location	Davayat	45.9468101	3.108931
+location	Davezieux	45.2567222	4.7057799
+location	David	8.4949423	-82.48261591569641
+location	Davidson County NC	35.7902384	-80.2115053
+location	Davidson County TN	36.189724	-86.7857862
+location	Daviess County IN	38.6776099	-87.0813484
+location	Davinopolis	-18.1536888	-47.5624052
+location	Davis	38.5449	-121.7405
+location	Davos	46.7961744	9.8237266
+location	Dawson	31.8940478	-96.7147127
+location	Dawson County MT	47.2416708	-104.9259088
+location	Dax	43.7084065	-1.0518771
+location	Daxing	39.725413	116.3354417
+location	De Goorn	52.62715	4.9464601
+location	De Haan	51.267145	3.0406481714449747
+location	De Klinge	51.2564526	4.0898144
+location	De Panne	51.095512049999996	2.581164640676633
+location	De Rijp	52.5548999	4.8440884
+location	De Witt County	40.1811468	-88.7861844
+location	Deaf Smith County	34.9323974	-102.5983118
+location	Dearborn County	39.1340338	-84.9820997
+location	Deba	42.9784438	-2.5675689
+location	Debica	50.04611635	21.412761546800066
+location	Debienko	52.2903041	16.7259004
+location	Debowiec	50.5963783	17.0836627
+location	Debrznik	51.0820026	15.8068665
+location	Děčín	50.7824196	14.2147221
+location	Decines-Charpieu	45.773606	4.9633314
+location	Deer Lodge County	46.0753795	-113.089332
+location	Deerlijk	50.837861	3.365039
+location	Deforest	43.244858	-89.351873
+location	Degersheim	47.3735896	9.1990317
+location	Dehiwala	6.8512785	79.8659769
+location	Dehradun	30.3255646	78.0436813
+location	Deifontes	37.3263415	-3.5946529
+location	Deinze	50.9875	3.5236
+location	Deir al-Hatab	32.217222	35.320833
+location	Deir Hanna	32.8625037	35.3666613
+location	Dekalb County	41.8903447	-88.7713953
+location	Dekalb County AL	34.4524349	-85.7662118
+location	Dekalb County GA	33.7575613	-84.2186508
+location	Dekalb County IL	41.8903447	-88.7713953
+location	Del Norte County	41.7261767	-123.91328
+location	Delaware County	42.194917	-75.0016302
+location	Delaware County NY	42.194917	-75.0016302
+location	Delaware County OH	40.2317686	-82.9651045
+location	Delaware County PA	39.9194117	-75.4001639
+location	Delčevo	41.9668344	22.7767722
+location	Delémont	47.3615882	7.354445
+location	Delft	52.0116	4.3571
+location	Delft NL	51.99931830989721	4.358032390987868
+location	Delfzijl	53.3337339	6.9237352
+location	Delmiro Gouveia	-9.3841161	-37.997756
+location	Dematagoda	6.9327474	79.8803715
+location	Den Haag	52.0799838	4.3113461
+location	Den Helder	52.9529894	4.8267592494488
+location	Denderhoutem	50.8717796	4.0180839
+location	Denderleeuw	50.88813845	4.062511248890271
+location	Deneuille Les Mines	46.3795	2.78148
+location	Dengkil	2.8680243	101.6756275
+location	Denia	38.8408382	0.1061105
+location	Denpasar	-8.6524973	115.2191175
+location	Dentergem	50.96614065	3.4019362200773458
+location	Denton County	33.1838787	-97.1413417
+location	Denver County	39.7348381	-104.9653271
+location	Depok	-6.4074657	106.8138131
+location	Dera Ismail Khan	31.827527	70.9090919
+location	Derbent	42.057858	48.2887648
+location	Derbyshire	53.142893	-1.611670
+location	Derevyanka	61.6169349	34.6261437
+location	Derio	43.2916949	-2.8858821
+location	Desamparados	9.895826	-84.062458
+location	Descalvado	-21.9090404	-47.6203241
+location	Deschutes County	43.8194838	-121.1669662
+location	Desertines	46.3556648	2.6157229
+location	DeSoto County MS	34.8702932	-89.9778704
+location	DeSoto Parish	32.071362	-93.725530
+location	Dessel	51.2395713	5.113243
+location	Desselgem	50.8866327	3.3497336
+location	Desterro do Melo	-21.1460033	-43.518329
+location	Detva	48.5449223	19.4152478
+location	Deurne	51.220173	4.458167
+location	Deux-Acren	50.7307336	3.8522036
+location	Deventer	52.2695736	6.236339604766698
+location	DeWitt County	29.0931328	-97.3158457
+location	DeWitt County IL	40.1734773	-88.9003733
+location	DeWitt County TX	29.0931328	-97.3158457
+location	Dhaka	23.810651	90.4126466
+location	Dhalai	23.8253158	91.9732226716333
+location	Dhamrai	23.920162	90.2108702
+location	Dhamtari	20.7083903	81.5485253
+location	Dhanbad	23.7952809	86.4309638
+location	Dhandhuka	22.3816365	71.9791414
+location	Dhanera	24.5064	72.0258
+location	Dhangadi	28.6919141	80.615147
+location	Dhanmondi	23.73642665	90.37624419477338
+location	Dhansura	23.3498	73.2087
+location	Dharmapuri	12.09680475	78.19304301026716
+location	Dharmasraya	-1.0585388500000001	101.64402551163604
+location	Dholka	22.726607	72.4411863
+location	Dhubri	26.0186768	89.9857236
+location	Dhuy	50.5596814	4.8573789
+location	Diadema	-23.692685	-46.606911
+location	Diakovce	48.1337877	17.8413564
+location	Diamante do Sul	-25.0436147	-52.6800923
+location	Diamantina	-18.2440862	-43.6006487
+location	Diamniadio	14.7202187	-17.1842439
+location	Dibrugarh	27.4844597	94.9019447
+location	Dickson County	36.1459327	-87.3480592
+location	Diegem	50.8945555	4.4365042
+location	Diego de Almagro	-26.3910794	-70.0459281
+location	Diemen	52.3390	4.9592
+location	Diemlach	47.431403	15.2756542
+location	Diepenbeek	50.9078485	5.4200307
+location	Diepoldsau	47.3859513	9.6556042
+location	Diest	50.998854	5.062917
+location	Dietlikon	47.4222808	8.6155979
+location	Digne Les Bains	44.0918144	6.2351431
+location	Digora	43.160561	44.157784
+location	Dijon	47.3220	5.0415
+location	Dilar	37.0737362	-3.6010019
+location	Dilbeek	50.8465	4.2621
+location	Dillon County	34.4014089	-79.3864339
+location	Dilsen	51.0354657	5.7246821
+location	Dilsen-Stokkem	51.0284779	5.7311405
+location	Dimapur	25.9136459	93.7283456
+location	Dimmit County	28.3821949	-99.7178226
+location	Dinajpur	25.6428253	88.72247038287404
+location	Dinan	48.4539775	-2.047687
+location	Dindigul	10.3303299	78.0673979084697
+location	Dirlewang	48.0018325	10.5025804
+location	District of Columbia County	38.893661249999994	-76.98788325388196
+location	Dittingen	47.4383276	7.4989147
+location	Diu	23.2104108	72.6535065
+location	Diviaky	48.7656016	18.4937163
+location	Diviaky nad Nitricou	48.7656016	18.4937163
+location	Divinolandia	-21.6604584	-46.7371151
+location	Divinopolis	-20.1597367	-44.8735103
+location	Djerba	33.77339055	10.885904100766005
+location	Dlhe nad Cirochou	48.96191	22.0629114
+location	Dluga Szlachecka	52.2482593	21.3359557
+location	Dmitrov	56.3450695	37.5200723
+location	Dmosin	51.917440549999995	19.758353674743773
+location	Dobczyce	49.8803432	20.0905415
+location	Dobiegniew	52.9667749	15.7548055
+location	Dobkow	50.98643	15.95807
+location	Dobra	53.584659	15.3073048
+location	Dobrá Voda	48.968182	14.527586
+location	Dobřany	49.6554407	13.2908386
+location	Dobre	52.32171	21.67852
+location	Dobre Miasto	53.9868899	20.3973402
+location	Dobrowo	53.9892582	16.1200473
+location	Dobry	54.1193053	19.9400577
+location	Dobrylewo	52.8941667	17.7222222
+location	Dobsina	48.8211362	20.3649119
+location	Dodge County	43.413614	-88.7177834
+location	Dodro	42.7156742	-8.7042779
+location	Doettingen	47.5739904	8.2569004
+location	Dois Corregos	-22.3697554	-48.3845315
+location	Dois Irmãos	-29.58356	-51.089776
+location	Dois Irmaos do Buriti	-20.6906107	-55.2760274
+location	Dois Vizinhos	-25.7464681	-53.0554369
+location	Doische	50.1357152	4.7458219
+location	Dojc	48.6771217	17.254151
+location	Doľany	49.021347	20.647670680715226
+location	Dolembreux	50.535464	5.632975
+location	Dolgoprudny	55.9341491	37.5142417
+location	Dolna Streda	48.2666667	17.75
+location	Dolná Súča	48.9579902	18.0330936
+location	Dolne Lovcice	48.370954600000005	17.660533122758636
+location	Dolne Otrokovce	48.4656637	17.9117881
+location	Dolne Saliby	48.1058442	17.781458
+location	Dolný Kubín	49.2145239	19.2953168
+location	Dolny Ohaj	48.0831022	18.2534725
+location	Dom Eliseu	-4.2928111	-47.5559083
+location	Dom Pedrito	-30.983755	-54.6746483
+location	Domažlice	49.4407069	12.9298338
+location	Domene	45.2013065	5.8388954
+location	Domerat	46.359995	2.5368661
+location	Domeyko	-28.9552468	-70.8928638
+location	Domingo Perez	39.9757512	-4.5049656
+location	Domingos Martins	-20.3646483	-40.6585797
+location	Don Bosco	9.0576699	-79.4168184
+location	Don Matias	6.502334100000001	-75.39457059470519
+location	Dona Ana County	32.32817	-106.8494235
+location	Donceel	50.6478971	5.3199408
+location	Donderen	53.0960429	6.5457328
+location	Dongguan	22.992389	113.744830
+location	Donihue	-34.226074	-70.9648916
+location	Donostia-San Sebastian	43.304023	-1.981439
+location	Donovaly	48.8790358	19.2239467
+location	Door County	44.7615925	-87.5329747
+location	Dorado	18.4587209	-66.2677506
+location	Dorado County	18.4587209	-66.2677506
+location	Dorat	45.8921095	3.4817086
+location	Dorchester County	33.0756291	-80.3431133
+location	Dordrecht	51.7958812	4.6779351
+location	Dores do Rio Preto	-20.6907113	-41.846385
+location	Dorinne	50.3173377	4.97325
+location	Dormaal	50.8075875	5.0991805
+location	Dornach	47.4891507	7.6109429
+location	Dornbirn	47.413631	9.7423875
+location	Dosquebradas	4.832649	-75.677377
+location	Dosrius	41.594347	2.4063166
+location	Dota	9.58474375	-83.89090654843775
+location	Dottignies	50.7273981	3.3037301
+location	Dottikon	47.3838825	8.241593
+location	Douai	50.3675677	3.0804641
+location	Douglas County CO	39.3420437	-104.9468945
+location	Douglas County IL	39.7628415	-88.2170516
+location	Douglas County NE	41.2954112	-96.1415672
+location	Douglas County NV	38.9072611	-119.6201824
+location	Douglas County OR	43.1922115	-123.1135963
+location	Douglas County WA	47.7652709	-119.6075365
+location	Douglas County WI	46.4396038	-91.9059158
+location	Dour	50.390137	3.785941
+location	Douradinho	-21.7261999	-53.3561218
+location	Dourado	-22.1124638	-48.3151079
+location	Dourados	-22.2206145	-54.812208
+location	Dourdan	48.5288442	2.0153689
+location	Dover	39.158168	-75.5243682
+location	Doyaler Mor	24.819583	88.9357721
+location	Dąbrowa	52.4009606	16.7449434
+location	Dąbrowa Tarnowska	50.1743495	20.9850707
+location	Dr. JS Moroka	-25.1145068	28.936121506726128
+location	Dracena	-21.4835523	-51.5334408
+location	Draguignan	43.5374662	6.4627333
+location	Drahovce	48.5183461	17.7985046
+location	Drakenstein	-33.68284482972923	18.99100453929437
+location	Drawno	53.2189468	15.7580084
+location	Drawsko Pomomorskie	53.53579247382535	15.808651076029417
+location	Drawsko Pomorskie	53.5310786	15.8134179
+location	Dreieich	50.011974	8.7123912
+location	Dresden	51.0493286	13.7381437
+location	Dreux	48.7358807	1.3684254
+location	Drewnica	54.2867295	18.9622871
+location	Drezdenko	52.8396642	15.8323083
+location	Driebes	40.2454366	-3.0406577
+location	Drietoma	48.8957791	17.9545746
+location	Drogenbos	50.786532	4.3173542
+location	Drongen	51.0504639	3.6639157
+location	Drugnia	50.655928	20.8449929
+location	Dryga	53.5162542	23.1193108
+location	Držovice	49.4910793	17.1338622
+location	Duas Barras	-22.0522519	-42.5194705
+location	Dubendorf	47.3968244	8.6183023
+location	Dubí	50.6812997	13.788771
+location	Dubné	48.9767819	14.3594962
+location	Dubnica nad Vahom	48.9574049	18.1662967
+location	Dubnik	47.9585854	18.4132259
+location	Dubrowna	54.5722003	30.6900772
+location	Dubuque County	42.4692988	-90.8742047
+location	Dudzele	51.2747463	3.2292277
+location	Duesseldorf	51.22166	6.75289
+location	Duffel	51.0957176	4.5061988
+location	Duggingen	47.4520839	7.606511
+location	Duisburg	50.814708	4.551668
+location	Duivendrecht	52.3235282	4.9364854
+location	Dulce Nombre	9.8155833	-83.5654462
+location	Dulliken	47.3537179	7.9424681
+location	Dulovo	48.37307425	20.195538367409377
+location	Dun sur Auron	46.822869600000004	2.7914650336384046
+location	Dunajska Streda	47.9893751	17.6202595
+location	Dungari	23.6738243	76.3529551
+location	Dunkerque	51.0347708	2.3772525
+location	Dunn County	44.9333564	-91.8994409
+location	Dupage County	41.8603735	-88.0906873
+location	Duque de Caxias	-22.7863	-43.3053
+location	Duran	-2.1734745203373604	-79.84449301923338
+location	Duras	50.8333924	5.148255
+location	Durcal	36.9879333	-3.5663828
+location	Durg	21.19903535	81.3979545573657
+location	Durham County	36.0181316	-78.8751582
+location	Durtol	45.7952023	3.0519799
+location	Dusin	53.9210478	14.7390662
+location	Duszniki	52.4490442	16.4054502
+location	Dutchess County	41.762637	-73.721778
+location	Duval County	30.3540073	-81.6632109
+location	Duże Łabno	53.4012792	21.9360097
+location	Dvory nad Žitavou	47.9937445	18.265206
+location	Dvurechensk	56.595737	61.095806
+location	Dworp	50.72878189595669	4.300660719111533
+location	Dybawka	49.7780832	22.6856816
+location	Dybowo	53.7761998	21.6122851
+location	Dylew	51.7142027	20.7859897
+location	Dywity	53.83404	20.47337
+location	Dzialdowski	53.28925805	19.980674905832608
+location	Dziarnowo	52.78001	18.1807
+location	Dziecielec	54.4983726	17.9081053
+location	Dzierzoniow	50.7291725	16.656753139456175
+location	Dziewkowice	50.51496	18.33657
+location	Dzikowo	51.9766467	14.8543316
+location	Dziwnow	54.025095	14.7526469
+location	Dziwnowek	54.0352141	14.8068413
+location	Dzwierzuty	53.7045998	20.960917
+location	East Baton Rouge Parish	30.469664	-91.097549
+location	East Carroll Parish	32.6949938	-91.2605142
+location	East Feliciana Parish	30.850463	-91.036298
+location	East Godavari	17.233496	81.7225986
+location	East Haven	41.298543	-72.862538
+location	East Jaintia Hills	25.25157605	92.48405006942016
+location	East Khasi Hills	25.405680850000003	91.83546771298455
+location	East Medinipur	22.037985	87.811563
+location	East Orange	40.767323	-74.2048677
+location	East Shewrapara	23.7940712	90.3756562
+location	East Sikkim	27.3152014	88.6013621
+location	East Singhbhum	22.7995551	86.1839568
+location	Eau Claire County	44.7257643	-91.3040313
+location	Eau Coulee	-20.3028842	57.5283234
+location	Ebbs	47.611313550000006	12.242748830477494
+location	Ebensee	47.8122366	13.7741666
+location	Ebensee Am Traunsee	47.8122362	13.7731508
+location	Eberstalzell	48.0433366	13.9814852
+location	Ebnat-Kappel	47.2635337	9.1233561
+location	Écaussinnes	50.561198	4.181268
+location	Echandelys	45.5433331	3.5303797
+location	Echapora	-22.4325855	-50.2037693
+location	Echavarri	42.727827	-2.066099
+location	Echt-Susteren	51.082135199999996	5.899125547533698
+location	Ecroignard	-20.2278636	57.7430658
+location	Ector County	31.8941755	-102.5794339
+location	Ecuires	50.4446893	1.7639661
+location	Eddy County	32.4003136	-104.3452596
+location	Edegem	51.1548066	4.4458312
+location	Edgar County	39.6714952	-87.7340364
+location	Edgefield County	33.7635851	-81.9759066
+location	Edt Bei Lambach	48.0977674	13.8995169
+location	Edwards County	38.410254	-88.0584362
+location	Eelde	53.1346105	6.5633884
+location	Een	53.0747383	6.3931283
+location	Eernegem	51.12798285	3.0232969770351183
+location	Eferding	48.3082607	14.0203999
+location	Effingham County	39.0520902	-88.6029006
+location	Éghezée	50.5917416	4.9049523
+location	Egreville	48.1758188	2.8738344
+location	Eibar	43.1842839	-2.4732748
+location	Eichstätt	48.8933417	11.1838965
+location	Eielson AFB	64.655387	-147.064620
+location	Eijsden-Margraten	50.804994199999996	5.768281652884866
+location	Eilabun	32.8349228	35.4011051
+location	Eilat	29.5569348	34.9497949
+location	Eindhout	51.1038459	5.0012703
+location	Eindhoven	51.4416	5.4697
+location	Einsiedeln	47.1286095	8.7500299
+location	Eisden	50.984698	5.714420
+location	Eisenstadt	47.83875775	16.536215864955643
+location	Eisenstadt-Umgebung	47.9396071	16.726515713873287
+location	Ejea De Los Caballeros	42.1264653	-1.1382958
+location	Ekaterinburg	56.839104	60.60825
+location	Ekeren	51.276812	4.418126
+location	Ekurhuleni Metro	-26.08802865	28.36673016689302
+location	El Argamason	36.9980535	-1.9779162
+location	El Bagre	7.6977101	-74.6222028245339
+location	El Bagre Antioquia	7.6977101	-74.6222028245339
+location	El Barranquete	36.8380656	-2.1970697
+location	El Bosque	-33.56230741147309	-70.6741011400813
+location	El Calabacito	7.7715462	-81.0254359
+location	El Carmen	7.5743366	-75.3512101
+location	El Casar	40.7021635	-3.4293352
+location	El Cerrito	3.684363	-76.311345
+location	El Chiru	8.352309299127603	-80.22005756058195
+location	El Chorrillo	8.949912	-79.545254
+location	El Coco	8.8747517	-79.7996973
+location	El Coco (Cocle)	8.2341869	-80.5371754
+location	El Coco (Panama Oeste)	8.8747517	-79.7996973
+location	El Crisol	9.045101	-79.4735522
+location	El Dorado County	38.7574137	-120.5276129
+location	El Dosel	39.1923591	-0.2253395
+location	El Ejido	36.7753425	-2.8168228
+location	El Empalme	9.4187024	-82.5215992
+location	El Empalme EC	-1.0508949573368922	-79.60856451803338
+location	El Empalme PA	9.40489643490683	-82.58534670461506
+location	El Guarco	9.731360200000001	-83.91912149998079
+location	El Jicaro	14.88934785	-89.91311543909032
+location	El Limonal	-2.1335042	-79.8815108
+location	El Maresme	41.6023964	2.5089332172779972
+location	El Masnou	41.4796899	2.3118347
+location	El Monte	-33.6783192	-70.9782465
+location	El Mujal	41.8971009	1.6415769
+location	El Palmar	37.9388703	-1.1619192
+location	El-Pangui	-3.625	-78.5869441
+location	El Paso County	31.7754152	-106.4646348
+location	El Paso County CO	38.8287435	-104.5253456
+location	El Paso County TX	31.8072184	-106.2230394
+location	El Peñol	6.218713493595848	-75.24265852037168
+location	El Perellonet	39.307241	-0.2964027
+location	El Pont De Suert	42.407609	0.7402551
+location	El Port de la Selva	42.3373159	3.2047232
+location	El Prat de Llobregat	41.3246333	2.0952568
+location	El Puig	39.5908	-0.3031
+location	El Rieral	41.6737516	2.2145712668068946
+location	El Roble	8.16710565	-80.6595415790818
+location	El Rosal	40.4637	3.7492
+location	El Salvador	-26.2462114	-69.6259658
+location	El Santuario	6.1232786	-75.2651735797388
+location	El Tejar	9.8444297	-83.9396009
+location	El Torno	-17.9980974	-63.387676488747985
+location	El Tumbador	14.83881835	-91.93647412246496
+location	El Valle	8.6025106	-80.1216077
+location	El Vendrell	41.2199677	1.5348566
+location	El Villar de Arnedo	42.318377	-2.093425
+location	Elad	32.0495306	34.9507087
+location	Elbigenalp	47.289202	10.434541
+location	Elblaski	54.1592651	19.638304593203088
+location	Elbląg	54.1988997	19.44108568736702
+location	Elche	38.2653307	-0.6988391
+location	Elda	38.4765	-0.7966
+location	Eldorado	-23.7838809	-54.2832024
+location	Elektrostal	55.7903785	38.4405711
+location	Elektrėnai	54.786657	24.6708398
+location	Elen	51.0663119	5.7577353
+location	Elephant Road	23.7391943	90.38753499789709
+location	Elewijt	50.9604886	4.4975514
+location	Eliksem	50.78710135	5.00749223194515
+location	Elisario	-21.16845203732542	-49.11068468306947
+location	Elista	46.306999	44.270187
+location	Elk	53.82395835	22.361915871120694
+location	Elkana	32.1116176	35.0354721
+location	Elkhart County	41.6012796	-85.8590603
+location	Elko County	41.1958128	-115.3272864
+location	Ellezelles	50.7338	3.6799
+location	Ellis County	32.3347829	-96.7920233
+location	Elm Grove	43.047975	-88.086157
+location	Elmendorf AFB	61.252028	-149.812043
+location	Elmore County	32.5801231	-86.125195
+location	Elmore County AL	32.5801231	-86.125195
+location	Elmore County ID	43.3073766	-115.5411027
+location	Els Alamus	41.6144087	0.7397036
+location	Els Hostalets De Balenya	41.809966	2.2290345
+location	Elsie's River	-33.9236280382506	18.57287646818325
+location	Elverdinge	50.8857806	2.8172929
+location	Elx	38.2653307	-0.6988391
+location	Elyakhin	32.3968889	34.9260605
+location	Emalahleni	-25.8763485	29.2010447
+location	Emblem	51.1625761	4.6047327
+location	Embrach	47.5056384	8.5941089
+location	Embrun	44.5642457	6.4957085
+location	Embu Das Artes	-23.6495294	-46.8528497
+location	Embu-Guacu	-23.8317997	-46.8156204
+location	Emfuleni	-26.609125	27.824607496874158
+location	Emilianopolis	-21.831436	-51.483168
+location	Émines	50.5157255	4.827948661757707
+location	Emmen	52.75286615	6.952513466208563
+location	Emmenbrücke	47.077539	8.270942
+location	Empedrado	-35.5907183	-72.2778646
+location	Empuriabrava	42.2443515	3.126551
+location	Encantado	-29.2392716	-51.8744817
+location	Encosta de Sol	38.7673226	-9.2101078
+location	Encruzilhada do Sul	-30.536175200000002	-52.51560417047334
+location	Engenheiro Paulo de Frontin	-22.5504556	-43.6783403
+location	Engerwitzdorf	48.3409827	14.4224476
+location	Enghien	50.690407	4.036980
+location	England	52.405994	-1.671707
+location	Engrais Martial	-20.3003821	57.5164263
+location	Énines	50.6943193	4.9260633
+location	Ennezat	45.8976947	3.2208875
+location	Ennis	45.348817	-111.729697
+location	Enotaevka	47.2402733931147	47.02771726849827
+location	Ensenada	31.8658887	-116.6029835
+location	Ensenada AR	-34.8569635	-57.9077143
+location	Ensenada MX	31.8658887	-116.6029835
+location	Ensisheim	47.8665246	7.3529099
+location	Entraigues	44.9023909	5.9490438
+location	Enval	45.9	3.0503
+location	Envigado	6.168786	-75.583389
+location	Epila	41.5984995	-1.2796166
+location	Epinal	48.1747684	6.4503643
+location	Épinois	50.4049792	4.2093685
+location	Eptingen	47.37927123251582	7.817952373890522
+location	Erandio	43.3055981	-2.9729697
+location	Erbaut	50.53309	3.884409
+location	Ere	50.580306	3.368009
+location	Erechim	-27.6350709	-52.2738654
+location	Erembodegem	50.92009	4.0587947
+location	Erie County	42.7164263	-78.7620327
+location	Erlangen	49.5981187	11.003645
+location	Erlen	47.5504462	9.2254631
+location	Ermelino Matarazzo	-23.491673499999997	-46.48407014366894
+location	Ermelo	-26.515556	29.992222
+location	Ermeton-sur-Biert	50.2975439	4.7197934
+location	Ernakulam	10.1295438	76.4848521
+location	Ernesto Cordoba	9.1046565	-79.49321483019312
+location	Erode	11.369204400000001	77.67662686841793
+location	Erpe-Mere	50.9226391	3.9459888
+location	Erpent	50.4473127	4.900545
+location	Erps-Kwerps	50.9039296	4.5587455
+location	Erquelinnes	50.3030663	4.158586422257155
+location	Erro	42.9419631	-1.4498042
+location	Erschwil	47.3735346	7.5416739
+location	Escambia County	31.1168422	-87.1070947
+location	Escambia County AL	31.1168422	-87.1070947
+location	Escambia County FL	30.6625885	-87.3451089
+location	Escazu	9.919781	-84.142340
+location	Eschenau Im Hausruckkreis	48.3891584	13.82061
+location	Eschenbach	47.2401739	8.9217296
+location	Escobal	9.1478042	-79.9639856
+location	Escobedo	43.26758	-3.90671
+location	Escuintla	14.3022857	-90.7866243
+location	Escurolles	46.1430218	3.2666452
+location	Esik City	43.359486	77.465919
+location	Esmeraldas	0.9668153	-79.6523847
+location	Esmeraldas BR	-19.7613111	-44.3145945
+location	Esmeraldas EC	0.9508653	-79.6516527
+location	Esparreguera	41.5393249	1.8694549
+location	Esparza	9.99604495	-84.62556364842699
+location	Esperanza	-31.448994	-60.9304048
+location	Espinal	4.1694098	-74.8896022123354
+location	Espinasse Vozelle	46.1278	3.32411
+location	Espinchal	45.3932043	2.8801485
+location	Espinosa de Henares	40.9044591	-3.071876
+location	Espirat	45.7495198	3.3352835
+location	Espirito Santo do Pinhal	-22.190871	-46.74767
+location	Esplugues de Llobregat	41.3776796	2.0899722
+location	Esponella	42.1773757	2.7955223
+location	Espumoso	-28.7256962	-52.8453751
+location	Esquel	-42.9173055	-71.3216508
+location	Esquipulas	14.6308869	-89.25525631254732
+location	Essen	51.4582235	7.0158171
+location	Essen BE	51.4626799	4.45117
+location	Essen DE	51.4582235	7.0158171
+location	Essex County	40.784033	-74.235550
+location	Essex County MA	42.6762973	-70.9486776
+location	Essex County NJ	40.7913922	-74.2479444
+location	Essex County NY	44.0638879	-73.7542043
+location	Essonne	48.53034015	2.239291805668168
+location	Estacion Central	-33.46294815	-70.70492135642672
+location	Estaimbourg	50.6826198	3.3180722
+location	Estaimpuis	50.7059794	3.2640184
+location	Estancia	-11.2682255	-37.4378341
+location	Estância Velha	-29.6529666	-51.1719687
+location	Esteban Echeverria	-34.4033193	-58.6866309
+location	Estebanez de la Calzada	42.4400439	-5.9408595
+location	Esteio	-29.8511627	-51.1778852
+location	Estella	42.672094	-2.0314834
+location	Estinnes	50.374881	4.103617
+location	Estrela do Norte	-22.4886301	-51.6606857
+location	Estrela Velha	-29.1775802	-53.1597523
+location	Estrella	6.1576944	-75.6434368
+location	Estremera	40.1837	-3.1071
+location	Etables sur Mer	48.62665135	-2.8400063011785353
+location	Etampes	48.4344621	2.1614464
+location	eThekwini	-29.861825	31.009909
+location	Etowah County	34.0371404	-86.022147
+location	Ettelgem	51.178991	3.030238
+location	Etterbeek	50.833658	4.394661
+location	Ettingen	47.4816164	7.5441378
+location	Euclides Da Cunha Paulista	-22.55452	-52.592779
+location	Eugenio Espejo	0.2105058	-78.2491045
+location	Eugies	50.3906692	3.8883703
+location	Eupen	50.6292	6.0337
+location	Euvoia	38.49417235	23.91108439913793
+location	Evangeline Parish	30.6976776	-92.4217813
+location	Évelette	50.4135772	5.171436
+location	Even Shmuel	31.8087214	35.1984071
+location	Everberg	50.8778651	4.5695061
+location	Evere	50.8720096	4.4034182
+location	Evergem	51.1187231	3.705820038711427
+location	Evilard	47.1494705	7.2395711
+location	Evreux	49.0268903	1.1510164
+location	Evritania	38.965892999999994	21.678705442804155
+location	Extremoz	-5.7057628	-35.3034765
+location	Ezcaray	42.3257844	-3.0146438
+location	Ezeiza	-34.816848	-58.54746382802307
+location	Facatativa	4.829488899999999	-74.33464735967988
+location	Fackov	49.0098761	18.5986667
+location	Fahy	47.4184563	6.9505047
+location	Faina	-15.4458005	-50.3633826
+location	Fair Haven	40.3606653	-74.0381947
+location	Fairbanks	64.835015	-147.664888
+location	Fairfax County	38.8156356	-77.2836849
+location	Fairfield	41.1408	-73.2613
+location	Fairfield County CT	41.2943069	-73.37486
+location	Fairfield County SC	34.4091797	-81.1131228
+location	Faisalabad	31.4220558	73.0923253
+location	Falecice	51.6713767	20.9394479
+location	Fallon County	46.3291957	-104.4366483
+location	Falls County	31.2320941	-96.9262126
+location	Famailla	-27.05752995	-65.40235548878282
+location	Fameck	49.3043497	6.1041352
+location	Fannin County TX	33.5372542	-96.0902822
+location	Farciennes	50.43209235	4.546797831198054
+location	Faridabad	28.402837	77.3085626
+location	Faridpur	23.6040182	89.8415542
+location	Farmgate	23.7665513	89.56672755034788
+location	Faroe Islands	62.0448724	-7.0322972
+location	Farroupilha	-29.22647	-51.3468188
+location	Farrukhabad	27.43719385	79.48912946503123
+location	Fatepura	23.9319264	72.5821336
+location	Fatikchari	22.7061834	91.7222974
+location	Fatima do Sul	-22.3750499	-54.516698
+location	Faulx-les-Tombes	50.4272928	5.0191438
+location	Favara	39.1273559	-0.2916155
+location	Fawwar	31.4806083	35.0613504
+location	Faye l'Abbesse	46.8303723	-0.3525362
+location	Fayette County	42.9258	-91.9099
+location	Fayette County AL	33.7303493	-87.7419088
+location	Fayette County GA	33.3899269	-84.4953763
+location	Fayette County IA	42.8420766	-91.850265
+location	Fayette County IL	39.0001282	-89.0430211
+location	Fayette County TX	29.8381635	-96.9559692
+location	Fazenda Rio Grande	-25.645841	-49.3126653
+location	Fedorovskoe	59.663059	30.530458
+location	Fehren	47.3967459	7.5790875
+location	Feijo	-8.1648652	-70.3539579
+location	Feira de Santana	-12.2598	-38.9675
+location	Felben-Wellhausen	47.575645	8.939863
+location	Feldbach	46.9525777	15.8887826
+location	Feldkirch	47.2375671	9.5981724
+location	Feldkirchen	46.7219887	14.0969727
+location	Feldkirchen in Kärnten	46.7229178	14.0964965
+location	Feluy	50.5625055	4.2507809
+location	Fenchuganj	24.6942465	91.9392229
+location	Feni	23.0170829	91.40786619267402
+location	Fenix	-23.9169495	-51.9801443
+location	Fenoarivo	-17.382029	49.4099733
+location	Fergus County	47.2128617	-109.2175566
+location	Fernado Prestes	-21.26673621453309	-48.68813024245462
+location	Fernan Caballero	39.1225007	-3.9010957
+location	Fernando de la Mora	-25.3281673	-57.5521492
+location	Fernando de Noronha	-3.8545643	-32.37861623300567
+location	Fernandopolis	-20.2825647	-50.2500762
+location	Ferral del Bernesga	42.615406	-5.6604701
+location	Ferry County	48.4736934	-118.4834362
+location	Feuillet	8.8803539	-79.78105412745327
+location	Feurs	45.7413143	4.2263699
+location	Fianarantsoa	-21.456444	47.085149
+location	Fieberbrunn	47.45518755	12.544424258717815
+location	Figaro	41.7208879	2.2715584
+location	Figaro-Montmany	41.7204695	2.2726891
+location	Fighiera	-33.1937547	-60.469476
+location	Figueirao	-18.67821	-53.6379864
+location	Figueiropolis	-12.1347916	-49.1737141
+location	Figueres	42.2666314	2.9638434
+location	Fillmore County	41.5637	-92.0077
+location	Filzbach	47.1204474	9.1296451
+location	Filzmoos	47.4329886	13.5182127
+location	Finana	37.1709721	-2.8397107
+location	Finca 30	9.42348245	-82.5562999569464
+location	Finsterwolde	53.1983394	7.0833842
+location	Firmat	-33.459525049999996	-61.48818099003141
+location	Firminy	45.3869468	4.2858545
+location	Fischlham	48.0882154	13.9470248
+location	Fitchburg	42.986206	-89.426696
+location	Fitero	42.059536	-1.858151
+location	Flathead County	48.3840879	-113.972144
+location	Flawil	47.414613	9.1861489
+location	Flémalle	50.59997972685316	5.438051256974423
+location	Flénu	50.433143	3.888990
+location	Fléron	50.6168354	5.6832219
+location	Fleurus	50.482944	4.549699
+location	Flexeiras	-9.2788679	-35.7235246
+location	Flims Dorf	46.8367698	9.2876705
+location	Flines-lès-Mortagne	50.5110815	3.4828966
+location	Flobecq	50.752594	3.731461
+location	Florânia	-6.1268685	-36.8183238
+location	Floreal	-20.3128287	57.5045014
+location	Florence	43.7698712	11.2555757
+location	Florence County	33.986694	-79.6644927
+location	Florence County SC	33.986694	-79.6644927
+location	Florence County WI	45.8379973	-88.3902943
+location	Florencia	1.7554212	-75.60811976268113
+location	Florencio Varela	-34.8044384	-58.2783224
+location	Florennes	50.2514227	4.6030187
+location	Flores	10.0062179	-84.1572343
+location	Flores CR	10.0058446	-84.15868270968596
+location	Flores Da Cunha	-29.030129	-51.1833349
+location	Floresta Azul	-14.8602238	-39.6561384
+location	Florestopolis	-22.8663942	-51.3905121
+location	Florianopolis	-27.581052	-48.481313
+location	Florida	27.6648	-81.5158
+location	Florida PR	18.3636604	-66.57201242195136
+location	Floridablanca	7.0625358	-73.0858228
+location	Florinea	-22.9016004	-50.7268005
+location	Flüh	47.4850563	7.4978069
+location	Flums	47.0939665	9.343589
+location	Flurlingen	47.68265185574865	8.63559169342289
+location	Foca	43.5058554	18.774393
+location	Focsani	45.697572	27.188348
+location	Fogars de la Selva	41.7342133	2.6728108
+location	Fogars de Montclus	41.74716075	2.4394273887762976
+location	Foggia	41.50281055	15.452899609627726
+location	Foios	39.5381541	-0.3561396
+location	Folgensbourg	47.5505154	7.4464337
+location	Folgueroles	41.9392868	2.3180742
+location	Foncea	42.6149845	-3.0390692
+location	Fond Du Lac County	43.739156	-88.479198
+location	Fondettes	47.4036631	0.5961846
+location	Fonelas	37.4137	-3.1742
+location	Fontaine-l'Évêque	50.407803	4.325273
+location	Fontaine-Valmont	50.317343	4.215677
+location	Fontainebleau	48.4049375	2.7015872
+location	Fontana	-27.4172158	-59.0342223
+location	Fontanals De Cerdanya	42.3840589	1.9118566643772805
+location	Fontans	44.74970892242206	3.376740389000668
+location	Fontcoberta	42.1425379	2.7897817
+location	Fontenay le Comte	46.4660771	-0.8064003
+location	Fontfreyde	45.7049356	3.00386
+location	Forchies-la-Marche	50.435103	4.319844
+location	Ford County IL	40.4980955	-88.2552987
+location	Forest	50.8134	4.3248
+location	Forest Side	-20.3293539	57.5342609
+location	Formentera	38.6964	1.4531
+location	Formiga	-20.4648425	-45.4266753
+location	Formosa	-15.5492443	-47.3301212
+location	Formoso do Araguaia	-11.8059989	-49.5257153
+location	Fornach	48.0228726	13.4305845
+location	Forquilhinha	-28.7487602	-49.4737661
+location	Forrest County	31.1540772	-89.2398601
+location	Forsyth County	36.1476399	-80.2415712
+location	Forsyth County NC	36.1476399	-80.2415712
+location	Fort Bend County	29.511218	-95.7807348
+location	Fort-de-France	14.6027962	-61.0676724
+location	Fortaleza	-3.7304512	-38.5217989
+location	Fortin Olmos	-29.1282293	-60.9341889
+location	Foshan	23.018766	113.121428
+location	Fougères	48.3503362	-1.1958526
+location	Fountain County	40.125252	-87.2497418
+location	Foxhol	53.1671992	6.7211866
+location	Foz do Iguacu	-25.5401479	-54.5858139
+location	Fraga	41.5210138	0.3515596
+location	Fraham	48.2836334	14.0296096
+location	Fraijanes	14.45400565	-90.44687500007848
+location	Frailes	37.4866	-3.8382
+location	Fraipont	50.5664059	5.7227298
+location	Frameries	50.389738	3.883946
+location	Franca	-20.5381768	-47.4009795
+location	Francisco Beltrao	-26.0790979	-53.0533527
+location	Francisco Morato	-23.2817308	-46.7448996
+location	Franciszkowo	53.64577	19.74363
+location	Franeker	53.18382835	5.552928909360742
+location	Franken	47.6026172	7.3543563
+location	Frankenburg Am Hausruck	48.0680308	13.4921448
+location	Frankenmarkt	47.9855432	13.4191655
+location	Frankfurt	50.1106444	8.6820917
+location	Franklin	42.882823	-88.009275
+location	Franklin County AL	34.440962	-87.8339064
+location	Franklin County IL	37.9765409	-88.9335327
+location	Franklin County NY	44.5926	-74.3388
+location	Franklin County OH	39.982385093297296	-83.0017763810311
+location	Franklin County WA	46.517555	-118.921601
+location	Franklin Parish	32.1254252	-91.6778053
+location	Fraserburgh	57.6935974	-2.0051497
+location	Frauenfeld	47.5561915	8.8963347
+location	Fray Luis Beltran	-32.7874256	-60.7295083
+location	Frederick County	39.2127031	-78.279166
+location	Frederick County MD	39.4608481	-77.4118135
+location	Frederick County VA	39.2127031	-78.279166
+location	Frederico Westphalen	-27.35711	-53.3964117
+location	Freestone County	31.6924428	-96.1629601
+location	Freetown	8.479004	-13.26795
+location	Frei Paulo	-10.549956	-37.5356071
+location	Freiburg	47.9960901	7.8494005
+location	Freire	-38.9514242	-72.6254333
+location	Freirina	-28.5085923	-71.0785655
+location	Freising	48.4008273	11.7439565
+location	Freistadt	48.5112961	14.5047566
+location	Frejus	43.4330308	6.7360182
+location	Fremont County ID	44.2309391	-111.4218314
+location	Frenkendorf	47.5028543	7.7138283
+location	Fresach	46.71223	13.6918166
+location	Fresia	-41.1531405	-73.4223148
+location	Fresno County	36.6713502	-119.8155355
+location	Fribourg	46.8030044	7.1512891
+location	Frick	47.5075081	8.0203065
+location	Frisco	33.1506744	-96.8236116
+location	Frombork	54.3583633	19.6823701
+location	Fronhausen	50.7027934	8.6945193
+location	Frosolone	41.600627	14.446525
+location	Froyennes	50.622463	3.347464
+location	Frutillar	-41.1258462	-73.0604738
+location	Frýdek-Místek	49.685635	18.3483416
+location	Fryšták	49.2852044	17.6834631
+location	Füllinsdorf	47.5056654	7.7299597
+location	Fuengirola	36.5387779	-4.6233348
+location	Fuenlabrada	40.282476	-3.7923422
+location	Fuenmayor	42.4670856	-2.5614574
+location	Fuente el Fresno	39.2276397	-3.7741252
+location	Fuente Vaqueros	37.2193966	-3.7833134
+location	Fuentenovilla	40.365604	-3.0942252
+location	Fuentes	-33.1729451	-61.0773558
+location	Fuerth	49.477263	10.989616
+location	Fulda	50.5521486	9.676511
+location	Fulton County	43.1061507	-74.4461771
+location	Fulton County GA	34.0580391	-84.2961283
+location	Fulton County IL	40.4714305	-90.1845556
+location	Fulton County NY	43.1061507	-74.4461771
+location	Fundao	-19.9332174	-40.4049674
+location	Funes	-32.9168704	-60.8105603
+location	Funza	4.713017	-74.206999
+location	Fuquene	5.4083822	-73.77339414321521
+location	Furmanov	57.248756	41.10923
+location	Fusagasuga	4.3369235	-74.3644854
+location	Futrono	-40.131196	-72.3826602
+location	Fuyang	32.904205	115.812367
+location	Fuzhou	27.965633	116.359573
+location	Ga-Segonyana	-27.634241453568887	23.592402142666945
+location	Gaasbeek	50.7998868	4.1890089
+location	Gaboltov	49.3704485	21.13877994375292
+location	Gachnang	47.5396518	8.8523731
+location	Gadchiroli	19.759070350000002	80.16228072580182
+location	Gadwal	16.2347032	77.7946371
+location	Gänserndorf	48.3401016	16.7169729
+location	Gaia	41.9160989	1.9255287
+location	Gaibandha	25.3315471	89.5485082
+location	Gajano	43.410599500000004	-3.770213189092482
+location	Galanta	48.1910498	17.7270629
+location	Galapagar	40.5774992	-4.0037748
+location	Galapagos ES	40.696359	-3.3387789
+location	Galazczyce	50.6888948	17.2805627
+location	Galdar	28.1442408	-15.6542506
+location	Gales Ferry	41.4298302	-72.0820131
+location	Galia	-22.2936976	-49.5516228
+location	Galilea	42.3475858	-2.2370324
+location	Galizano	43.4682658	-3.6712146
+location	Gallatin County	37.7509507	-88.2264519
+location	Gallatin County IL	37.7509507	-88.2264519
+location	Gallatin County MT	45.4868491	-111.1967693
+location	Gallecs	41.5643783	2.1948193
+location	Gallur	41.8690263	-1.3182962
+location	Galowo	52.5981475	16.5645678
+location	Galtür	46.919455400000004	10.170590352537147
+location	Galvarino	-38.4111234	-72.7812506
+location	Galveston County	29.3872254	-94.992736
+location	Gama	43.42248	-3.51847
+location	Gameleira	-8.579803	-35.384573
+location	Gamlitz	46.7213788	15.5533088
+location	Gampern	47.9884349	13.5535036
+location	Gams	47.2054106	9.4421264
+location	Gancedo	-27.476570549999998	-61.66884506313528
+location	Gandhinagar	23.227004	72.643142
+location	Gandia	38.9680	-0.1845
+location	Gani Tikva	32.0604256	34.8760954
+location	Ganjam	19.5	84.5
+location	Gannat	46.0996068	3.1995251
+location	Ganshoren	50.873	4.3093
+location	Ganzhou	25.8307	114.9335
+location	Gaoua	10.3303342	-3.1795681
+location	Gap	44.5612032	6.0820639
+location	Garabito	9.707248100000001	-84.6218658823131
+location	Garca	-22.2125766	-49.6547994
+location	Garches	48.8461	2.1887
+location	Garden Route	-34.05747092711639	23.37463208713873
+location	Garfield County	46.4604687	-117.5294769
+location	Garibaldi	-29.2562253	-51.5269167
+location	Garies	-30.560738100000002	17.988800095992133
+location	Gariyaband	20.42857015	82.24698984817437
+location	Garmisch	47.4938417	11.0829
+location	Garopaba	-28.0274798	-48.6240197
+location	Garrafão do Norte	-1.9282256	-47.0513157
+location	Garrafe de Torio	42.730915	-5.5233043
+location	Garriguella	42.3446368	3.0642397
+location	Garrovillas de Alconetar	39.7131229	-6.5494671
+location	Garrucha	37.1853447	-1.8204711
+location	Gartzain	43.1298357	-1.5366744
+location	Garupa	-27.47856825	-55.8332474840408
+location	Garut	-7.2162543	107.9014912
+location	Gasawy	52.6073677	16.6319272
+location	Gasconade County	38.4575789	-91.5177499
+location	Gasel	46.8996747	7.4034016
+location	Gaspoltshofen	48.1438731	13.7351465
+location	Gaston County	35.2849659	-81.179014
+location	Gatchina	59.5706273	30.1305083
+location	Gatesville	31.4351645	-97.743911
+location	Gaufelden	48.5534259	8.8229748
+location	Gaurain-Ramecroix	50.5924891	3.4834445
+location	Gauting	48.0676689	11.3796987
+location	Gava	41.3050933	2.0063126
+location	Gavere	50.9292335	3.6614192
+location	Gavet de La Conca	42.123377	0.9202116
+location	Gaviao Peixoto	-21.8377536	-48.492853
+location	Gaziabad	28.6711527	77.4120356
+location	Gazipur	23.9980797	90.4229848
+location	Gdansk	54.347629	18.6452324
+location	Gdanski	54.36556221042414	18.584256222497245
+location	Gdow	49.9085036	20.1996034
+location	Gdynia	54.50383255	18.462806155884614
+location	Gdynski	54.51832735	18.55731987107607
+location	Gebenstorf	47.4819508	8.2408818
+location	Gedera	31.8117747	34.7803882
+location	Geel	51.1610826	4.9903187
+location	Geetbets	50.891512	5.132033
+location	Geffen	51.7422922	5.462088
+location	Geheul	51.3795419	4.8997477
+location	Geleen	50.9673322	5.8277007
+location	Gelles	45.7696093	2.7625344
+location	Gellik	50.8839456	5.6091315
+location	Gelnica	48.8532052	20.9369156
+location	Gelterkinden	47.4640069	7.8544495
+location	Geluwe	50.809763	3.076704
+location	Gem County	44.0123019	-116.3846609
+location	Gembloux	50.5597273	4.6943126
+location	Gemersky Sad	48.5854284	20.3137231
+location	Genappe	50.603841	4.451737
+location	Genech	50.5305709	3.2141332
+location	Genemuiden	52.6229099	6.0423473
+location	General Alvear	-35.244655449999996	-67.09644459551242
+location	General Conesa	-40.1061785	-64.4530092
+location	General Deheza	-34.6872239	-58.3413787
+location	General Guemes	-24.8076741	-64.9167381759887
+location	General Mosconi	-22.59888955	-63.80834176495482
+location	General Roca	-39.0266276	-67.5754863
+location	General Rodriguez	-34.6082302	-58.9522206
+location	General San Martin	-34.5762765	-58.5388435
+location	General Villamil Playas	-2.5937913000000004	-80.42615751756438
+location	General Villegas	-35.032594	-63.0148473
+location	Genesee County	43.0102726	-78.1780196
+location	Geneva County	31.0862933	-85.803014
+location	Genk	50.966203	5.492020
+location	Gennevilliers	48.927444	2.292449
+location	Genoelselderen	50.8017668	5.5369013
+location	Gent	51.099884349999996	3.739013449056724
+location	Gentbrugge	51.042328	3.759051
+location	Gentry County	40.2044898	-94.4159527
+location	Genval	50.720392	4.493708
+location	George	-33.964444	22.459722
+location	George County	30.857421	-88.6537118
+location	Georgetown	33.4392245	-79.3343041
+location	Georgetown County	33.4392245	-79.3343041
+location	Georgetown DE	38.6900507	-75.3858753
+location	Georgetown TX	30.671598	-97.65500660120435
+location	Geraardsbergen	50.777365	3.899454
+location	Gergal	37.118565	-2.5395634
+location	Gerhardshofen	49.6302367	10.6914557
+location	Gerlachov (Poprad)	49.09695605	20.206087777478253
+location	Germersheim	49.2222749	8.36659
+location	Gerona	41.9793006	2.8199439
+location	Gerpinnes	50.346989300000004	4.527624748646935
+location	Gers	43.695527600000005	0.4101019175237992
+location	Gerzat	45.8250404	3.1435185
+location	Gestel	51.1290504	4.6694284
+location	Gesves	50.4028535	5.0776175
+location	Getafe	40.3081807	-3.7302679
+location	Getxo	43.3479409	-3.0087671
+location	Ghazipur	25.603508400000003	83.50745404887138
+location	Ghlin	50.467281	3.892335
+location	Ghogha	21.6874043	72.2761717
+location	Gianyar	-8.5482357	115.32605401537212
+location	Giat	45.80177	2.46698
+location	Gibraltar	36.140807	-5.3541295
+location	Giddings	30.1830498	-96.9366112
+location	Giedlarowa	50.2265339	22.4014412
+location	Gierle	51.2672	4.8677
+location	Gigosos de los Oteros	42.3797688	-5.5140632
+location	Gijon	43.5450394	-5.6626443
+location	Gijzegem	50.9847481	4.0525271
+location	Gila County	33.74135485	-110.68128894247536
+location	Gilchin	49.903302205780186	127.86212703615573
+location	Gilet	39.6668	-0.3325
+location	Gilgit	35.880589	74.448161
+location	Gillespie County	30.2954086	-98.9086643
+location	Gilliam County	45.3298742	-120.2202197
+location	Gilly	50.4262689	4.484719762079403
+location	Gilwa	53.7123923	19.146635
+location	Gilze en Rijen	51.56323905	4.913039391005126
+location	Gingelom	50.751534750000005	5.132409812775332
+location	Ginsheim	49.9711057	8.3484576
+location	Giou de Mamou	44.9314821	2.5116651
+location	Girardota	6.3757634	-75.44053710521231
+location	Girau do Ponciano	-9.884041	-36.831592
+location	Giron	7.0732333	-73.1689196
+location	Girona	41.9793006	2.8199439
+location	Gironella	42.0337588	1.8825316
+location	Girua	-28.0299396	-54.3506855
+location	Gisors	49.2789504	1.777826
+location	Gistel	51.1542785	2.961541
+location	Givat Hen	32.1685932	34.876063
+location	Givat Ye'Arim	31.7859942	35.092569
+location	Givors	45.5844238	4.7696529
+location	Givry	50.380304	4.037642
+location	Giza	30.01580945	31.332779718798953
+location	Gizycki	54.01819955	21.85342119561347
+location	Gizycko	54.0361354	21.7661326027255
+location	Glabbeek	50.8725203	4.9513009
+location	Glacier County	48.6966449	-112.9467116
+location	Glain	50.648205	5.541864
+location	Glaine Montaigut	45.7499399	3.3926456874395208
+location	Glarus	47.0422116	9.0674041
+location	Glashütten	47.2587718	7.8445122
+location	Glastonbury	41.6862	-72.5451
+location	Glebock	54.3790769	20.2812583
+location	Gledowo	53.6576618	17.4029968
+location	Glendale	43.129400	-87.930209
+location	Glenn County	39.5912766	-122.3778662
+location	Glichów	49.8186357	20.0968789
+location	Glimes	50.6800531	4.838004
+location	Gliniszcze Małe	53.4824313	23.5059303
+location	Glinsk	52.3046466	15.5523497
+location	Glisno	52.47658	15.24138
+location	Gliwice	50.30113145	18.662347227971978
+location	Glödnitz	46.8742382	14.1166943
+location	Glogoczow	49.8948023	19.8759729
+location	Głogówek	50.3534373	17.8619329
+location	Glorinha	-29.8790534	-50.7869437
+location	Gloucester County	39.7267303	-75.1535378
+location	Gloucester County NJ	39.7267303	-75.1535378
+location	Glowno	51.96239825	19.71166242050556
+location	Glubczyce	50.2000941	17.8293199
+location	Głuchołazy	50.3170828	17.3833809
+location	Gluszyna	51.1615477	17.8209992
+location	Gmina Trzeszczany	50.821758849999995	23.725387271832616
+location	Gmünd	48.7729279	14.9861752
+location	Gmunden	47.9185855	13.8003048
+location	Gniezno	52.52465015	17.598152438162245
+location	Gnojno	53.17198	20.10228
+location	Goalanda	23.7239033	89.7641298
+location	Goalpara	26.1698607	90.623914
+location	Gobernador Crespo	-31.638791	-60.7166527
+location	Godawari	28.0406232	83.1773077
+location	Godella	39.5184276	-0.4103168
+location	Godhra	22.7785001	73.6245157
+location	Godoy Cruz	-32.93151965	-68.84996157133858
+location	Godziesze Male	51.647178	18.1599931
+location	Göfis	47.24176735	9.632840922767645
+location	Gölsental	48.04448379398174	15.736140695943707
+location	Gofis	47.24176735	9.632840922767645
+location	Goiana	-7.560603	-34.99591
+location	Goianesia do Para	-3.8380998	-49.0977992
+location	Goiania	-16.680882	-49.2532691
+location	Goicoechea	9.9670623	-83.9818366
+location	Going	47.5142224	12.3275716
+location	Going am Wilden Kaiser	47.53295955	12.345026270277598
+location	Golasowice	49.9237705	18.6929338
+location	Golczewo	53.8241081	14.9773396
+location	Gold Coast	-28.019726	153.398160
+location	Goldapski	54.26102275	22.28107341680129
+location	Goldswil	46.6918793	7.8722878
+location	Golebiewo Wielkie	54.1463889	18.5522222
+location	Goleniow	53.5656704	14.8300626
+location	Goleszow	49.7336888	18.7402381
+location	Golfito	8.533789500000001	-83.45844839937729
+location	Golianovo	48.269485	18.204560963028868
+location	Golkowice	49.91371446642107	18.515027494367065
+location	Golling An Der Salzach	47.5967154	13.1674472
+location	Goluski	52.3577625	16.7507998
+location	Gomez	8.5648635	-82.7410207
+location	Gomez Palacios	25.5732473	-103.494779
+location	Gondal	21.9612	70.7939
+location	Gondecourt	50.5432418	2.9830581
+location	Gondrecourt-le-Chateau	48.505557	5.503554
+location	Gonesse	48.9863555	2.4500537
+location	Gonzales County	29.4436555	-97.5108636
+location	Gonzalez Suarez	0.1809706	-78.2032913
+location	Goodhue County	44.396973	-92.7175627
+location	Gooding County	43.0031041	-114.8286924
+location	Gooise Meren	52.322224000000006	5.104556785563771
+location	Gopalgonj	23.007874712199573	89.82222732257613
+location	Gora	52.12128	16.98452
+location	Gora (Dolnośląskie)	51.6681499	16.5393277
+location	Gora (Wielkopolskie)	52.12128	16.98452
+location	Gora Kalwaria	51.9843765	21.2140226
+location	Gorakhpur	26.67132865	83.36458284327038
+location	Gordaliza Del Pino	42.3435046	-5.1575995
+location	Gorizia	45.9441278	13.6252288
+location	Gorki Wielkie	49.7721682	18.8525357
+location	Gorlice	49.6663323	21.16348426717198
+location	Gorredijk	53.0059606	6.0641634
+location	Gorzewo	52.73854	17.39025
+location	Gorzow Wielkopolski	52.73057555	15.210755319093852
+location	Gorzow Wlkp	52.73057555	15.210755319093852
+location	Gorzyca	52.4650517	15.4949647
+location	Gosairhat Upazila	23.10020718743971	90.45029323211318
+location	Gosau	47.5851071	13.5362156
+location	Goscice	50.43158	16.97886
+location	Gossau	47.4155906	9.249359
+location	Gosselies	50.473588649999996	4.44924225712702
+location	Gostyn	51.8778633	17.0167637
+location	Gostynin	52.424245299999995	19.463338416212153
+location	Goszcz	51.3961703	17.4804228
+location	Gouda	52.018119350000006	4.711122134697802
+location	Gourdinne	50.2899588	4.456597
+location	Goutroux	50.406076	4.360658
+location	Gouttieres	46.0628233	2.7699886
+location	Gouy-lez-Piéton	50.4875628	4.3287132
+location	Goven	48.0054828	-1.8476016
+location	Governador Celso Ramos	-27.317161	-48.557608
+location	Governador Edson Lobao	-4.2339244	-44.8169366
+location	Governador Lindenberg	-19.25076	-40.462888
+location	Governador Valadares	-18.8539497	-41.9458753
+location	Gozdawa	52.6445992	17.9125122
+location	Gozdzielin	50.9080088	21.4244495
+location	Gozée	50.3332279	4.3515595
+location	Grabouw	-34.15669281172831	19.003896660042415
+location	Grabowiec	52.7522152	23.0427621
+location	Grabówki	49.9758477	20.0285684
+location	Grabs	47.1816557	9.4446312
+location	Grabserberg	47.1847295	9.4315373
+location	Gracanica	42.623454550000005	21.241032254746372
+location	Grâce-Hollogne	50.6393049	5.5057631
+location	Gradignan	44.7739701	-0.613907
+location	Grado	43.3894263	-6.0686955
+location	Grafton	43.315718	-87.954140
+location	Graham County	32.8397096	-109.8685752
+location	Grainger County	36.2810821	-83.5107018
+location	Grajau	-5.8154034	-46.1361454
+location	Grajewo	53.6399088	22.457839141500717
+location	Gral Rodriguez	-34.61071357316214	-58.92211424933349
+location	Gramado	-29.3787488	-50.8724941
+location	Granada	37.1773	-3.5986
+location	Granada CO	3.5036552	-73.73695976066583
+location	Granada ES	37.183054	-3.6021928
+location	Granadilla	9.9342017	-84.0138034
+location	Grand Bel Air	-20.40894625	57.69236425316552
+location	Grand-Leez	50.582921	4.774690
+location	Grand Princess Cruise Ship	38.308882	-123.779663
+location	Grand Santi	4.2734484	-54.3810948
+location	Grandola	38.1761212	-8.5680717
+location	Graneros	-34.0644743	-70.7262983
+location	Granite County	46.3944149	-113.4687025
+location	Granito	-7.7166517	-39.6161866
+location	Granollers	41.6079555	2.2876008
+location	Grant County NM	32.7548776	-108.3634144
+location	Grant County OR	44.464824	-119.0565278
+location	Grant County WA	47.209925	-119.420874
+location	Grant County WI	42.888151	-90.703612
+location	Grant Parish	31.570014	-92.534059
+location	Grasse	43.6589011	6.9239103
+location	Grau de Sagunt	39.633481	-0.241370
+location	Gravata	-8.1993049	-35.5631137
+location	Gravataí	-29.9440222	-50.9930938
+location	Gravelines	50.9870697	2.1273118
+location	Gray County	35.3711816	-100.7892236
+location	Grays Harbor County	47.1744169	-123.8658829
+location	Grayson County TX	33.5636114	-96.6702111
+location	Grayvoron	50.47677485986811	35.68007258899261
+location	Graz	47.0708678	15.4382786
+location	Graz-Umgebung	47.011479550000004	15.4439766245784
+location	Greater Houston Area	29.679767	-95.360138
+location	Greater Milwaukee Area	43.0389	-87.9065
+location	Grecia	10.071966	-84.312172
+location	Green County	42.687601	-89.584475
+location	Green Lake County	43.7971612	-89.0402508
+location	Green Road	23.7437581	90.3845921
+location	Greene County	42.2628769	-74.0878112
+location	Greene County AL	32.8620514	-87.9915392
+location	Greene County IL	39.3573664	-90.3898985
+location	Greene County NY	42.2628769	-74.0878112
+location	Greene County OH	39.6908207	-83.9175037
+location	Greenfield	42.957786	-88.007122
+location	Greenlee County	33.2312681	-109.2751297
+location	Greenville County	34.8550021	-82.3356457
+location	Greenwich	41.0262	-73.6282
+location	Greenwood County	34.1489805	-82.112882
+location	Greenwood County SC	34.1489805	-82.112882
+location	Gregg County	32.4492408	-94.8532848
+location	Gregorio de Laferrere	-34.7504785	-58.5846362
+location	Grellingen	47.4411563	7.5876358
+location	Grenada County	33.772401	-89.7674875
+location	Grenoble	45.1875602	5.7357819
+location	Grenzach-Wyhlen	47.5528548	7.6737981
+location	Gresik	-5.79334655	112.6598223201143
+location	Greven	52.0929254	7.6120326
+location	Grez-Doiceau	50.7386182	4.6962324
+location	Grieskirchen	48.235011	13.826192
+location	Griffen	46.7038006	14.7308073
+location	Grigorovo	58.550271366744546	31.208599279569
+location	Grimbergen	50.942962	4.375664
+location	Grimes County	30.5169334	-95.9943034
+location	Grivegnée	50.6192957	5.6047622
+location	Grobbendonk	51.176608	4.738931
+location	Grobniki	50.1959161	17.8702215
+location	Grochowo	52.43826	15.29117
+location	Grodziec	49.8006421	18.8694816
+location	Grodzisk	51.9007566	17.9659861
+location	Grodzisk Mazowiecki	52.105601	20.633940
+location	Gromadzin	54.18879	18.33685
+location	Groningen	53.2190652	6.5680077
+location	Groot-Bijgaarden	50.8707084	4.2651493
+location	Groot-Gelmen	50.7830874	5.2663492
+location	Grootegast	53.2115071	6.2744862
+location	Groslay	48.9867112	2.3458615
+location	Grosswangen	47.1322635	8.0491183
+location	Grote-Brogel	51.153218	5.508637
+location	Grozny	43.3197031	45.6934308
+location	Grub	47.2497978	9.1595611
+location	Grudziadz	53.47251195	18.761893676880046
+location	Grünau im Almtal	47.8529968	13.9571241
+location	Gruendau	50.2212637	9.1234581
+location	Grunddorf	48.2644695	15.8190851
+location	Grundy County IL	41.2747363	-88.4119361
+location	Gruszów	49.8534512	20.2075859
+location	Gruzovce	48.9725467	21.8674848
+location	Gryfice	53.9148529	15.1987062
+location	Gryfino	53.2535889	14.4924243
+location	Grzedzice	53.3692197	14.9731207
+location	Grzybno	53.5879	15.88094
+location	Grzybow	51.1532275	20.5383535
+location	Guabito	9.4957629	-82.6121137
+location	Guacima	9.9628161	-84.2543221
+location	Guacimo	10.2105886	-83.6850907
+location	Guadalajara	40.7399963	-2.505930025884726
+location	Guadalest	38.6754609	-0.1995862
+location	Guadalupe	8.859217	-79.808174
+location	Guadalupe County	29.6480061	-97.8279576
+location	Guadalupe County NM	34.8980615	-104.8282135
+location	Guadalupe County TX	29.6480061	-97.8279576
+location	Guadalupe CR	9.94907	-84.0509598
+location	Guadalupe ES	39.4515241	-5.3277307
+location	Guadalupe PA	8.859725909154333	-79.80778803200464
+location	Guadassuar	39.1859294	-0.4769464
+location	Guadix	37.3011	-3.1403
+location	Guaiba	-30.1130731	-51.329442
+location	Guaira	-19.4608971	-42.5227089
+location	Guaitecas	-43.917431	-73.9078914874624
+location	Gualba	41.7321147	2.5018684
+location	Guamare	-5.1075611	-36.3195361
+location	Guanambi	-14.223066	-42.779943
+location	Guangzhou	23.123972	113.292889
+location	Guape	-20.7619447	-45.9174969
+location	Guapiacu	-20.79663	-49.2253917
+location	Guapiara	-24.18921	-48.529549
+location	Guapiles	10.2152164	-83.7913841
+location	Guapimirim	-22.5266308	-42.9790687
+location	Guapore	-28.8471928	-51.8907881
+location	Guara	-20.4290496	-47.8250067
+location	Guarai	-8.835429	-48.511432
+location	Guarambare	-25.4910738	-57.45276881329977
+location	Guaranda	-1.590027	-78.999653
+location	Guarapari	-20.6718755	-40.4984617
+location	Guarapuava	-25.3950986	-51.4622016
+location	Guararapes	-21.2542739	-50.6440083
+location	Guararema	-23.4133724	-46.0379249
+location	Guaratingueta	-22.8057839	-45.1908926
+location	Guardiaregia	41.435024	14.541729
+location	Guarei	-23.3718195	-48.184685
+location	Guariba	-21.35938	-48.23158
+location	Guarne	6.272654	-75.43925679397356
+location	Guarnizo	43.39953	-3.83026
+location	Guarujá	-23.9927768	-46.2558332
+location	Guarulhos	-23.4430602	-46.524459
+location	Guasave	25.5046381	-108.539960314508
+location	Guastatoya	14.8514688	-90.08597618783097
+location	Guatemala	14.6222328	-90.5185188
+location	Guatuso	10.703137349999999	-84.84109533332072
+location	Guayaquil	-2.1899066	-79.887726
+location	Guaymallen	-33.0563827	-68.884028
+location	Guaynabo	18.3581491	-66.1116969
+location	Guazacapan	14.034872799999999	-90.42187793937953
+location	Gubin	51.95734105	14.737042559250952
+location	Guebwiller	47.9094629	7.2113271
+location	Guediawaye	14.7828	-17.3760
+location	Guereo	14.526659	-17.096156
+location	Gueret	46.1686865	1.8713349
+location	Güssing	47.05552765	16.322717864620014
+location	Guetersloh	51.9063997	8.3782078
+location	Guevejar	37.2574	-3.5977
+location	Guglionesi	41.9138877	14.9136133
+location	Guia Lopes Da Laguna	-21.5375346	-55.96134153440401
+location	Guignies	50.5471385	3.3663017
+location	Guilford County	36.0875688	-79.7888515
+location	Guimera	41.5646664	1.1834968
+location	Guingamp	48.5618483	-3.1502007
+location	Gujrat	32.5812723	74.0875086307851
+location	Gulf Coast Alaska	59.9768	-150.7114
+location	Gulpen-Wittem	50.79962605	5.890529675273097
+location	Gulshan	23.7925	90.4078
+location	Gundelfingen	48.032914950000006	7.893234691631104
+location	Gunskirchen	48.1334587	13.9427447
+location	Guntramsdorf	48.04717635	16.32019634126145
+location	Guntur	16.2915189	80.4541588
+location	Gunzwil	47.2116702	8.1800549
+location	Gurabo	18.2555647	-65.9723799
+location	Gurabo County	18.2555647	-65.9723799
+location	Guriezo	43.33683555	-3.324953504422364
+location	Gurugram	28.4646148	77.0299194
+location	Gurupi	-11.72794	-49.068046
+location	Gutenberg-Stenzengreith	47.21114095	15.530309934233168
+location	Gutkowo	53.7997465	20.400654230051003
+location	Guttaring	46.8903519	14.5113664
+location	Guttenberg	40.7920454	-74.0037505
+location	Guyancourt	48.7629	2.0753
+location	Gwinnett County	33.9566869	-84.0227467
+location	Gyeonggi	37.397957	127.380864
+location	Haacht	50.9769286	4.6386824
+location	Haag Rheintal	47.2089851	9.4886539
+location	Haaltert	50.887393349999996	3.9904300285117014
+location	Haarlem	52.3874	4.6462
+location	Haasrode	50.831336	4.733827
+location	Habiganj	24.3840	91.4169
+location	Haedo	-34.6431369	-58.5947185
+location	Hämikon	47.240715	8.28041
+location	Haifa	32.8191218	34.9983856
+location	Hainfeld	48.045008949999996	15.797844432315877
+location	Haizing	48.3765399	14.0010015
+location	Haj	48.6283881	20.8545111
+location	Hajnacka	48.2165364	19.9518891
+location	Hajnowka	52.731735549999996	23.571247984159466
+location	Hale County	32.7412417	-87.6561668
+location	Hale County AL	32.7412417	-87.6561668
+location	Hale County TX	34.0321298	-101.8088827
+location	Halen	50.948587	5.090071
+location	Halfweg	52.3826063	4.7546903
+location	Halhul	31.5775471	35.0993156
+location	Halic	48.3542823	19.5742231
+location	Halinow	52.3581586	19.4706484
+location	Hall County	34.5036637	-100.6536777
+location	Hallaar	51.0845683	4.7294097
+location	Halle	50.723860	4.235891
+location	Hallein	47.6821521	13.0956313
+location	Ham	51.1054908	5.1609815
+location	Ham Sous Varsberg	49.1796	6.6452
+location	Ham-sur-Heure	50.3219897	4.3889214
+location	Ham-sur-Heure-Nalinnes	50.32592795	4.414523504903954
+location	Hamden	41.397428	-72.924035
+location	Hamilton County	43.6307863	-74.4659275
+location	Hamilton County IL	38.0619569	-88.5301136
+location	Hamilton County IN	40.0749813	-86.0498885
+location	Hamilton County NY	43.6307863	-74.4659275
+location	Hamilton County OH	39.2085354	-84.5501874
+location	Hamirpur	31.69255285	76.5417689794739
+location	Hamme	51.081154	4.142607
+location	Hammerbach	51.0221457	13.6371496
+location	Hamont	51.2512315	5.5454386
+location	Hamont-Achel	51.2547636	5.5128696
+location	Hampden County	42.1285315	-72.6063441
+location	Hampshire County	42.3432499	-72.6213339
+location	Hampton County	32.7861789	-81.1237271
+location	Hamulka	53.6803206	23.2373235
+location	Hanau	50.1335542	8.9168179
+location	Hancock County	40.3941712	-91.1458063
+location	Hancock County IL	40.3941712	-91.1458063
+location	Hancock County ME	44.7135397	-68.2994753
+location	Hancock County MS	30.3892456	-89.4782116
+location	Handlová	48.7314317	18.7626944
+location	Hangzhou	30.272732	120.154501
+location	Hanna	51.7183255	23.5037805
+location	Hannover	52.3744779	9.7385532
+location	Hannut	50.667745	5.077469
+location	Hanoi	21.020191	105.836099
+location	Harbin	45.743472	126.645116
+location	Harbutowice	49.8168277	19.7832809
+location	Harchies	50.479753	3.694996
+location	Hard	47.489391	9.6916539
+location	Hardin County IL	37.5137015	-88.2675733
+location	Hardin County OH	40.6880457	-83.6835337
+location	Hardinxveld	51.8324	4.8336
+location	Hardinxveld Giessendam	51.830196	4.840971
+location	Hardoi	27.33857665	80.0975264641719
+location	Harelbeke	50.865264	3.308918
+location	Haren	50.8909441	4.4157553
+location	Haren BE	50.8886636	4.4198135
+location	Haren NL	53.1709841	6.6061413
+location	Harford County	39.548545	-76.3048991
+location	Haridwar	29.9384473	78.1452985
+location	Harkema	53.1843251	6.1368138
+location	Harmignies	50.4076446	4.0177899
+location	Harmonia	-29.549989	-51.422308
+location	Harnett County	35.388093	-78.8624963
+location	Harney County	43.055195	-119.0240263
+location	Haro	42.5768922	-2.8466768
+location	Harris County	29.8119769	-95.3741247
+location	Harrison County	32.5233959	-94.3982158
+location	Harrison County MS	30.4553392	-89.1313136
+location	Harrison County TX	32.5233959	-94.3982158
+location	Harry Gwala	-30.0841649	29.745542074375365
+location	Hartberg-Fürstenfeld	47.2809371	15.9691769
+location	Hartford County	43.3178	-88.3790
+location	Hartkirchen	48.3623242	14.0030662
+location	Harzé	50.4409138	5.6672743
+location	Hasenberg	48.3370128	9.8370729
+location	Hathazari	22.498691	91.8071182
+location	Hattersheim	50.0723339	8.4858331
+location	Hatton	6.8916333	80.5984591
+location	Haulchin	50.383200	4.081708
+location	Haus	47.42343325	13.756522860009792
+location	Haute-Garonne	43.305454600000004	0.9716791701901577
+location	Hautes-Pyrenees	43.1437925	0.15866611287926924
+location	Hauts-de-Seine	48.840185899999994	2.198641221906077
+location	Havelange	50.359744	5.246545
+location	Haveri	14.7874825	75.3996731
+location	Havířov	49.784045	18.442395
+location	Havré	50.463797	4.044809
+location	Hawaii County	19.6273325	-155.5645619
+location	Hawali	9.3378	48.0235
+location	Hays County	30.0447901	-98.0393127
+location	Hazas de Cesto	43.3956522	-3.5907858
+location	Hażlach	49.8042891	18.6645205
+location	Hearne	30.8788819	-96.5962378
+location	Hechtel	51.1236746	5.3638574
+location	Hechtel-Eksel	51.1340192	5.3780119
+location	Heemstede	52.3427475	4.618043843137004
+location	Heer	50.161698	4.831747
+location	Heerbrugg	47.4109666	9.6271219
+location	Heerhugowaard	52.6780162	4.851688593963786
+location	Heerlen	50.8876735	5.9773285
+location	Heers	50.747246849999996	5.304934039603534
+location	Heestert	50.7821543	3.4120184
+location	Heeswijk Dinther	51.664083399999996	5.466634823340177
+location	Heeze-Leende	51.35863595	5.5779773009269675
+location	Hefei	31.806280	117.227234
+location	Hegenheim	47.5624713	7.5261691
+location	Heidelberg	49.4093582	8.694724
+location	Heiligerlee	53.1554663	7.0074324
+location	Heiloo	52.60192475	4.70503175175436
+location	Heinsberg	51.056262	6.113915
+location	Heinsberg District	51.0499	6.1163
+location	Heist	51.3374355	3.2399794
+location	Heist-op-den-Berg	51.06251575	4.71943107216415
+location	Hel	54.6369868	18.787504051511178
+location	Helchteren	51.0566984	5.3830618
+location	Hélécine	50.7514034	4.9822395
+location	Helenowka	51.4035402	21.596811
+location	Hellikon	47.5095692	7.9249732
+location	Hellin	38.5069	-1.6979
+location	Helmond	51.4793	5.6570
+location	Helvecia	-31.4088249	-60.9179136
+location	Hemiksem	51.143514	4.339896
+location	Hencovce	48.8718203	21.7294565
+location	Hendaye	43.3641518	-1.7616499
+location	Henderson County IL	40.8156124	-90.9104547
+location	Hendricks County	39.7565309	-86.5173641
+location	Hengelo	52.2523195	6.795525590808008
+location	Henin-Beaumont	50.4194308	2.9469926
+location	Hennebont	47.8057224	-3.2751147
+location	Hennef	50.7754417	7.2847945
+location	Hennersdorf	48.113904250000004	16.369216091308893
+location	Hennuyères	50.6386981	4.1715689
+location	Henri-Chapelle	50.666254	5.938463
+location	Henrietta	-20.3367951	57.470641
+location	Henry County	31.4838041	-85.2447377
+location	Henry County AL	31.4838041	-85.2447377
+location	Henry County GA	33.4519942	-84.1367771
+location	Henry County IL	41.3418549	-90.1177442
+location	Henry County KY	38.447983	-85.1191168
+location	Henrykow	50.6537021	17.0103463
+location	Hensies	50.435594	3.711566
+location	Heppen	51.108225	5.228402
+location	Herce	42.2142703	-2.1654832
+location	Herculandia	-22.004508	-50.3862746
+location	Heredia	9.9983493	-84.1167945
+location	Herent	50.912473399999996	4.6517147625934285
+location	Herentals	51.1855307	4.83462866367042
+location	Herenthout	51.1392427	4.7543972
+location	Herink	49.9668575	14.574906
+location	Herisau	47.38555	9.2787571
+location	Herk-de-Stad	50.922291099999995	5.188430186895337
+location	Herkimer County	43.4911326	-74.9481252
+location	Hermagor	46.6268076	13.3702382
+location	Hermanovce nad Toplou	48.9841993	21.5100965
+location	Hermanus	-34.41766351172948	19.2331271593558
+location	Herment	45.7535232	2.5678124
+location	Hermosillo	29.0948207	-110.9692202
+location	Hernani	43.2661107	-1.9747419
+location	Herne	50.72329555	4.026011566349657
+location	Herrera (Panama Oeste)	8.947953	-79.856674
+location	Herrera de Camargo	43.422762683876584	-3.8633191471782347
+location	Herrera del Duque	39.1676109	-5.0504659
+location	Herseaux	50.7227127	3.2342044
+location	Herselt	51.048723	4.879674
+location	Herstal	50.680399	5.606845
+location	Hertain	50.6141111	3.2880161
+location	Herten	51.1806454	5.9654489
+location	Herthoek	50.8298784	3.1491352090317264
+location	Herve	50.647665	5.794572
+location	Herzele	50.870107000000004	3.89902812063107
+location	Herzelia	32.1639806	34.8175864
+location	Hessequa	-34.1176026	21.17880986383399
+location	Hettstadt	49.8011671	9.8136266
+location	Heule	50.8433241	3.2348571
+location	Heusden	51.0286768	3.8003138
+location	Heusden-Zolder	51.016671	5.290726
+location	Hever	50.9925865	4.5553278
+location	Heverlee	50.861704	4.695889
+location	Hewitt	31.4623902	-97.1958377
+location	Hickman County	35.794948	-87.4646163
+location	Hidalgo County	26.3530256	-98.216445
+location	Hidalgo County TX	26.3530256	-98.216445
+location	Highlands	-20.281674	57.521123
+location	Hill County	31.993848238478744	-97.15210246163512
+location	Hill County MT	48.6655784	-110.2107103
+location	Hill County TX	31.9595085	-97.0881654
+location	Hillegom	52.29482605	4.572971256401671
+location	Hillpoint	43.423267	-90.113371
+location	Hillsborough County	42.9373379	-71.751376
+location	Hillsborough County FL	27.9184543	-82.3488057
+location	Hillsborough County NH	42.9373379	-71.751376
+location	Hilversum	52.23158695	5.173493602392345
+location	Himatnagar	23.5969	72.9630
+location	Himmelried	47.4212297	7.5980409
+location	Hinds County	32.2506391	-90.4793259
+location	Hingoli	19.54140965	77.17376601317515
+location	Hinojal	39.7069897	-6.3584871
+location	Hinojedo	43.39463	-4.0493
+location	Hinojosas Calatrava	38.6135415	-4.1387605
+location	Hinwil	47.3015316	8.8419423
+location	Hipolito Yrigoyen	-23.2443133	-64.276584
+location	Hlboke	48.6592309	17.4066055
+location	Hlinné	48.9510859	21.577723
+location	Hlivistia	48.8044394	22.2178145
+location	Hlohovec	48.4278838	17.798782
+location	Hluk	48.988328	17.5268918
+location	Hniezdne	49.3009005	20.6357519
+location	Hnusta	48.5787043	19.9531888
+location	Hoboken	51.1794946	4.3617847
+location	Hochdorf	47.1665361	8.2899709
+location	Hochficht	48.7370219	13.9208425
+location	Hochwald	47.4562417	7.6402192
+location	Hocking County	39.4644491	-82.5469722
+location	Hockley County	33.5714311	-102.3110415
+location	Hodonín	48.865453	17.114406
+location	Höchst	47.4598203	9.6379578
+location	Hoegaarden	50.7743	4.8927
+location	Hoeilaart	50.7674846	4.474407
+location	Hoeleden	50.8682843	4.9879425
+location	Hörbranz	47.554821	9.7513786
+location	Hoeselt	50.8500788	5.4865309
+location	Hoevenen	51.3066168	4.4046996
+location	Hofstade	50.9912146	4.4938796
+location	Hofstetten	47.4755349	7.5158929
+location	Hohenems	47.3639973	9.689271
+location	Hohenwarsleben	52.1715806	11.512391478173285
+location	Hojai	26.0018224	92.8521037
+location	Holambra	-22.6332028	-47.0545305
+location	Holíč	48.808256	17.1628162
+location	Holice	47.9916159	17.4809847
+location	Hollabrunn	48.54884285	16.071909806521816
+location	Hollebeke	50.8056486	2.9383694
+location	Holmes County MS	33.1018124	-90.0656168
+location	Holon	32.0193121	34.7804076
+location	Holsbeek	50.9211	4.757
+location	Holy Cross	43.469964	-87.900967
+location	Holzhausen	48.2230119	14.0968764
+location	Homagama	6.841273	80.0030581
+location	Hombeek	51.0158695	4.4398366
+location	Hong Kong	22.3964	114.1095
+location	Honnelles	50.350747	3.714603
+location	Honolulu County	21.468151	-157.960511
+location	Hood County	32.4107555	-97.828282
+location	Hood River County	45.5311636	-121.6475587
+location	Hoofddorp	52.3054468	4.6927278
+location	Hoogeveen	52.7264258	6.49308148854467
+location	Hoogezand	53.1638192	6.7556852
+location	Hooghly	22.9052114	88.3760639
+location	Hoogkarspel	52.690467	5.1825103
+location	Hoogland	52.19079405	5.351266316652196
+location	Hooglede	50.9785478	3.0823431
+location	Hoogstraten	51.39573015	4.744087183464012
+location	Hoorn	52.622545450000004	5.067726588147824
+location	Horana	6.716628	80.0619488
+location	Hořátev	50.1496656	15.039817
+location	Horcajo de los Montes	39.3264384	-4.650099
+location	Horche	40.5655103	-3.0641857
+location	Horebeke	50.8348628	3.6920346
+location	Horgen	47.260692	8.5976831
+location	Horizonte	-4.0964618	-38.4965574
+location	Hormilleja	42.455544	-2.7309573
+location	Horn	48.6636596	15.6563147
+location	Horná Štubňa	48.8227658	18.8867943
+location	Hornany	48.7796748	18.1983578
+location	Horne Saliby	48.1226481	17.7520836
+location	Horne Strhare	48.27060095	19.351450231137676
+location	Horne Trhoviste	48.4699495	17.871528848324974
+location	Horni Jeleni	50.0490103	16.0839638
+location	Hornu	50.4337613	3.8276077
+location	Horquetas	10.3370076	-83.9539378
+location	Horrues	50.6093445	4.0413076
+location	Horry	33.9204504	-78.9578973
+location	Horry County	33.9204504	-78.9578973
+location	Horry County SC	33.9204504	-78.9578973
+location	Horst Aan de Maas	51.4515953	6.030898893223135
+location	Hortolandia	-22.881443	-47.206973
+location	Horw	47.0185008	8.3107797
+location	Hospital De Orbigo	42.4636603	-5.8821214
+location	Hostalrich	41.5651635	1.8013467
+location	Hostice	48.2372801	20.0667775
+location	Hotton	50.2688011	5.4463304
+location	Houdeng-Goegnies	50.4879863	4.1575303
+location	Houndé	11.4921785	-3.5205952
+location	Houston	29.813606	-95.415223
+location	Houston County	43.676439	-91.493283
+location	Houston County AL	31.1355603	-85.2654592
+location	Houston County MN	43.6624222	-91.4685617
+location	Houtain-le-Val	50.576293500000006	4.411033951743339
+location	Houten	52.0278	5.1630
+location	Houthalen-Helchteren	51.0312	5.3765
+location	Houthem	50.7868243	2.9640553
+location	Houthulst	50.973812249999995	2.943856800994059
+location	Houwaart	50.9329808	4.8595549
+location	Hove	51.1486117	4.477387
+location	Howard County	43.3353641	-92.3230007
+location	Howrah	22.554019	88.182766
+location	Hoz de Anero	43.4064922	-3.6651279
+location	Hozelec	49.02960815	20.338867334449482
+location	Hrabovec	49.2722061	21.3807607
+location	Hrabovec nad Laborcom	49.0966802	21.9405675
+location	Hrachovo	48.459807999999995	19.92857447078379
+location	Hradiste	48.6861145	18.3787168
+location	Hradiste (Trenčín)	48.6861145	18.3787168
+location	Hradište pod Vrátnom	48.6271718	17.4871953
+location	Hranovnica	48.9877666	20.3093442
+location	Hrinova	48.5764603	19.525865
+location	Hrubieszow	50.80679625	23.886349876429893
+location	Hrušov	50.3448714	14.846374
+location	Hrušovany nad Jevišovkou	48.8299011	16.4022403
+location	Hrušovany U Brna	49.0388994	16.5942408
+location	Hrustin	49.3242445	19.3490376
+location	Huaian	33.574586	119.132155
+location	Huaihua	27.554599	109.9641566
+location	Hualane	-34.9773866	-71.801171
+location	Hualpen	-36.7928161	-73.094216
+location	Hualqui	-36.9759363	-72.9383874
+location	Huanan City	46.2354272	130.5570647
+location	Huancayo	-12.0761679	-75.2063189
+location	Huaraz	-9.5298511	-77.5289981
+location	Huarmey	-10.0643674	-77.9718798
+location	Huarochiri	-11.916667	-76.416667
+location	Huarte	42.8313514	-1.590407
+location	Huasco	-28.4651248	-71.2207947
+location	Huayna Cápac	-2.91227675	-78.9981571429828
+location	Hudson County	40.741619	-74.059016
+location	Hudson County NJ	40.7381635	-74.0550731
+location	Huechuraba	-33.365721449999995	-70.6429271186091
+location	Huehuetenango	15.3184301	-91.4723295
+location	Huelago	37.4205176	-3.2622608
+location	Huelma	37.6473035	-3.4551806
+location	Huercal de Almeria	36.8836087	-2.4398613
+location	Huescar	37.8086268	-2.5398775
+location	Huetor Santillan	37.2228	-3.5150
+location	Huetor Tajar	37.1966709	-4.0466475
+location	Huetor Vega	37.1452042	-3.5694625
+location	Hughes	-33.8012821	-61.3363467
+location	Huimanguillo	17.7620967	-93.66344080511583
+location	Huizen	52.296484449999994	5.240582040690262
+location	Huizhou	23.107144	114.457913
+location	Huizingen	50.7481095	4.276727
+location	Hukuk	32.867141	35.531275
+location	Hul	48.1	18.2666667
+location	Huldenberg	50.7886	4.5881
+location	Hulshout	51.0749541	4.796794688834951
+location	Hulste	50.8820656	3.2990273
+location	Humacao	18.138073849999998	-65.81963689761
+location	Humanes	40.8280275	-3.1541095
+location	Humbeek	50.9673676	4.3794122
+location	Humboldt County	40.7450	-123.8695
+location	Humenne	48.9350033	21.9020268
+location	Humphreys County MS	33.1282074	-90.5408182
+location	Huncovce	49.12824315	20.378241965790373
+location	Huningue	47.5941514	7.5794613
+location	Hunt County	33.1161567	-96.0808922
+location	Hunterdon County	40.5770634	-74.9261552
+location	Hurbanovo	47.8761227	18.198313
+location	Hurefeish	33.021767395388366	35.34665715770681
+location	Huriel	46.3733261	2.477798
+location	Hurlingham	-34.5933423	-58.6378405
+location	Hutt Valley	-41.163361	174.964731
+location	Hyderabad	17.431807	78.416233
+location	I'Billin	32.8261251	35.1867412
+location	Iaciara	-14.1014906	-46.6343388
+location	Iapu	-19.436389	-42.217223
+location	Iasi	47.155585	27.590394
+location	Ibague	4.438643	-75.190558
+location	Ibaiti	-23.8452962	-50.1905666
+location	Ibarra	0.3478421	-78.1173588
+location	Iberia Parish	29.9812242	-91.7451362
+location	Iberville Parish	30.256342	-91.380864
+location	Ibio	43.2901034	-4.1450006
+location	Ibipora	-23.2684137	-51.0475907
+location	Ibira	-21.0815104	-49.2424619
+location	Ibirajuba	-8.5795521	-36.178045
+location	Ibirama	-27.0537021	-49.5190771
+location	Ibirite	-20.0214251	-44.0621506
+location	Ibiruba	-28.630161	-53.096124
+location	Ibitinga	-21.75623	-48.831903
+location	Ibitirama	-20.5394377	-41.6644451
+location	Ibitiura de Minas	-22.060833	-46.439722
+location	Ibiuna	-23.6548363	-47.2210116
+location	Ibiza	39.0200	1.4821
+location	Ibra	22.6895878	58.5469793
+location	Ibri	23.2178676	56.4921938
+location	Icara	-28.7116553	-49.2971441
+location	Icem	-20.3413103	-49.1970982
+location	Ichtegem	51.08743265	3.029462506474408
+location	Icolo E Bengo	-9.1920421	13.88466385063246
+location	Iconha	-20.7935003	-40.8108852
+location	Idaho County	45.7680684	-115.5160723
+location	Idron	43.2910849	-0.3117531
+location	Idukki	9.8497872	76.9797914
+location	Igaracu do Tiete	-22.5165369	-48.5582558
+location	Igarapava	-20.0411471	-47.7477444
+location	Igarapé-Açú	-1.128244	-47.6199021
+location	Igarassu	-7.8354423	-34.9061125
+location	Ignalina	55.3398975	26.1614043
+location	Ignalinos rajono savivaldybė	55.4107054	26.30126999241191
+location	Igollo de Camargo	43.42776	-3.8845
+location	Igrejinha	-29.569318	-50.791894
+location	Iguaba Grande	-22.8388498	-42.2286746
+location	Igualada	41.5790182	1.617346
+location	Iguape	-24.7042692	-47.5563733
+location	Iguatemi	-23.673555	-54.563731
+location	Ijmuiden	52.4573438	4.6110644
+location	Ijsselmuiden	52.5633577	5.9403387
+location	Ijui	-28.3878734	-53.9201692
+location	Ikaria	37.599929450000005	26.151689404867284
+location	Ilava	48.9985674	18.2307598
+location	Ilawski	53.67479095	19.4915030031177
+location	iLembe	-29.240765	31.234110920000003
+location	Ilha Bela	-23.9025724	-46.4428997
+location	Ilha Solteira	-20.4281001	-51.3410871
+location	Ilheus	-14.792599	-39.0453843
+location	Illar	36.9851023	-2.6391402
+location	Illinois	40.088552	-89.301876
+location	Illora	37.2885009	-3.8795173
+location	Iluman	0.2806483095960454	-78.23574162416124
+location	Ilza	51.172394749999995	21.27601003015772
+location	Imbabura	0.2542902	-78.1803913
+location	Imbe	-29.975269	-50.128068
+location	Imbe de Minas	-19.5989453	-41.9694294
+location	Imbituba	-28.241827	-48.6643444
+location	Imbituva	-25.2293338	-50.6051002
+location	Imel	47.902284	18.143292
+location	Imielno	50.5859921	20.4479001
+location	Imperatriz	-5.5269279	-47.478115
+location	Imperial County	32.845969	-115.543429
+location	Imphal East	24.85154025	94.00947957721581
+location	Imphal West	24.757326	93.85847858025147
+location	Imst	47.275902099999996	10.700690365218966
+location	Inca	39.7211448	2.9111493
+location	Inconnu	45.75883985	3.1277826865635405
+location	Indaiatuba	-23.09028	-47.21806
+location	Indang	14.1958306	120.8784148
+location	Independencia	-33.41447275	-70.66595560996643
+location	Indian River County	27.7041555	-80.5894422
+location	Indianapolis	39.7684	-86.1581
+location	Inezgane	30.3562929	-9.5459347
+location	Inga	-7.2904513	-35.6109945
+location	Ingelmunster	50.9218112	3.2626791680840155
+location	Ingenbohl	47.0007581	8.6150227
+location	Ingersheim	48.0968771	7.3022832
+location	Ingham County	42.5860505	-84.3800841
+location	Ingiriya	6.7437564	80.1766773
+location	Ingolstadt	48.7630165	11.4250395
+location	Ingombota	-8.80020825	13.255358031414445
+location	Inhambane	-23.865961	35.384363
+location	Inirida	3.2036605	-68.38094411558828
+location	Innsbruck	47.283507	11.379467
+location	Innsbruck-Land	47.2065094	11.383694590035379
+location	Inovce	48.8231273	22.3576717
+location	Intendente Alvear	-35.2340308	-63.5929581
+location	Interior Alaska	64.7638	-147.7008
+location	Inyo County	36.5595325	-117.4074712
+location	Iowa County WI	42.9732457	-90.1334393
+location	Ipala	14.6193092	-89.6241477
+location	Ipanguacu	-5.5090713	-36.8594421
+location	Ipero	-23.3508977	-47.687611
+location	Ipiales	0.828410	-77.638041
+location	Ipigua	-20.657282	-49.3881146
+location	Ipixuna	-7.047909	-71.693426
+location	Ipojuca	-8.3980773	-35.0611068
+location	Ipsach	47.1118789	7.2329528
+location	Ipu	-4.3239824	-40.7097463
+location	Iquique	-20.2140657	-70.1524646
+location	Iracemapolis	-22.5869091	-47.5160966
+location	Iracoubo	5.4794424	-53.2057374
+location	Iranduba	-3.2758203	-60.1867429
+location	Irati	-25.469663	-50.649287
+location	Iredell County	35.8101636	-80.8805593
+location	Iriepal	40.6387506	-3.1204448
+location	Irineopolis	-26.242006	-50.795687
+location	Irituia	-1.7709543	-47.4399687
+location	Irkutsk	52.289597	104.280586
+location	Iron County	46.2254778	-90.2125304
+location	Iron County UT	37.8546136	-113.2867347
+location	Iron County WI	46.2254778	-90.2125304
+location	Iroquois County	40.7351265	-87.8309209
+location	Irun	43.3383176	-1.7888095
+location	Irupi	-20.346479	-41.6392581
+location	Iruya	-22.791212	-65.2158295
+location	Ischgl	47.011789	10.289683
+location	Isernia	41.649467599999994	14.208148034519315
+location	Isidro Casanova	-34.7047876	-58.5861609
+location	Isla	43.4934282	-3.5689291
+location	Isla de Maipo	-33.7537387	-70.9039325
+location	Isla del Cerrito	-27.2951994	-58.62300289157733
+location	Isla Mocolí	-2.105443357660198	-79.86027555110115
+location	Island County	48.2162669	-122.6842402
+location	Isoka	-10.1535149	32.6368762
+location	Isserteaux	45.6528133	3.3872068
+location	Issoire	45.5432973	3.2502213
+location	Issy-Les-Moulineaux	48.8250508	2.273457
+location	Istocno Sarajevo	43.89884385	18.732747065951273
+location	Ita	-25.5074747	-57.3631906
+location	Itabaiana	-7.331674	-35.331723
+location	Itabera	-23.8621345	-49.1398926
+location	Itabirito	-20.2519724	-43.8029171
+location	Itaborai	-22.7570	-42.8643
+location	Itabuna	-14.7935179	-39.274318
+location	Itacare	-14.2781298	-38.9951418
+location	Itacoatiara	-3.1477898	-58.4461041
+location	Itagimirim	-16.0852591	-39.614789
+location	Itagua	-25.3947318	-57.3532892
+location	Itaguaí	-22.8629597	-43.775322
+location	Itagui	6.174822	-75.607579
+location	Itaiopolis	-26.3391899	-49.9071983
+location	Itajai	-26.9117879	-48.6669852
+location	Itajuba	-22.4238234	-45.4524156
+location	Itajuipe	-14.6744381	-39.3759427
+location	Italva	-21.4214056	-41.6907956
+location	Itamaraju	-17.0363103	-39.527994
+location	Itambaraca	-23.0176678	-50.406887
+location	Itambe	-7.448754326649954	-35.131398444731765
+location	Itambe PE	-7.4108509	-35.10967
+location	Itambe PR	-23.659424	-51.9903555
+location	Itanhaem	-24.1848847	-46.7921572
+location	Itaobim	-16.5614934	-41.502275
+location	Itaocara	-21.6725236	-42.0798658
+location	Itapaci	-14.9522349	-49.5511221
+location	Itapecerica Da Serra	-23.734665	-46.857835
+location	Itapema	-27.09472	-48.6137778
+location	Itapemirim	-21.0105534	-40.8351239
+location	Itaperucu	-25.21926	-49.345427
+location	Itaperuna	-21.2048	-41.88801
+location	Itapetim	-7.377514	-37.1887321
+location	Itapetininga	-23.588607	-48.048326
+location	Itapeva	-23.9849105	-48.8803886
+location	Itapevi	-23.54888	-46.933889
+location	Itapicuru	-11.3094471	-38.2184391
+location	Itapitanga	-14.4213865	-39.5664662
+location	Itapolis	-21.5958368	-48.8122696
+location	Itapora	-22.0799142	-54.7874239
+location	Itaporanga	-7.3040747	-38.1505782
+location	Itaporanga Dajuda	-10.9961671	-37.3045841
+location	Itapui	-22.2346755	-48.7189744
+location	Itaquaquecetuba	-23.4754492	-46.3514033
+location	Itaqui	-29.1222037	-56.5551258
+location	Itaquirai	-23.4801914	-54.1833692
+location	Itarare	-24.1145368	-49.3352464
+location	Itariri	-24.2900711	-47.176151
+location	Itati	-27.517731	-58.5528977
+location	Itatiaia	-22.4955278	-44.5633108
+location	Itatiba	-22.9965861	-46.8412042
+location	Itaugua	-25.3947318	-57.3532892
+location	Itauna	-20.075556	-44.576389
+location	Itawamba County	34.2774018	-88.3713687
+location	Itegem	51.1030959	4.7294471
+location	Ithaca	42.4396039	-76.4968019
+location	Itingen	47.4665362	7.7877841
+location	Itirapina	-22.2536514	-47.8212546
+location	Itobi	-21.730853	-46.9743
+location	Itterbeek	50.8395994	4.2501187
+location	Ittre	50.6501961	4.2637077
+location	Itu	-23.2638828	-47.298892
+location	Ituiutaba	-18.9691887	-49.4639335
+location	Itumbiara	-18.4135862	-49.2172596
+location	Itupeva	-23.1531055	-47.0580347
+location	Itupiranga	-5.1337224	-49.3321988
+location	Ituporanga	-27.4096219	-49.6014812
+location	Ituverava	-20.3366604	-47.7797924
+location	Ituzaingo	-34.6583293	-58.6671441
+location	Ivaipora	-24.2433517	-51.6719268
+location	Ivanka Pri Dunaji	48.1885931	17.2578039
+location	Ivanovo	56.9984452	40.9737394
+location	Ivdel	60.6973287	60.4172583
+location	Ivoti	-29.5934057	-51.1599403
+location	Ivry-sur-Seine	48.8122302	2.3872525
+location	Iwaniska	50.7314289	21.281111
+location	Ixelles	50.826707	4.374329
+location	Izegem	50.913822249999996	3.2090654210556964
+location	Iznalloz	37.3926	-3.5199
+location	Jabalpur	23.1608938	79.9497702
+location	Jabbeke	51.1823049	3.0934604
+location	Jablonec nad Nisou	50.7240899	15.1710958
+location	Jablonka	53.4960002	20.558356
+location	Jaboatao Dos Guararapes	-8.1752476	-34.9468716
+location	Jaboatiana	-10.9437642	-37.085801
+location	Jaboticabal	-21.252037	-48.325223
+location	Jacareí	-23.30528	-45.96583
+location	Jacarezinho	-23.159115	-49.973889
+location	Jaci	-20.8844434	-49.5710544
+location	Jackson County AL	34.7692447	-85.9867941
+location	Jackson County IA	42.195909	-90.570525
+location	Jackson County IL	37.7668943	-89.3563845
+location	Jackson County MS	30.4899024	-88.6486325
+location	Jackson County OR	42.398015	-122.7540948
+location	Jackson County TX	28.9224028	-96.55561
+location	Jackson County WI	44.312857	-90.780626
+location	Jackson Parish	32.2932692	-92.5628442
+location	Jacobacci	-41.1543657	-71.3219762
+location	Jacupiranga	-24.703773	-48.0060639
+location	Jadraque	40.9263778	-2.9226718
+location	Jaffna	9.665093	80.0093029
+location	Jagodnik	50.3811586	16.8262952
+location	Jagtial	18.82135895	78.91506632525903
+location	Jaguapita	-23.1102516	-51.5327741
+location	Jaguariaiva	-24.2589699	-49.7201518
+location	Jaguariuna	-22.70374	-46.985062
+location	Jaguaruana	-4.831508	-37.780997
+location	Jaguaruna	-28.6237365	-49.0288664
+location	Jahodna	48.050525	17.7049589
+location	Jaiba	-15.3373744	-43.6734439
+location	Jaipur	26.901676	75.793978
+location	Jaksmanice	49.753276	22.8802859
+location	Jalandhar	31.29201065	75.56805772253911
+location	Jalapa	14.6344164	-89.9897996
+location	Jalazone	31.951986	35.21155
+location	Jales	-20.2671767	-50.5492435
+location	Jalgaon	20.84351185	75.52592658756026
+location	Jalna	19.9182328	75.8686246900443
+location	Jalpaiguri	26.626483649999997	88.73407701468993
+location	Jamal Khan	22.3446905	91.8329751
+location	Jamnagar	22.471143	70.051543
+location	Jamundi	3.260158	-76.539750
+location	Janakpur	26.7281124	85.93643035322714
+location	Jandaia do Sul	-23.6003907	-51.645674
+location	Jandaira	-11.5628009	-37.7820255
+location	Jandira	-23.5282044	-46.9019554
+location	Janesville	42.691211	-89.014160
+location	Jangaon	17.746584300000002	79.24072182693956
+location	Janinow	51.06677	18.60071
+location	Janjgir-Champa	21.967126399999998	82.6647242496104
+location	Jankowo	53.5160393	15.7520295
+location	Janovce	49.183742050000006	21.3049069607189
+location	Janow Lubelski	50.7065895	22.4110663
+location	Janowice	49.94829	20.00868
+location	Janowice Wielkie	50.87828	15.9208773
+location	Janowo	53.31562	20.67352
+location	Jantar	54.3352789	19.0322591
+location	Januaria	-15.4875	-44.361111
+location	Januszowice	50.1471454	19.8936009
+location	Januszowka	51.9007462	18.6960422
+location	Japeri	-22.6427642	-43.6533831
+location	Japonvar	-15.9980389	-44.2755057
+location	Jaqueira	-8.7276422	-35.7948925
+location	Jaragua	-15.7528866	-49.3344033
+location	Jaragua do Sul	-26.4897432	-49.0778063
+location	Jaraicejo	39.6669756	-5.8135394
+location	Jarandilla de la Vera	40.1282875	-5.6587
+location	Jardim	-21.479941	-56.148902
+location	Jardim (Ceará)	-7.5838966	-39.279713
+location	Jardim (Mato Grosso do Sul)	-21.479941	-56.148902
+location	Jardim de Piranhas	-6.3796347	-37.3495566
+location	Jardim do Seridó	-6.59043	-36.7736039
+location	Jardinopolis	-21.0255126	-47.7706807
+location	Jarinu	-23.0949584	-46.7148636
+location	Jarocin	51.9738992	17.5011225
+location	Jarod	22.4413467	73.3380845
+location	Jaroslaw	50.0104958	22.678605
+location	Jarosławiec	52.25324	17.2293
+location	Jaroszewice Grodzieckie	52.06419	18.11753
+location	Jaroszewo	52.6222377	16.099639
+location	Jaroty	53.74069325	20.497921309754368
+location	Jaru	-10.431826	-62.478769
+location	Jashore	23.1665971	89.2095143
+location	Jasienica	49.8227628	19.8467742
+location	Jasienica (Malopolskie)	49.8227628	19.8467742
+location	Jasienica (Slaskie)	49.8134638	18.9196004
+location	Jasienin Maly	51.8156695	19.9418137
+location	Jasova	47.9866478	18.3984991
+location	Jasper County	30.7485258	-94.000884
+location	Jasper County IL	39.0082423	-88.1552371
+location	Jasper County IN	41.0321808	-87.1066598
+location	Jasper County MO	37.176515	-94.3103412
+location	Jasper County SC	32.4048602	-81.0414726
+location	Jasper County TX	30.7485258	-94.000884
+location	Jastrzebie-Zdroj	49.96067945	18.599367592200732
+location	Jatai	-17.8783829	-51.7204241
+location	Jatov	48.1284623	18.028264
+location	Jatrabari	23.711397	90.435403
+location	Jau	-22.293585	-48.559193
+location	Jaunpur	25.7955927	82.48834097504385
+location	Javouhey	5.6048166	-53.8178376
+location	Jawornik	49.8550051	19.9002228
+location	Jaworze	49.77857709572317	18.938449674898123
+location	Jaworzno	50.203439	19.2721559
+location	Jazernica	48.9265839	18.8306113
+location	Jedrzejow	50.6394435	20.3046116
+location	Jefferson County AL	33.5228184	-86.9164513
+location	Jefferson County CO	39.5699803	-105.2561919
+location	Jefferson County ID	43.8010248	-112.3498022
+location	Jefferson County IL	38.3010487	-88.9344303
+location	Jefferson County IN	38.8166724	-85.4299489
+location	Jefferson County KY	38.1787175	-85.664528
+location	Jefferson County MT	46.1850019	-112.1388102
+location	Jefferson County NY	44.095507	-75.890072
+location	Jefferson County OH	40.3792938	-80.7847619
+location	Jefferson County OR	44.6072499	-121.2463145
+location	Jefferson County TX	29.834772	-94.1704496
+location	Jefferson County WA	47.728342	-123.606395
+location	Jefferson County WI	43.025978	-88.773336
+location	Jefferson Davis Parish	30.2575503	-92.7886576
+location	Jefferson Parish	29.777633	-90.114916
+location	Jeffreys Bay	-34.051111	24.922222
+location	Jelenia Gora	50.8501049	15.653749235408073
+location	Jelesnia	49.6295063	19.3313366
+location	Jeleńska Huta	54.4522375	18.2280899
+location	Jelna	49.70442	20.72343
+location	Jemappes	50.446399	3.898191
+location	Jemeppe-sur-Sambre	50.46299585	4.654598601240723
+location	Jena	50.9281717	11.5879359
+location	Jenaz	46.9274527	9.7130354
+location	Jenin	32.4687623	35.2997901
+location	Jenipapo de Minas	-17.08493	-42.259576
+location	Jenkowice	51.23163	17.32291
+location	Jerez De La Frontera	36.690491	-6.126763
+location	Jerome County	42.702266	-114.2867043
+location	Jeronimo Monteiro	-20.7882214	-41.3921464
+location	Jersey City	40.7281575	-74.0776417
+location	Jersey County	39.0848464	-90.3303344
+location	Jersey County IL	39.0848464	-90.3303344
+location	Jerusalem	31.79592425	35.21198075969497
+location	Jerutki	53.5919113	21.1377193
+location	Jesenské (Rimavska Sobota)	48.2978052408123	20.059687251919208
+location	Jesionowo	52.93	16.3855556
+location	Jesus Maria	-38.8875243	-62.0579646
+location	Jesus Maria AR	-30.9764132	-64.0957082
+location	Jesus Maria PE	-12.0781861	-77.04640320962204
+location	Jetpur	21.7547	70.6180
+location	Jette	50.883110	4.324621
+location	Jeziorki	52.3124256	16.5906245
+location	Jeziorko	50.8783841	21.3344233
+location	Jezow	51.81371	19.96878
+location	Jezow Sudecki	50.933694	15.743396
+location	Jhapa	26.583735400000002	87.88570103314731
+location	Jhargram	22.3770636	87.04867177362203
+location	Jharsuguda	21.87705125	84.00905063735019
+location	Jhenaidah	23.5448144	89.1734196
+location	Jian	27.0876	114.9647
+location	Jičín	50.4370452	15.3516528
+location	Jim Hogg County	27.0065425	-98.7047316
+location	Jim Wells	27.8067733	-98.1084601
+location	Jim Wells County	27.8067733	-98.1084601
+location	Jimenez	9.81883425	-83.71156568638008
+location	Jimenez de Jamuz	42.2648745	-5.9291703
+location	Jindřichův Hradec	49.1443265	15.003354
+location	Jingzhou	30.350752	112.237294
+location	Jipijapa	-1.5158193	-80.61249824917113
+location	Jish	33.0243744	35.4458835
+location	Jiujiang	29.7051	116.0019
+location	Jo Daviess County	42.3506664	-90.1743742
+location	Joacaba	-27.1737204	-51.5065214
+location	Joal-Fadiouth	14.1857143	-16.8588515
+location	João Câmara	-5.5349637	-35.8150811
+location	Joao Pessoa	-7.1215981	-34.882028
+location	Joao Pinheiro	-17.742777	-46.175278
+location	Joaquim Tavora	-23.4999724	-49.9232545
+location	Joarilla De Las Matas	42.2872779	-5.178728
+location	Joboticabel	-21.2560780392603	-48.327711584268236
+location	Jocotan	14.8211974	-89.3906946
+location	Jodar	37.8406832	-3.3548686
+location	Jodhpur	26.2967719	73.0351433
+location	Jodlowno	54.246804	18.3830005
+location	Jodoigne	50.724179	4.8679997
+location	Joe Gqabi	-30.94155986620789	27.130695927230565
+location	Jönköping	57.777979	14.160453
+location	Joeuf	49.2302031	6.0092074
+location	Jogulamba Gadwal	16.0999202	77.73415835077523
+location	Johannesburg Metro	-26.205	28.049722
+location	Johnson County	41.6861834	-91.6061124
+location	Johnson County IA	41.6861834	-91.6061124
+location	Johnson County IL	37.4501818	-88.8844045
+location	Johnson County IN	39.4891804	-86.1079903
+location	Johnson County KS	38.8837933	-94.8389141
+location	Johnson County TX	32.3766071	-97.3568623
+location	Joinville	-26.235559	-48.950735
+location	Jona	47.2299661	8.837658
+location	Jonava	55.0737086	24.2756961
+location	Joncret	50.35278095337974	4.513072379458692
+location	Jones County MS	31.6058959	-89.1636245
+location	Jorba	41.6014534	1.547408
+location	Jordán	0.2357332863593663	-78.2617092391726
+location	Jordania	-15.899444	-40.178889
+location	Jordanow	51.75826	19.67593
+location	Jose Bonifacio	-23.564090999999998	-46.434766582997995
+location	José C Paz	-34.511906	-58.7776777
+location	Jose D. Espinar	9.04693915	-79.47730691472555
+location	Jose Domingo Espinar	9.049737	-79.477684
+location	Jose Leonardo Ortiz	-6.74207775	-79.83421240603172
+location	Josephine County	42.3554368	-123.5602707
+location	Josselin	47.9540017	-2.5472538
+location	Joue-Les-Tours	47.3510905	0.6622524
+location	Joze	45.8615564	3.3018722
+location	Jozefin	52.1803495	22.0462602
+location	Jozefow	52.12849335	21.21358509994632
+location	Juan Augusto Saldívar	-25.428188249999998	-57.42910290825559
+location	Juan Demóstenes Arosemena	8.928077	-79.730252
+location	Juan Díaz	8.9818212	-79.5678952
+location	Juan Jose Castelli	-25.940052899999998	-60.617290857332314
+location	Juazeiro do Norte	-7.2153453	-39.3153336
+location	Jubbega	53.0033704	6.1220155
+location	Jucurutu	-6.0343518	-37.0186249
+location	Juiz de Fora	-21.7609533	-43.3501129
+location	Julianow	53.72544109653824	20.877284070208418
+location	Julio Mesquita	-22.0099839	-49.7889446
+location	Jumet	50.442063	4.436515
+location	Jun	37.2203	-3.5931
+location	Junagadh	21.5222	70.4579
+location	Juncosa	41.3714063	0.7754401
+location	Jundia	-6.2707116	-35.3279507
+location	Jundiai	-23.1887866	-46.8845122
+location	Juneau	58.541037	-134.236606
+location	Juneau County	43.8673	-90.0747
+location	Juneda	41.5500153	0.8275473
+location	Junin	-34.5934412	-60.9461678
+location	Junqueiropolis	-21.5109531	-51.4351505
+location	Juquia	-24.3172209	-47.6355618
+location	Juquitiba	-23.932346	-47.0714217
+location	Jurbise	50.523647	3.904391
+location	Juripiranga	-7.3743307	-35.2396
+location	Jurki	53.9505447	19.9485902
+location	Juruti	-2.1571381	-56.0900977
+location	Jussac	44.9880092	2.4212934
+location	Jussara	-15.874813	-50.867431
+location	Jussara PR	-23.621931	-52.46931
+location	Jussari	-15.1882453	-39.493597
+location	Justynow	51.2462905	20.010171
+location	Jutaí	-2.7471478	-66.7721255
+location	Jutiapa	14.2922649	-89.8953317
+location	Juvisy-sur-Orge	48.690609	2.377581
+location	Jwaneng	-24.600417	24.730277
+location	K-Kozle	50.3448836	18.2109594
+location	Ka'Abiyye-Tabbash-Hajajre	32.748855882519834	35.183732222189015
+location	Kaarst	51.226675	6.6193924
+location	Kaatsheuvel	51.6598038	5.0319484
+location	Kabirhat	22.8220772	91.1170328
+location	Kabwe	-14.5262739	28.34204494171865
+location	Kachkanar	58.6981697	59.4810114
+location	Kacik	54.1679868	18.9557149
+location	Kaczki Srednie	51.9702995	18.5501365
+location	Kaczyce	49.834077	18.592432
+location	Kadapa	14.4752936	78.8216861
+location	Kadi	23.294922	72.333046
+location	Kafr Kanna	32.7516395	35.3464804
+location	Kafue	-15.7445125	28.1755158
+location	Kaggevinne	50.980233	5.021191
+location	Kahathuduwa	6.7831285	79.9839654
+location	Kailali	28.6869857	80.8731502
+location	Kain	50.637121	3.379162
+location	Kaiseraugst	47.5399823	7.7230178
+location	Kaiserslautern	49.4432174	7.7689951
+location	Kakching	24.38904015	93.88013239529906
+location	Kakinada	16.9437385	82.2350607
+location	Kalabagan	23.74695835	90.38393803066401
+location	Kalachinsk	55.049091	74.582428
+location	Kalamazoo County	42.2494968	-85.5372797
+location	Kalay	23.195728	94.0158882
+location	Kalia	23.037114	89.641357
+location	Kalimpong	27.02787695	88.64606085772425
+location	Kalininets	55.55928668927188	36.97461147894476
+location	Kaliningrad	54.710128	20.5105838
+location	Kalinkavichy	52.1286204	29.3314442
+location	Kalinki	51.1324045	19.831224
+location	Kalinkovo	48.0587538	17.2520824
+location	Kalisz	51.743335	18.073619
+location	Kalisz Pomorski	53.2981616	15.9059903
+location	Kalitola	24.8590277	89.3729468
+location	Kalken	51.037676	3.917157
+location	Kallakurichi	11.7406259	78.9637131
+location	Kallnach	47.0205806	7.2363159
+location	Kalmthout	51.383	4.4752
+location	Kalol	23.238801	72.498547
+location	Kalsdorf Bei Graz	46.9644025	15.4786966
+location	Kaltbrunn	47.2134573	9.0249831
+location	Kalukhali Upazila	23.765566034504623	89.48824818987217
+location	Kalyanpur	22.08421335	69.3041972072113
+location	Kalymnos	37.00262545	26.992424179156217
+location	Kamanova	48.4742265	18.099349
+location	Kamareddy	18.316551	78.05393808043348
+location	Kamenica nad Cirochou	48.9315807	21.9957848
+location	Kamenica nad Hronom	47.831347	18.7255594
+location	Kamenicna	47.8162871	18.0426149
+location	Kamensk-Shakhtinsky	48.3210807	40.2650679
+location	Kamensk-Uralsky	56.415451	61.917797
+location	Kamien	53.1257825	20.6869343
+location	Kamien Maly	52.2884074	18.0293306
+location	Kamien Pomorski	53.9648364	14.7734718
+location	Kamieniec Wrocławski	51.075237	17.1735569
+location	Kamieniki	51.5325884	18.3784425
+location	Kamienka SL	49.3320588	20.6137536
+location	Kamienna Gora	50.78468925	16.022363067768467
+location	Kamiesberg	-30.50414	17.889710754257905
+location	Kamieskroon	-30.2096443	17.9345442
+location	Kamionki	52.28553	16.99438
+location	Kamjong	24.8409769	94.52830740954334
+location	Kampenhout	50.945063	4.567367
+location	Kamrej	21.2797773	72.948269
+location	Kamrup	26.1390895	91.7463206
+location	Kamrup Municipal	26.1390895	91.7463206
+location	Kamyshlov	56.846161	62.712154
+location	Kamyzyak	46.1175499	48.0884863
+location	Kanash	55.5113818	47.5067782
+location	Kanawha	39.1989653	-81.4601209
+location	Kancheepuram	12.87960515	79.70427615297989
+location	Kandy	7.2930922	80.6350768
+location	Kane County	41.923434	-88.4248315
+location	Kane County IL	41.923434	-88.4248315
+location	Kangra	32.06854705	76.24336792335127
+location	Kanigowo	53.31922	20.43213
+location	Kankakee County	41.1253903	-87.848682
+location	Kannaland	-33.61886	21.227504095340592
+location	Kannauj	26.999697400000002	79.68861212775874
+location	Kanpur	26.4609135	80.3217588
+location	Kanty	53.8483217	19.7308677
+location	Kanyakumari	8.079252	77.5499338
+location	Kaohsiung	22.622632	120.312435
+location	Kapadvanj	23.0200	73.0700
+location	Kapellen	51.332758999999996	4.431231830555777
+location	Kapfenberg	47.4405481	15.2901669
+location	Kappl	47.05342475	10.342014611207333
+location	Kaprun	47.2713898	12.7573679
+location	Karachayevsk	43.7715594	41.911979
+location	Karapitiya	6.0670789	80.2257615
+location	Karauli	26.51668105	77.05772976517363
+location	Karawang	-6.3042012	107.307897
+location	Karditsa	39.3639689	21.9213213
+location	Kargil	34.420542600000005	75.6467756307598
+location	Karimnagar	18.4346438	79.1322648
+location	Karkams	-30.36922786960893	17.886940492824987
+location	Karlino	54.0410287	15.8793019
+location	Karlsfeld	48.2266316	11.4676387
+location	Karlshuld	48.6822692	11.2877512
+location	Karná	48.9844958	21.8060267
+location	Karnes County	28.8791858	-97.9062893
+location	Karonga	-10.08474695	33.86619181196623
+location	Karoo Hoogland	-31.59588	21.27258581983207
+location	Karsino	54.47	16.56236
+location	Kartuski	54.326832249999995	18.108863258211223
+location	Kartuzy	54.3342281	18.1973639
+location	Karur	10.9301522	78.08485454572889
+location	Karviná	49.850056	18.546309
+location	Kasauli	30.85844455	76.99796611489867
+location	Kasdobir	24.9115659	91.8753147
+location	Kashgar	39.4666397	75.9900091
+location	Kashino	56.538687192694844	60.86596040407967
+location	Kasinka Mala	49.7024609	20.0370039
+location	Kaskelen City	43.2022724	76.6245772
+location	Kaster	50.814135	3.4962534
+location	Kasterlee	51.2405	4.9674
+location	Katembe	-26.02703125	32.54984173582457
+location	Kathmandu	27.712907	85.323557
+location	Katowice	50.2598987	19.0215852
+location	Katwijk	52.2005078	4.4146372
+location	Katwoude	52.4774282	5.042960875677453
+location	Katy Rybackie	54.3399675	19.2295294
+location	Kauai County	22.0557204	-159.4945109
+location	Kaufman County	32.581020800000005	-96.29927072197667
+location	Kaulille	51.186846	5.525937
+location	Kavadarci	41.4332802	22.0122593
+location	Kaweczyn	51.271229	19.9632926
+location	Kawki	54.1122299	19.7134063
+location	Kazan	55.7823547	49.1242266
+location	Kazhma	62.549908	34.839161
+location	Kazir Dewri	22.3476072	91.8255493
+location	Kazmierz	52.5129241	16.5831468
+location	Kdumim	32.21192845	35.15107683682172
+location	Kecovo	48.4926227	20.483668
+location	Kedainiai	55.2887322	23.9758359
+location	Kedrovoye	57.1595769	60.5695324
+location	Kedzierzyn Kozle	50.3448836	18.2109594
+location	Keerbergen	51.0049242	4.6265551
+location	Kefar Sava	32.1773471	34.907459
+location	Kegalle	7.2532006	80.3454132
+location	Kelaniya	6.9501246	79.9172715
+location	Kelmis	50.714674	6.023042
+location	Kematen in Tirol	47.253643	11.273540
+location	Kembs	47.6895561	7.5048054
+location	Kemerovo	55.355125	86.087234
+location	Kemmel	50.7828552	2.8258709
+location	Kempton Park	-26.0964372	28.2336325
+location	Kemzeke	51.2065228	4.0771037
+location	Kendall County	41.5853584	-88.4319488
+location	Kendall County IL	41.5853584	-88.4319488
+location	Kendall County TX	29.943885	-98.7258845
+location	Kendari	-3.9918068	122.5180066
+location	Kenedy County	27.246847000000002	-97.36462995563213
+location	Kennebec County	44.4184616	-69.8250659
+location	Kenosha County	42.5729233	-88.0679837
+location	Kent County	39.1156908	-75.4841394
+location	Kent County DE	39.1156594	-75.484116
+location	Kent County RI	41.6722912	-71.602762
+location	Kepanow	49.8329152	20.2611704
+location	Kepno	51.2790265	17.9866632
+location	Keqiao	30.0819	120.4951
+location	Keraniganj	23.698240300000002	90.35048563452816
+location	Kerkrade	50.87489555	6.05938669638836
+location	Kerksken	50.8894722	3.9935955
+location	Kermt	50.946857	5.247189
+location	Kern County	35.3145701	-118.7538222
+location	Kerr County	30.045717	-99.3884839
+location	Kersbeek-Miskom	50.886946	4.999315
+location	Kershaw County	34.3334398	-80.5669895
+location	Kessel	51.1383696	4.6282198
+location	Kessel-Lo	50.8851	4.7357
+location	Kessenich	51.1512668	5.8196246
+location	Kestenholz	47.28203	7.7549744
+location	Ket	47.9666667	18.5666667
+location	Ketchikan	55.346882	-131.655301
+location	Ketrzynski	54.1361925	21.28938022588305
+location	Keur Massar	14.7825027	-17.3111773
+location	Kewaunee County	44.521282	-87.6301086
+location	Kezmarok	49.1362088	20.4308701
+location	Kfar Habad	31.9901	34.8491
+location	Kfar Saba	32.180607	34.912861
+location	Khagrachari	23.21477295	91.95910219841397
+location	Khambhaliya	22.2176085	69.6578939
+location	Khammam	17.5	80.333333
+location	Khanty-Mansiysk	61.00346	69.019157
+location	Kharabali	47.4083742	47.2538899
+location	Khayelitsha	-34.0405905	18.6674201
+location	Kheda	22.749950	72.686465
+location	Khedbrahma	24.0291	73.0435
+location	Khimki	55.8892847	37.4449896
+location	Khombole	14.760535	-16.691803
+location	Khulshi	22.3688486	91.7966938
+location	Kielce	50.85403585	20.609914352101452
+location	Kielczow	51.1398527	17.1790872
+location	Kieldrecht	51.2888268	4.1758418
+location	Kielno	54.4526152	18.3382936
+location	Kietrz	50.0796271	18.0021082
+location	Kikinda	45.8297838	20.4653942
+location	Kilamba Kiaxi	-8.90137245	13.236425787515477
+location	Killeen	31.1171441	-97.727796
+location	Kimble County	30.4744131	-99.8199792
+location	Kimswerd	53.1412169	5.4376572
+location	Kinaxixi	-8.81590505	13.23982627124515
+location	Kineshma	57.4431	42.1400999
+location	King Cetshwayo	-28.750343899999997	32.050227274984636
+location	King County	47.449221	-121.864246
+location	King Koti	17.3936821	78.4823947
+location	Kings County	36.0784807	-119.7956342
+location	Kings County CA	36.0784807	-119.7956342
+location	Kings County NY	40.64530975	-73.9550230275334
+location	Kinrooi	51.14313325	5.74145646069855
+location	Kipen	59.6739	29.8498
+location	Kipfenberg	48.949209	11.3948573
+location	Kiphire	25.81551155	94.84166400470303
+location	Kirchbichl	47.51380975	12.091103520158118
+location	Kirchdorf	48.0568378	13.6981378
+location	Kirchhain	50.826987700000004	8.927593310210382
+location	Kirchham	47.9706301	13.8992429
+location	Kirishi	59.450325	32.010578
+location	Kirkland	47.679486	-122.206354
+location	Kirovgrad	57.4265271	60.0665927
+location	Kirovsk	59.8813954	30.9855331
+location	Kirpichny	56.9595029	60.4375162
+location	Kiryat Ata	32.8115779	35.1163659
+location	Kiryat Ekron	31.8607858	34.823337
+location	Kiryat Gat	31.6093998	34.7711983
+location	Kiryat Ono	32.0591691	34.8594303
+location	Kiryat Ye'Arim	31.8035128	35.1012545
+location	Kishoreganj	24.4341287	90.7862596
+location	Kisiny	53.22399	20.21094
+location	Kisra-Sumei	32.97168	35.301796704158846
+location	Kitsap County	47.594502	-122.6474421
+location	Kittitas County	47.1750	-120.9319
+location	Kitzbühel	47.4463585	12.3911473
+location	Kitzbühel-Land	47.45102190209532	12.441278851414303
+location	Kitzbühel-Stadt	47.4462181	12.3901626
+location	Klacany	48.3894586	17.8727907
+location	Kladno	50.1478497	14.1025379
+location	Klagenfurt	46.6228162	14.3079604
+location	Klagenfurt Am Wörthersee	46.6228162	14.3079604
+location	Klagenfurt-Land	46.6333333	14.2
+location	Klaipeda	55.7127529	21.1350469
+location	Klaj	49.9925308	20.3154849
+location	Klamath County	42.6052565	-121.739544
+location	Klamath Falls	42.224867	-121.7816704
+location	Klatovy	49.3951183	13.2935954
+location	Kleberg County	27.2841795	-97.37419761689159
+location	Klein-Gelmen	50.7713536	5.2763925
+location	Klein-Pöchlarn	48.2185879	15.2161113
+location	Klein-Zimmern	49.8683011	8.8494245
+location	Kleinlützel	47.4259552	7.4172702
+location	Kleinvlei	-33.98849192171085	18.71260483036835
+location	Klenčí	49.4348	12.8147
+location	Klenovec	48.5971614	19.8902514
+location	Klickitat County	45.8767731	-120.7976033
+location	Klickitat County WA	45.8767731	-120.7976033
+location	Klin	49.4350714	19.4971363
+location	Klipfontein	-32.0027832	18.5072125
+location	Klizska Nema	47.7513765	17.8190874
+location	Klocko	51.5666667	18.6833333
+location	Klodzko	50.43371175	16.642246491692106
+location	Klonowo Dolne	54.20713	18.30261
+location	Klosterneuburg	48.30499	16.323756
+location	Kluczbork	50.9730701	18.2140089
+location	Kluisbergen	50.7782986	3.5212498
+location	Klungkung	-8.5350173	115.4032763
+location	Knezevo	44.4899319	17.3800905
+location	Knokke	51.3464525	3.2876342
+location	Knokke-Heist	51.331501	3.308826
+location	Knox County	40.920889	-90.2202325
+location	Knox County IL	40.920889	-90.2202325
+location	Knox County MO	40.122723	-92.1573551
+location	Knox County TN	35.9859998	-83.9375598
+location	Knox County TX	33.5871385	-99.7073621
+location	Knysna	-34.035734	23.048485
+location	Knyszyn	53.3122442	22.9200387
+location	Kobiernice	49.8509514	19.214703
+location	Koblenz	50.3533278	7.5943951
+location	Kobylanka	53.3462246	14.8699004
+location	Kobylniki	52.0661153	16.5793121
+location	Kochani	41.9211332	22.4114182
+location	Kochánky	50.2770296	14.7802312
+location	Kochanovce (Humenne)	48.9537933	21.9418492
+location	Kochanow	50.697364	16.149269
+location	Kochanowka	51.086579	21.3986805
+location	Kodinar	20.8009	70.6960
+location	Kodomtoly	23.703843	90.875119
+location	Koekange	52.7017754	6.3180238
+location	Koekelare	51.09122995	2.968139586416541
+location	Koekelberg	50.8606042	4.3315503
+location	Koersel	51.058003	5.272274
+location	Koforidua	6.1104472	-0.2673795
+location	Kohima	25.75	94.166667
+location	Kokava nad Rimavicou	48.5713992	19.8410608
+location	Kokrajhar	26.58687695	90.29293105124796
+location	Koksijde	51.109246049999996	2.6352642048261234
+location	Koksov-Baksa	48.6475338	21.3226784
+location	Kolar	13.1369996	78.1339606
+location	Kolárovo	47.9182347	17.9966591
+location	Kolasib	24.18947525	92.7133181281124
+location	Kolbuszowa	50.2433277	21.7754563
+location	Kolhapur	16.7028412	74.2405329
+location	Kolin	50.0288894	15.2011571
+location	Kolin 2	50.0226044	15.1907306
+location	Kolkata	22.543905	88.374991
+location	Kolno	53.401686749999996	21.936077723604825
+location	Koło	52.2019866	18.6359912
+location	Kolobrzeg	54.176211550000005	15.57640369780165
+location	Kolodishchi	53.9454227	27.7749292
+location	Kolonia Nadwislanska	51.1193642	21.787911
+location	Kolonnawa	6.9326254	79.8903143
+location	Kolozab	53.8814583	19.1301651
+location	Kolpino	59.748444	30.604479
+location	Kolta	48.0176388	18.4138373
+location	Koluszki	51.7444956	19.817966
+location	Komaigari	24.830791262227557	88.92873029766788
+location	Komarno	47.7574079	18.1298249
+location	Komjatice	48.1522793	18.1686035
+location	Komoca	47.9498145	18.0227382
+location	Komorniki	52.3360059	16.8080811
+location	Komorniki WN	53.2617878	20.20857615
+location	Komorniki WP	52.3360059	16.8080811
+location	Komorow	51.3266557	17.6892808
+location	Komprachcice	50.6356474	17.8227459
+location	Konczyce Wielkie	49.8333835	18.651605
+location	Kondopoga	62.20929	34.268185
+location	Konetopy	50.276404	14.6538239
+location	Konin	52.25590205	18.267866211748718
+location	Koningshooikt	51.0965644	4.6097183
+location	Konskie	51.1910223	20.4071836
+location	Konstancin Jeziorna	52.0834787	21.1208073
+location	Konstantinovka	49.618553	127.987968
+location	Konstantynow Lodzki	51.75721335	19.308241229915176
+location	Konstanz	47.659216	9.1750718
+location	Kontich	51.134377	4.4456359
+location	Koog Aan de Zaan	52.4620521	4.8071394
+location	Koolskamp	51.0020706	3.2092316
+location	Kootenai County	47.654857	-116.7162916
+location	Kopcany	48.7876098	17.114639
+location	Koprivnica	49.1563934	21.3953283
+location	Korea	23.2382999	82.3906588
+location	Korinthos	37.9386936	22.9280447
+location	Korneuburg	48.3440605	16.3334321
+location	Korolyov	55.9204898	37.8326289
+location	Korsze	54.1707614	21.1442323
+location	Kortemark	51.0314599	3.036868308654011
+location	Kortenaken	50.906611	5.0622937
+location	Kortenberg	50.887699	4.567473
+location	Kortessem	50.8600026	5.3865719
+location	Korzen	51.6412901	20.8785388
+location	Korzkiew	50.1625137	19.883817
+location	Kos	36.793693250000004	27.084826562878217
+location	Kosakowo	54.5887906	18.4926928
+location	Kosarovce	49.0433951	21.7814348
+location	Koscian	52.08336945	16.646088826711576
+location	Koscierzyce	50.8694758	17.5184423
+location	Kościerzyna	54.1210215	17.9781656
+location	Kosmonosy	50.4389828	14.9305091
+location	Kostany nad Turcom	49.0304112	18.901709
+location	Kostelec N. Černými Lesy	49.9996259	14.851957749764026
+location	Kostelec nad Labem	50.226532	14.5855201
+location	Kostoliste	48.4450588	16.9832918
+location	Kostolna-Zariecie	48.877472	17.9694367
+location	Kostrza	51.111643	15.9337186
+location	Kostrzewice	51.6592915	18.464832
+location	Kostrzyca	50.8181961	15.8020626
+location	Kostrzyn	52.6155694	14.7015242
+location	Kostrzyn (Lubuskie)	52.6155694	14.7015242
+location	Kostrzyn (Mazowieckie)	51.5748717	20.7309873
+location	Kostrzyn (Wielkopolskie)	52.3932322	17.2246954
+location	Kostrzyn nad Odra	52.61626975	14.627947699728011
+location	Koszalin	54.20727105	16.217530768271565
+location	Koszary	51.3887652	21.5356425
+location	Kotawaringin Barat	-2.6865269	111.629247
+location	Kotawaringin Timur	-2.8383962499999997	112.96825492706611
+location	Kotor Varos	44.6204796	17.3698016
+location	Kourou	5.1581197	-52.64263
+location	Kovalov	48.7043477	17.2813154
+location	Kovarce	48.4952834	18.1580893
+location	Kovdor	67.563049	30.474108
+location	Kovrov	56.35684460928298	41.318864604223485
+location	Kowale	52.8641915	22.9785478
+location	Kowale (Podlaskie)	52.8641915	22.9785478
+location	Kowale (Pomorskie)	54.3584562	17.7916932
+location	Kowale Ksieze	51.97268	18.50513
+location	Kowale Panskie-Kolonia	51.9386721	18.534998
+location	Kowanowko	52.6734543	16.8534353
+location	Kozhikode	11.2586082	75.7788735
+location	Koziegłowy	52.4450201	16.992239
+location	Kozielice	53.85511	14.86377
+location	Kozłowo	53.3071759	20.2931276
+location	Kozmodemyansk	56.3324346	46.5462855
+location	Kozy	49.8462862	19.145175
+location	Kraaifontein	-33.843435456354456	18.716575944747177
+location	Kraainem	50.8611	4.4593
+location	Kragujevac	44.0125745	20.91877
+location	Kraków	50.0647	19.9450
+location	Kraljevo	43.7234519	20.6870792
+location	Kralovsky Chlmec	48.4223618	21.9804775
+location	Králův Dvůr	49.9502063	14.0344556
+location	Kramarzyny	54.05861	17.24115
+location	Kramsach	47.4553157	11.873043308886206
+location	Kranj	46.2417685	14.355964
+location	Krapkowice	50.4747413	17.9675262
+location	Krasnik	50.943493200000006	22.208352670460982
+location	Krasno nad Kysucou	49.3897116	18.8318753
+location	Krasnodar	45.0352566	38.9764814
+location	Krasnohorska Dlha Luka	48.6254064	20.5804364
+location	Krasnoufimsk	56.604538	57.771313
+location	Krasnouralsk	58.357063	60.037445
+location	Krasnoyarsk	56.0090968	92.8725147
+location	Krasnyi Aduy	57.0938362	60.5886044
+location	Krasnystaw	50.99184805	23.165038002215837
+location	Krasocin	50.88936	20.11781
+location	Kraszew	51.8965858	19.8226161
+location	Kraszkow	50.8355048	21.2461018
+location	Krauupy nad Vltavou	50.23784897053732	14.299589372242485
+location	Kravany	48.9976596	20.2029613
+location	Krefeld	51.3331205	6.5623343
+location	Kreileroord	52.8407282	5.0812679
+location	Krems an der Donau	48.409809300000006	15.60631866409324
+location	Krepiec	54.30924	18.69733
+location	Kretingos rajono savivaldybė	55.9686093	21.36040592407803
+location	Kretlewo	53.8273116	14.8933616
+location	Krhanice	49.8560083	14.557357
+location	Kriens	47.034146	8.2807994
+location	Kriessern	47.3653317	9.6071943
+location	Krishnagiri	12.5188835	78.2206536
+location	Krivá	49.2825832	19.4791415
+location	Krolewo	54.04166	19.13836
+location	Krolowka	49.583637	20.8448424
+location	Kroměříž	49.2984191	17.3929804
+location	Krommenie	52.4954557	4.7664946
+location	Kroonstad	-27.6532701	27.235515
+location	Krosno	49.68898435	21.75347880451494
+location	Krosno Odrzańskie	52.0536361	15.0980258
+location	Krotoszyn	51.695926	17.4374158
+location	Kruchowo	52.60724	17.8089
+location	Kruibeke	51.17625475	4.298147844222809
+location	Krukowszczyzna	52.9850238	23.5435534
+location	Krupina	48.3527285	19.069182
+location	Krusevac	43.5825653	21.326599
+location	Kruzlova	49.3626385	21.5822088
+location	Kruzno	48.413636999999994	19.927208225106664
+location	Krzecin	53.08109	15.4869
+location	Krzeszow	50.7333131	16.0689853
+location	Krzyszkowice	49.884506	19.9250104
+location	Krzywin	53.0011933	15.6263392
+location	Ksar Hellal	35.6516722	10.906119548434997
+location	Ksiaznice	49.9491855	20.2973915
+location	Kuantan	3.7985637	103.32199
+location	Kubinka	55.5755486	36.6952802
+location	Kuboes	-28.4470694	16.9903196
+location	Kuce	53.2983333	20.5308333
+location	Kuchl	47.6258369	13.1451024
+location	Kuczow	51.0027513	21.1261376
+location	Kuczyna	51.746182	16.9584643
+location	Kudelstaart	52.2342834	4.7497339
+location	Kudrovo	59.9025191	30.5154613
+location	Küssnacht Am Rigi	47.0835618	8.4335777
+location	Kufstein	47.582996	12.1692134
+location	Kukułowo	53.9187309	14.7023526
+location	Kuleszewo	54.3546728	16.96865
+location	Kumanovo	42.1359459	21.7177635
+location	Kumtich	50.8188455	4.8874012
+location	Kunjachaya	23.7707025	90.36708025711391
+location	Kunming	25.013024	102.866742
+location	Kunow	50.9541063	21.278823
+location	Kunowice	52.3508485	14.635166
+location	Kupang	-10.1632209	123.6017755
+location	Kurimka	49.3189105	21.4381755
+location	Kuringen	50.9439384	5.3052007
+location	Kurnool	15.8309251	78.0425373
+location	Kurov	49.3483112	21.12657469997454
+location	Kurozwecz	54.05483	16.27273
+location	Kursk	52.44345	78.9215365
+location	Kurunegala	7.4870464	80.364908
+location	Kushtia	23.8987955	89.1295536
+location	Kushva	58.281757	59.762329
+location	Kutch	23.941578550000003	70.90137328666603
+location	Kutná Hora	49.9486561	15.2681123
+location	Kutno	52.2220021	19.387595057455435
+location	Kuurne	50.860060	3.270708
+location	Kuwait City	29.3797091	47.9735629
+location	Kuźnica	53.5100543	23.6490923
+location	Kvetnice	50.0570595	14.6838842
+location	KwaDukuza	-29.335722	31.296489
+location	Kwahu East	6.6712596389928205	-0.7460340859707717
+location	Kwahu West	6.500692055984153	-0.776952367201721
+location	Kwidzyn	53.7204653	18.937464130662192
+location	Kyadondo	0.39738930117776006	32.58046115287309
+location	Kynice	49.7392	15.3601
+location	Kyoto	35.007542	135.768455
+location	Kysucke Nove Mesto	49.2999184	18.7865084
+location	Kyzylorda	44.8426778	65.5036151
+location	l'Alcora	40.0744223	-0.2138589
+location	l'Alcudia	39.1947105	-0.5042406
+location	L'Ametlla del Valles	41.669334	2.2614527
+location	L'Aquila	42.360082	13.391087
+location	L'Estartit	42.0512172	3.1990824
+location	L'Hospitalet de Llobregat	41.3598601	2.0997927
+location	L'Isle-Adam	49.1125294	2.2186324
+location	La Aldea de San Nicolas	27.9827393	-15.779715
+location	La Baneza	42.2998096	-5.8970081
+location	La Batlloria	41.7175269	2.5468103
+location	La Bisbal d'Empordà	41.9598687	3.039616
+location	La Bisbal de l'Emporda	41.9720829	3.1198892
+location	La Boca	-34.6335103	-58.3590424
+location	La Bourboule	45.5892481	2.7401614
+location	La Bouverie	50.4074083	3.8768211
+location	La Brède	44.6811652	-0.5279844
+location	La Calahorra	37.1814745	-3.0640503
+location	La Canada de San Urbano	36.8414444	-2.4070041
+location	La Carrera de Otero	42.5099199	-6.0425563
+location	La Cavada	43.35226	-3.70862
+location	La Ceja	5.985242250000001	-75.4467398934149
+location	La Cellera de Ter	41.9686921	2.6205193
+location	La Chapelle-Saint-Luc	48.3185478	4.0413095
+location	La Chorrera	8.9789112	-79.87043288185177
+location	La Cisterna	-33.529525449999994	-70.66425672284569
+location	La Clua	42.0981239	0.7267439
+location	La Colorada	8.0163715	-80.9840861
+location	La Costa	-36.66264385	-56.69228197388749
+location	La Crosse County	43.8617	-91.1353
+location	La Crosse County WI	43.8890516	-91.0902393
+location	La Cruz	11.0090665	-85.55069626857352
+location	La Cruz CR	11.0090665	-85.5506962685735
+location	La Cuesta	8.4924424	-82.8492286
+location	La Dorada	5.4544379	-74.6633693
+location	La Estrada	42.6899	-8.4909
+location	La Estrella	-34.2052857	-71.6546039
+location	La Estrella CL	-34.2052857	-71.6546039
+location	La Estrella CO	6.1576944	-75.6434368
+location	La Falda	-38.7016629	-62.2570967
+location	La Fleche	47.6968408	-0.0746149
+location	La Florida	-33.530816599999994	-70.54407548567474
+location	La Fuliola	41.7127829	1.0186209
+location	La Gacilly	47.772628850000004	-2.1519418829005823
+location	La Garriga	41.6849111	2.2865796
+location	La Goutelle	45.842035	2.759199
+location	La Granja	-33.53371615049343	-70.62367859979743
+location	La Granja d’Escarp	41.4191988	0.3520585
+location	La Hulpe	50.7313729	4.4893987
+location	La Jonquera	42.4207991	2.8728485
+location	La Libertad	-8.4893613	-77.3174141
+location	La Ligua	-32.4496375	-71.2316695
+location	La Linea de la Concepcion	36.166010	-5.347498
+location	La Llagosta	41.5139877	2.1912073
+location	La Londe-Les-Maures	43.1381313	6.2355346
+location	La Marsa	36.8790882	10.327678
+location	La Matanza	-34.7332835	-58.3700599
+location	La Monnerie le Montel	45.8709833	3.6073529
+location	La Moutade	45.9661909	3.1603593
+location	La Nucia	38.6133727	-0.1257319
+location	La Palma	8.4038183	-78.141242
+location	La Paz County	33.77379054664268	-114.00207639793348
+location	La Penilla	43.3180686	-3.8813451
+location	La Penne-sur-Huveaune	43.2810535	5.515363
+location	La Peza	37.2755038	-3.2849172
+location	La Pintada	8.7154629	-80.56751178681893
+location	La Pintana	-33.591388550000005	-70.63642326010053
+location	La Plata	-34.9206797	-57.9537638
+location	La Pobla De Farnals	39.577785	-0.3264302
+location	La Pobla de Segur	42.2473665	0.9672725
+location	La Pobla de Vallbona	39.5907339	-0.5532185
+location	La Pobla Llarga	39.0854584	-0.4772459
+location	La Pobla Tornesa	40.1026879	-0.0014726
+location	La Pola De Gordon	42.8549855	-5.6725955
+location	La Revilla	43.3453253	-3.6940147
+location	La Robla	42.8029091	-5.6292227
+location	La Roca	42.3222717	2.3328249
+location	La Roca del Valles	41.5883381	2.3314594
+location	La Roche Bernard	47.5185354	-2.3014671
+location	La Roche Blanche	45.7085345	3.1276022
+location	La Roche Noire	45.7083	3.225
+location	La Roche-sur-Yon	46.6705431	-1.4269698
+location	La Rochelle	48.1776576	-2.5195222
+location	La Romana	38.3678386	-0.8961147
+location	La Salle County	28.3391148	-99.0982257
+location	La Selva de Mar	42.3241056	3.1868248
+location	La Selva del Camp	41.2145609	1.1377856
+location	La Serena	-29.902631	-71.2520253
+location	La Seu D'Urgell	42.3575723	1.4560067
+location	La Seyne-sur-Mer	43.1007714	5.8788948
+location	La Solana	38.941937	-3.236528
+location	La Suiza	9.853005	-83.6115748
+location	La Tour D Auvergne	45.1448265	5.724228051647891
+location	La Union	9.922919	-84.001485
+location	La Union CL	-40.2952392	-73.0820366
+location	La Union CO	5.951615800000001	-75.36359699712276
+location	La Union CR	9.9133715	-83.98392968999697
+location	La Union GT	14.9662736	-89.2904492
+location	La Vall D'en Bas	42.12501845	2.4356715864152942
+location	La Verde	-27.1304632	-59.3762738
+location	La Victoria	-6.795021	-79.8445606
+location	La Virgen del Camino	42.5816647	-5.6437418
+location	La Virreina	41.3823351	2.171480868779458
+location	La Zubia	37.1206862	-3.5850833
+location	Laa An Der Thaya	48.724723749999995	16.407176390998046
+location	Laakdal	51.081957	4.997449
+location	Laakirchen	47.9825598	13.8225156
+location	Labrea	-7.2613683	-64.7924505
+location	Lachar	37.1952099	-3.8340663
+location	Ladario	-19.0036585	-57.6028285
+location	Ladeuze	50.563047	3.768438
+location	Laengenfeld	47.073729	10.969964
+location	Lafayette County	42.662913	-90.134986
+location	Lafayette County MS	34.3519035	-89.4664677
+location	Lafayette County WI	42.6632391	-90.1317754
+location	Lafayette Parish	30.2141462	-92.0710624
+location	Lafeuillade en Vezie	44.7893536	2.4594014
+location	Lafourche Parish	29.5820155	-90.3964889
+location	Lagarto	-10.9141791	-37.6715308
+location	Lages	-27.8165664	-50.325883
+location	Lago Ranco	-40.22866535	-72.47840382545147
+location	Lagoa do Carro	-7.843834	-35.310783
+location	Lagoa Formosa	-18.7741896	-46.4082511
+location	Lagoa Grande	-8.9930649	-40.2716452
+location	Lagoa Santa	-19.6357376	-43.8966132
+location	Lagoa Vermelha	-28.2087034	-51.527499
+location	Lagow	52.3331186	15.2969511
+location	Laguna	-28.483118	-48.7811993
+location	Laguna Carapa	-22.5549233	-55.1505549
+location	Laguna De Negrillos	42.2397289	-5.6611973
+location	Laguna Paiva	-31.275412	-60.61846475843447
+location	Lahore	31.5656822	74.3141829
+location	Laje	-13.1809956	-39.4222968
+location	Laje do Muriae	-21.2082595	-42.1226959
+location	Lajeado	-29.4671522	-51.9624046
+location	Lajeado Grande	-26.8583425	-52.5666619
+location	Laka Prudnicka	50.31122	17.52841
+location	Lake County CA	39.071954	-122.739331
+location	Lake County IL	42.3327033	-87.9939552
+location	Lake County IN	41.4193829	-87.3692227
+location	Lake County MT	47.7142864	-114.1204325
+location	Lake County OH	41.7064789	-81.2380032
+location	Lake County OR	42.7702847	-120.4528326
+location	Lake Oswego	45.4206749	-122.6706498
+location	Laken	50.887688	4.353935
+location	Lakhimpur	27.985060150000002	80.75384538357649
+location	Lakonia	36.5296636	22.976579215613675
+location	Lakshmipur	22.9444179	90.827495
+location	Laktasi	44.9074664	17.3022887
+location	Lalin	42.6612	-8.1110
+location	Lalitpur	27.6676649	85.3183888179628
+location	Lamar County	33.6383552	-95.582343
+location	Lamb County	34.0321667	-102.3429233
+location	Lambach	48.0919647	13.8724131
+location	Lamballe	48.46244615	-2.516502292079859
+location	Lambare	-25.3455354	-57.6261456
+location	Lambayeque	-6.1898359	-79.9240312
+location	Lambinowice	50.5384423	17.5596387
+location	Lamine	50.688307	5.334720
+location	Lamontgie	45.4743272	3.3332332
+location	Lampa	-33.2864213	-70.8729771
+location	Lampasas County	31.1761363	-98.240563
+location	Lanaken	50.884429	5.634002
+location	Lanaudière	46.76678	-73.83248
+location	Lancaster County	40.7768326	-96.7111039
+location	Lancaster County NE	40.7768326	-96.7111039
+location	Lancaster County PA	40.08067	-76.2411283
+location	Lancaster County SC	34.6628067	-80.700546
+location	Lanco	-39.4522225	-72.7754222
+location	Landeck	47.1274736	10.555680223492256
+location	Landelies	50.377822	4.3496404
+location	Landen BE	50.75267	5.082
+location	Lander County	39.9059878	-116.9843374
+location	Landes	45.6643474	4.7783329
+location	Landgraaf	50.902456599999994	6.02931034376856
+location	Landquart	46.9661557	9.5567722
+location	Landskron	46.6336371	13.8872722
+location	Lane County OR	43.9314567	-122.8575849
+location	Langdorp	50.9934543	4.8697373
+location	Langemark	50.8996304	2.9406998
+location	Langemark-Poelkapelle	50.9122567	2.9338635
+location	Langenselbold	50.1780857	9.0433074
+location	Langkat	3.8290501	98.24827397454335
+location	Langlade County	45.2728122	-89.067113
+location	Langogne	44.7129345	3.79687902643736
+location	Langon	44.5530659	-0.2449274
+location	Langreo	43.2955423	-5.6839733
+location	Lanjaron	36.9181138	-3.4801561
+location	Lanklaar	51.018366238339176	5.726114042627846
+location	Lannilis	48.569633	-4.5215472
+location	Lannion	48.7322183	-3.4587994
+location	Lanús	-34.7033363	-58.3953235
+location	Lanzarote	29.03970805	-13.636291608604138
+location	Laon	49.564665	3.620686
+location	Lapa	-25.76709	-49.716777
+location	Lapachito	-27.1593809	-59.3854377
+location	Lapalisse	46.2488636	3.6324006
+location	Lapanow	49.8648601	20.2913672
+location	Lapino	55.2055779	36.2763394
+location	Laporte County	41.5718945	-86.7490124
+location	Laqueuille	45.6507627	2.7320917
+location	Lar do Patriota	-8.9519898	13.197779960108381
+location	Laranjal do Jari	-0.8419994	-52.516
+location	Laranjeiras	-10.8040231	-37.1658336
+location	Laranjeiras (Espirito Santo)	-20.648227	-41.4517391
+location	Laranjeiras (Sergipe)	-10.8040231	-37.1658336
+location	Laranjeiras do Sul	-25.4073197	-52.4150132
+location	Lardero	42.4272883	-2.4624393
+location	Laredo	43.41063	-3.4173
+location	Larimer County	40.6810174	-105.4726907
+location	Larino	41.8055672	14.9210984
+location	Larissa	39.6383092	22.4160706
+location	Laroquebrou	44.967739	2.1911658
+location	Larroude	-35.0259663	-63.5827254
+location	Las Breñas	-27.0863246	-61.0859456
+location	Las Condes	-33.4247879	-70.51749760753927
+location	Las Cumbres	9.047266	-79.660616
+location	Las Fraguas	43.193262	-4.0571328
+location	Las Gabias	37.13257725	-3.694362820083108
+location	Las Garzas	9.118082910248495	-79.26144944246062
+location	Las Lajas	-38.5235152	-70.3616347
+location	Las Lajas PA	8.540809664867663	-79.90930515286213
+location	Las Mañanitas	9.107966	-79.406759
+location	Las Ovejas	-36.9889752	-70.7495354
+location	Las Palmas	8.114568	-81.50352053030002
+location	Las Palmas de Gran Canaria	28.1009	-15.4654
+location	Las Palmas PA	8.1374273	-81.4565654
+location	Las Presillas	43.32513	-3.98076
+location	Las Rosas	-31.9697481	-60.9233512
+location	Las Rozas	40.0959741	-3.3535849
+location	Las Tablas	7.65163785	-80.31489041885015
+location	Las Talitas	-27.4405403	-65.1789772
+location	Las Varillas	-34.42226265	-58.85518230242946
+location	Las Vegas	36.1672559	-115.1485163
+location	Lasalle County	41.3474892	-88.9011861
+location	LaSalle County IL	41.3474892	-88.9011861
+location	Lask	51.5929947	19.1334784
+location	Laski	51.31463	19.56056
+location	Laskowiec	50.3823503	17.5765375
+location	Lasne	50.679575	4.463992
+location	Lassen County	40.7685579	-120.730998
+location	Lastenia	-26.866667	-65.15
+location	Latacunga	-0.931685	-78.605732
+location	Latah County	46.8171611	-116.693441
+location	Latchorzew	52.2456507	20.8581513
+location	Latur	18.35146855	76.7551212230513
+location	Lauderdale County	34.9049555	-87.6747398
+location	Laufen	47.4224096	7.5020019
+location	Laufenburg	47.5604617	8.0601696
+location	Launsdorf	46.7683161	14.4517409
+location	Laurel	8.4447431	-82.909004
+location	Laurens County SC	34.4646451	-81.9944042
+location	Lauro Muller	-28.3942244	-49.3975402
+location	Lausen	47.4736459	7.7591139
+location	Lautaro	-38.534312	-72.4350504
+location	Lauwe	50.7945667	3.1857233
+location	Lavaca County	29.3703333	-96.9334531
+location	Laval	48.0710377	-0.7723499
+location	Laviana	43.23204335	-5.547717886512423
+location	Lavras do Sul	-30.8118057	-53.8982856
+location	Lawrence County	34.4776367	-87.3017331
+location	Lawrence County AL	34.4776367	-87.3017331
+location	Lawrence County IL	38.7108998	-87.7194375
+location	Lawrence County PA	41.001415	-80.350071
+location	Laxmipur Sadar	22.9428644	90.9181638
+location	Laxou	48.6848709	6.1522232
+location	Layyah	30.964868	70.9455995
+location	Łaz	53.27511	21.00234
+location	Laziska	52.3331783	20.0875415
+location	Łańcut	50.069594949999995	22.233505598976215
+location	Le Breuil sur Couze	45.4680065	3.26417
+location	Le Cendre	45.7205658	3.1856364
+location	Le Chesnay	48.8278506	2.1319603
+location	Le Haillan	44.872105	-0.6761661
+location	Le Havre	49.4938975	0.1079732
+location	Le Lamentin	14.614557	-61.0018145
+location	Le Lorrain	14.8326715	-61.0554208
+location	Le Mans	48.0073796	0.1967599
+location	Le Mayet de Montagne	46.070171	3.6663495
+location	Le Mont Dore	45.5749966	2.8094117
+location	Le Mouret	46.7487136	7.1718165
+location	Le Muy	43.4713932	6.566111
+location	Le Pecq	48.8973	2.1064
+location	Le Port	-20.9354584	55.2916763
+location	Le Puy-en-Velay	45.0459739	3.8855537
+location	Le Roeulx	50.505667	4.104105
+location	Le Vernet	46.1084089	3.4626994
+location	Leba	54.7604388	17.531376945616415
+location	Lebanon County	40.375713	-76.4626118
+location	Lebbeke	51.0004013	4.1307711
+location	Lebork	54.5326494	17.744474748366954
+location	Lecce	40.354894	18.168455
+location	Lechow	50.8058501	20.9994606
+location	Leczna	51.3002941	22.886766
+location	Leczyca	52.1041727	21.0876719
+location	Leczyca (Łódzkie)	52.054506200000006	19.19828880034903
+location	Leczyca (Mazowieckie)	52.1041727	21.0876719
+location	Lede	50.9698619	3.987875782018607
+location	Ledeberg	51.0372053	3.7414088
+location	Ledegem	50.868978549999994	3.1176025915050873
+location	Ledzokuku-Krowor	5.60253895	-0.10819196029698519
+location	Lee County	41.7459056	-89.2888533
+location	Lee County AL	32.5814796	-85.3077038
+location	Lee County FL	26.5999265	-81.8823135
+location	Lee County IA	40.6524894	-91.507313
+location	Lee County IL	41.7459056	-89.2888533
+location	Lee County MS	34.265749	-88.6913264
+location	Lee County SC	34.1619217	-80.2539608
+location	Lee County TX	30.3031353	-96.9588587
+location	Leefdaal	50.847321	4.5913344
+location	Leek	53.1632327	6.377119
+location	Leernes	50.3974398	4.3307851
+location	Leers	50.6792095	3.2399516
+location	Leest	51.0350559	4.4150058
+location	Leffinge	51.1746761	2.8776766
+location	Leganés	40.3320	-3.7687
+location	Legionowo	52.4048356	20.933146571453094
+location	Legnica	51.204768900000005	16.174675034638256
+location	Legowo	54.2225333	18.646857
+location	Lehavim	31.3703233	34.8136886
+location	Lehigh County	40.6096215	-75.6048728
+location	Leiblachtal	47.55186295444749	9.760274369402639
+location	Leibnitz	46.7804762	15.5407005
+location	Leiden	52.1518157	4.4811088666204295
+location	Leioa	43.3271048	-2.9846079
+location	Leisele	50.9844835	2.622401
+location	Leitza	43.0806959	-1.9163064
+location	Leiva	42.5029174	-3.04658
+location	Lekarcice Stare	51.723194	20.9114685
+location	Lelystad	52.5150949	5.4768915
+location	Lembeek	50.7135392	4.2229681
+location	Leme	-22.1859721	-47.389764
+location	Lemhi County	44.9321886	-113.852998
+location	Lempdes	45.7727	3.19478
+location	Lempdes sur Allagnon	45.3853961	3.2691547
+location	Lenartov	49.3103365	21.0236233
+location	Lencois Paulista	-22.6029897	-48.8031367
+location	Lendelede	50.88542005	3.2311009715425536
+location	Lennik	50.8085632	4.1648626
+location	Lens	50.4291723	2.8319805
+location	Lens BE	50.5590928	3.9033334
+location	Lens FR	50.437993944238976	2.817782493480297
+location	Lenzing	47.9733296	13.6049039
+location	Leon	42.63414505	-5.971415104539984
+location	Leon County	31.2715127	-95.9953382
+location	Leopoldina	-21.5314282	-42.6403534
+location	Leopoldov	48.4441776	17.7654426
+location	Leopoldsburg	51.1220584	5.26393943423483
+location	Leotoing	45.3620828	3.2218838
+location	Les	42.8126916	0.7118311
+location	Les Ancizes Comps	45.9378694	2.792983946099338
+location	Les Bons Villers	50.52042405	4.463110137558774
+location	Les Borges Blanques	41.5203322	0.8684098
+location	Les Franqueses del Valles	41.64750335	2.30663056794073
+location	Les Iffs	48.2880565	-1.8667945
+location	Les Martres D'Artiere	45.8348671	3.2628298
+location	Les Martres de Veyre	45.6843764	3.1903821
+location	Les Martres sur Morge	45.9376791	3.2208867
+location	Les Masies de Voltrega	42.0267288	2.2347147
+location	Les Ponts-de-Cé	47.4286962	-0.5270662
+location	Les Preses	42.1450901	2.4592158
+location	Les Sables D'Olonne	46.5002031	-1.7924575344192666
+location	Les Useres	40.1573984	-0.164553
+location	Lesedi	-26.424185	28.656453171163257
+location	Lesiska	54.0570641	20.0071388
+location	Lesna	49.671311964247344	19.13781133083059
+location	Lesneven	48.5718493	-4.3235917
+location	Lesniow Maly	52.0053231	15.278039
+location	Lesno Gorne	53.5091596	14.5144056
+location	Lessines	50.710456	3.828368
+location	Lesvos	39.2074811	26.1342123
+location	Leszczyna	54.1181716	19.6262194
+location	Leszczynski	51.8500649	16.737710773395786
+location	Leszno	51.8436068	16.58042182076424
+location	Leticia	-4.212580	-69.943144
+location	Leudal	51.2339148	5.895853139985457
+location	Leut	50.9921542	5.7355102
+location	Leuven	50.876941	4.701994
+location	Levallois-Perret	48.8932	2.2879
+location	Levice	48.2163194	18.6000869
+location	Levoca	49.0251116	20.587999
+location	Levy County	29.3008632	-82.7824592
+location	Lewis and Clark County	47.2117026	-112.4768049
+location	Lewis County	43.7344277	-75.440289
+location	Lewis County ID	46.2651949	-116.4050453
+location	Lewis County MO	40.0902418	-91.7013355
+location	Lewis County NY	43.7344277	-75.440289
+location	Lewis County WA	46.5612011	-122.4225561
+location	Lexington County	33.8986841	-81.275054
+location	Leymen	47.4940419	7.4826921
+location	Lezajsk	50.265395749999996	22.42176054362956
+location	Lezoux	45.8281092	3.3805242
+location	Lezuza	38.9496	-2.3555
+location	Liano	43.3829224	-3.8396364
+location	Liberchies	50.5135682	4.420755
+location	Liberec	50.7702648	15.0583947
+location	Liberia	10.6333401	-85.4362722
+location	Libertador General San Martin	-23.8093358	-64.7921741
+location	Liberty County	30.0856736	-94.7856262
+location	Liberty County GA	31.8031632	-81.483441
+location	Liberty County MT	48.5608235	-111.0465825
+location	Liberty County TX	30.0856736	-94.7856262
+location	Libis	50.27444	14.502345
+location	Libochovice	50.4061126	14.044564
+location	Libolo	-10.0346332	14.6327886
+location	Licanten	-34.9856892	-71.9845873
+location	Lichinga	-13.2999118	35.2458642
+location	Lichnowy	53.6495767	17.6046553
+location	Lichtaart	51.2240538	4.9198927
+location	Lichtervelde	51.03017215	3.1418417778171865
+location	Licking County	40.1318041	-82.4627856
+location	Lidianopolis	-24.1073464	-51.6525676
+location	Lídice	8.7487532	-79.9087931
+location	Lidzbark	53.2628043	19.8231836
+location	Lidzbark Warminski	54.130586300000004	20.56491698491211
+location	Lidzbarski	54.105782399999995	20.427427993257282
+location	Liedekerke	50.86765469556411	4.091346204050425
+location	Liencres	43.4604709	-3.927618
+location	Lienz	46.82958615	12.750316209629112
+location	Liepvre	48.2730754	7.283351
+location	Lier	51.131069	4.5696516
+location	Lierganes	43.3457326	-3.7432184
+location	Liesek	49.3610205	19.6679205
+location	Liestal	47.4839723	7.7347783
+location	Lietavska Lucka	49.1755047	18.7224237
+location	Liezen	47.5070965	14.212568375549036
+location	Ligny	50.5126287	4.5757572
+location	Ligota Czamborowa	50.57361	18.18051
+location	Lilienfeld	47.9880551	15.529481416119136
+location	Lille	50.6365654	3.0635282
+location	Lille BE	51.238218	4.8242404
+location	Lille FR	50.6365654	3.0635282
+location	Lillois-Witterzée	50.644797	4.366948
+location	Lilongwe	-13.9875107	33.768144
+location	Lima	-12.0621065	-77.0365256
+location	Lima Campos	-4.5179809	-44.4671291
+location	Lima Puluh Kota	-0.0041436	100.55927144934105
+location	Limache	-33.0018741	-71.2657315
+location	Limanowa	49.7149918	20.423074222125905
+location	Limay	48.9921015	1.7353686
+location	Limbourg BE	50.613635	5.935911
+location	Limeira	-22.5615068	-47.401766
+location	Limelette	50.6805002	4.5731775
+location	Limerick City	52.648596049999995	-8.452318819134495
+location	Limestone County	31.5261854	-96.580617
+location	Limestone County AL	34.8342463	-86.9901321
+location	Limestone County TX	31.5261854	-96.580617
+location	Limkheda	22.8321862	73.9880696
+location	Limoges	45.8354243	1.2644847
+location	Limon	9.9951608	-83.0303724
+location	Limpio	-25.1736487	-57.4780665
+location	Linares	-35.8452905	-71.5977173
+location	Lincoln County	45.3265631	-89.7326216
+location	Lincoln County ID	43.0138672	-114.1650584
+location	Lincoln County MS	31.4885409	-90.4480916
+location	Lincoln County MT	48.5891095	-115.4911526
+location	Lincoln County NC	35.4866424	-81.2062724
+location	Lincoln County NM	33.7525727	-105.4158806
+location	Lincoln County OR	44.6201742	-123.9276915
+location	Lincoln County WA	47.5664588	-118.3588615
+location	Lincoln County WI	45.3265631	-89.7326216
+location	Lincoln Parish	32.598162	-92.6792848
+location	Linden	50.895349	4.7672872
+location	Lingolsheim	48.5559512	7.6817943
+location	Linha Nova	-29.467709	-51.2001125
+location	Linhares	-19.3816944	-40.0612213
+location	Linkebeek	50.7732003	4.3359991
+location	Linkhout	50.9657859	5.1372552
+location	Linn County	44.4968904	-122.5485977
+location	Linn County OR	44.4968904	-122.5485977
+location	Lins	-21.6741873	-49.7518932
+location	Lint	51.1268305	4.4922187
+location	Linter	50.818098	5.042221
+location	Linyola	41.7104501	0.9037626
+location	Linz	48.3059078	14.286198
+location	Linz-Land	48.2322391	14.3067516
+location	Lipiany	53.0035599	14.9697645
+location	Lipicze	51.42917	18.49039
+location	Lipinka	54.1226479	19.1230879
+location	Lipiny	52.75481	23.6246
+location	Lipka	53.49578	17.25017
+location	Lipljan	42.57643955	21.032371075473243
+location	Lipnik	49.7965863	20.0163512
+location	Lipno	50.7622222	16.745
+location	Lipnowski	52.8156762	19.1696988941429
+location	Lipova	49.2616548	21.4814297
+location	Lipowa	49.6748012	19.0940283
+location	Lippelo	51.041285	4.258686
+location	Lipscomb County	36.2695629	-100.2711772
+location	Lipsko	51.158513	21.6490099
+location	Liptovska Teplicka	48.9665599	20.089061
+location	Liptovsky Mikulas	49.0832482	19.6164972
+location	Lishui	28.460681	119.919147
+location	Lisiecice	50.2619374	17.8769631
+location	Lisieux	49.1460831	0.2255168
+location	Lisse	52.2540183	4.541928029675811
+location	Litchfield County	41.767249	-73.2543049
+location	Litomerice	50.5340795	14.1317985
+location	Litovel	49.7014789	17.0761064
+location	Little River Academy	30.9862937	-97.3586138
+location	Litueche	-34.1154229	-71.7296864
+location	Litvinov	50.6009532	13.6110485
+location	Livadeia	38.3312202	23.2555681
+location	Live Oak County	28.2678746	-98.101923
+location	Liverpool	53.407154	-2.991665
+location	Livingston County	42.80453775	-77.77145715002706
+location	Livingston County IL	40.8682487	-88.5631125
+location	Livingston County NY	42.7360902	-77.7781416
+location	Livingston Parish	30.463159	-90.743070
+location	Livov	49.2508036	21.0884714
+location	Livovska Huta	49.2439631	21.0329684
+location	Liwa	53.7516109	19.1085802
+location	Llagostera	41.8289064	2.8920386
+location	Llanars	42.3197051	2.3435638
+location	Llanca	42.3646215	3.1581373
+location	Llanera	43.442383	-5.8158063
+location	Llano County	30.6663312	-98.6970374
+location	Llano Grande	8.6389782	-80.4391763
+location	Llano Norte	8.634063637273321	-80.43974251104038
+location	Llanos de Santa Lucia	9.84811255	-83.88122915008321
+location	Lleida	41.6147605	0.6267842
+location	Llerona	41.648290599999996	2.2985436461011526
+location	Llica D'Amunt	41.6104867	2.2397066
+location	Lliça de Vall	41.5915542	2.2422403
+location	Llimiana	42.0750605	0.91585
+location	Llinars del Valles	41.6383547	2.4033771
+location	Llissa de Munt	41.6104867	2.2397066
+location	Llivia	42.4640786	1.9804293
+location	Llombai	39.2816214	-0.5731796
+location	Llorente	9.956165976053066	-84.06629844736024
+location	Lloret de Mar	41.6973503	2.8392392
+location	Llosa de Ranes	39.0185366	-0.5335879
+location	Llubi	39.6994	3.0063
+location	Llucena	40.1372729	-0.2808155
+location	Lluchmayor	39.4908	2.8917
+location	Llutxent	38.9421	-0.3554
+location	Lo Barnechea	-33.2935888	-70.39035501440654
+location	Lo de Fuentes	14.678455750000001	-90.53569795631799
+location	Lo Espejo	-33.5201685	-70.6897368284454
+location	Lo Prado	-33.44704385	-70.72339935540677
+location	Lo-Reninge	50.9928529	2.7918753
+location	Lobbes	50.35415555	4.238652470459903
+location	Lobez	53.6391189	15.6213487
+location	Lochovice	49.84228315	13.96652650825936
+location	Lochristi	51.097928350000004	3.835561373149549
+location	Lod	31.9489012	34.8884857
+location	Lodelinsart	50.430796660336036	4.447265702399177
+location	Lodosa	42.4241886	-2.0785646
+location	Lodwigowo	53.4696086	20.1192933
+location	Lodygowice	49.7304647	19.1403324
+location	Lodz	51.7687323	19.4569911
+location	Loenhout	51.3994474	4.6428328
+location	Lörrach	47.6120896	7.6607218
+location	Lörrach-Stetten	47.6018633	7.6591859
+location	Logan County	40.1075089	-89.3768539
+location	Logan County IL	40.1075089	-89.3768539
+location	Logrono	42.460541	-2.446303
+location	Lohra	50.736102	8.6348744
+location	Loire Atlantique	47.34816145	-1.8727461214619257
+location	Loja	37.1664839	-4.1496374
+location	Loja EC	-4.0094781077309865	-79.20700621741999
+location	Loja ES	37.1664839	-4.1496374
+location	Lokeren	51.1042159	3.9911114
+location	Loksbergen	50.9341079	5.0702987
+location	Lolol	-34.727836	-71.6440839
+location	Lomas de Zamora	-34.7612	-58.4302
+location	Lome	6.1306727	1.2179661
+location	Lometa	31.2170915	-98.3933268
+location	Lommel	51.223057	5.304938
+location	Lomnica	50.8933333	16.695
+location	Lomonosov	59.816012	29.3919784
+location	Łomża	53.18243065	22.052183817808846
+location	Loncin	50.665153	5.502732
+location	Loncoche	-39.370616	-72.6300704
+location	Loncopue	-38.0707995	-70.6148771
+location	Londerzeel	51.0122466	4.299072941633785
+location	London	51.497327	-0.118796
+location	Londrina	-23.3112878	-51.1595023
+location	Longjumeau	48.6931	2.2948
+location	Longues	45.6631524	3.2074733
+location	Lons le Saunier	46.6727037	5.5589973
+location	Lontras	-27.1679891	-49.5424602
+location	Lontzen	50.680409	6.0072347
+location	Loon	51.379197	5.443200
+location	Loon op Zand	51.625527	5.070262
+location	Loonbeek	50.8070345	4.6067572
+location	Lopon	49.9696094	20.7718261
+location	Loppem	51.139975750000005	3.18196243045658
+location	Lorain County	41.2633554	-82.1734746
+location	Loredo	43.46128	-3.71962
+location	Lorena	-22.7367652	-45.1070876
+location	Lorena BR	-22.7367652	-45.1070876
+location	Lorena SP	-22.7367652	-45.1070876
+location	Lorena TX	31.3865592	-97.2155596
+location	Lorient	47.7477336	-3.3660907
+location	Lorraine	48.5222144	6.917528
+location	Los Alamos County	35.8585475	-106.317166
+location	Los Algarrobos	8.08357405	-81.05296293681428
+location	Los Andes	-32.8336867	-70.5981609
+location	Los Angeles	-37.4707455	-72.351686
+location	Los Angeles County	34.029267	-118.242865
+location	Los Chiles	10.8572565	-84.71445358787409
+location	Los Corrales de Buelna	43.2619686	-4.0667653
+location	Los Guido	9.8683594	-84.0450907
+location	Los Lagos	-39.8634009	-72.8129655
+location	Los Lagos (Los Rios)	-39.8634009	-72.8129655
+location	Los Mochis	25.7928058	-108.990188
+location	Los Molinos	-33.1023459	-61.3259258
+location	Los Muermos	-41.3960568	-73.4617177
+location	Los Sauces	-33.4028183	-70.6900715
+location	Losenstein	47.924273	14.433111
+location	Losia Wolka	52.3666667	20.7141667
+location	Losieniec	51.6069446	18.654896
+location	Lot	50.7651699	4.2762018
+location	Lot BE	50.7659519	4.2733784
+location	Lot-Et-Garonne	44.3691703	0.45391575832487524
+location	Lot FR	44.624991800000004	1.6657742169753669
+location	Lota	-37.0944223	-73.1563622
+location	Lotenhulle	51.047900	3.465749
+location	Loubeyrat	45.9357694	3.0112633
+location	Loudoun County	39.0984586	-77.6705008
+location	Loumbila	12.5337651	-1.3849640638881864
+location	Louňovice	49.9822632	14.7617424
+location	Loupoigne	50.5976913	4.4424218
+location	Loures	38.8578642	-9.175816056948255
+location	Lourinha	39.246033100000005	-9.271338790806393
+location	Lousame	42.7655657	-8.8489519
+location	Lovendegem	51.100478	3.624891
+location	Lowndes County	32.1088066	-86.6402541
+location	Lowndes County AL	32.1088066	-86.6402541
+location	Lowndes County MS	33.4466925	-88.4108384
+location	Lozin	48.6608699	21.8365915
+location	Lozorno	48.3346371	17.0444471
+location	Łąka Prudnicka	50.31122	17.52841
+location	Lu'An	31.7383487	116.5142252
+location	Luanda	-8.8272699	13.2439512
+location	Lubango	-14.9191716	13.4896401
+location	Lubartow	51.45842245	22.6120935788813
+location	Lubawa	53.5005027	19.735448592924836
+location	Lubawka	50.7070882	16.0003894
+location	Lubbeek	50.880093	4.821901
+location	Lubbock County	33.5831241	-101.818598
+location	Lubianka	53.0991647	15.366971
+location	Lubienia	51.0245753	20.971489
+location	Lubieszewo	52.6706316	18.0784717
+location	Lubin	51.399678300000005	16.1993379441299
+location	Lubisa	49.0057438	21.9489461
+location	Lubkowo	54.04883	17.04533
+location	Lublin	51.218194499999996	22.554677565192677
+location	Lubniewice	52.5119594	15.2441003
+location	Lubnowo	54.2948291	19.9315657
+location	Lubnowy Male	53.7991518	19.3296477
+location	Lubnowy Wielkie	53.7844307	19.3340974
+location	Lubon	52.33884585	16.86973700391791
+location	Lubosz	52.53029	16.18494
+location	Lubów	52.3876565	14.9525089
+location	Lubowidz	53.117552950000004	19.845369062803073
+location	Lubrza	52.3071516	15.4411776
+location	Lubrza (Lubuskie)	52.3071516	15.4411776
+location	Lubrza (Wielkopolskie)	52.09760204807948	17.387962824879722
+location	Lubsko	51.7881902	14.9721266
+location	Lubuczewo	54.5361594	17.0731406
+location	Lucala	-9.4328932	14.8260767
+location	Lucas County	41.6508446	-83.621321
+location	Lucciana	42.5459392	9.4175597
+location	Lucena	-6.8984018	-34.8711915
+location	Lucena del Cid	40.1372729	-0.2808155
+location	Lucenec	48.3300774	19.6637435
+location	Lucera	41.5082727	15.3376465
+location	Lucito	41.731931	14.687228
+location	Lucknow	26.8381	80.9346001
+location	Luçon	46.45427517728182	-1.1647203563479258
+location	Luczyce	50.1594896	20.0787396
+location	Ludomki	52.7486111	16.8205556
+location	Ludwichowo	53.6185955	18.1624468
+location	Lufingen	47.48915935	8.592920004231086
+location	Lugano	46.0050102	8.9520281
+location	Lugo	43.0462247	-7.4739921
+location	Lugones	43.404341	-5.8120701
+location	Lugros	37.2296011	-3.2412578
+location	Luingne	50.737783	3.234058
+location	Luis Antonio	-21.55	-47.78008333333334
+location	Luiz Gomes	-5.7773301	-35.2698523
+location	Luján	-34.5661734	-59.1152598
+location	Lujan de Cuyo	-33.00308105	-68.8720247183036
+location	Lulinek	52.5689354	16.6978697
+location	Lummen	50.995516	5.181081
+location	Luna County	32.1345966	-107.7682754
+location	Lunglei	22.898553	92.75192291719874
+location	Lupionopolis	-22.7558205	-51.6575301
+location	Lupsingen	47.4466659	7.6938955
+location	Lupstych	53.7828036	20.3641032
+location	Luque	-25.2665417	-57.4926928
+location	Lusaka	-15.4164488	28.2821535
+location	Lusowo	52.4331671	16.6971054
+location	Lutise	49.2937547	18.9556005
+location	Lutomia Dolna	50.7593967	16.5392945
+location	Lutry	46.5032766	6.6867879
+location	Lutry CH	46.5032766	6.6867879
+location	Lutry PL	54.0094389	20.8979502
+location	Lutsk	50.7450733	25.320078
+location	Luttre	50.509069	4.391808
+location	Luxembourg	49.607806	6.130375
+location	Luya	-6.3569584	-78.0576782
+location	Luzern	47.0505452	8.3054682
+location	Luzillat	45.9460345	3.3888868
+location	Luzino	54.5618906	18.1047847
+location	Luzon	41.0265222	-2.2773363
+location	Lwowek	52.4489307	16.1803554
+location	Lwowek Slaski	51.1108891	15.5850018
+location	Lynn County	33.1474257	-101.812592
+location	Lyon	45.757870	4.841293
+location	Lyon County	38.9887898	-119.1822042
+location	Lysakowo	53.3570841	20.3181587
+location	Lyubertsy	55.6783142	37.89377
+location	Lyubinsky	55.156715	72.699005
+location	Lyz-Les-Lannoy	50.673310351294035	3.2175693006103923
+location	L’alcora	40.0744223	-0.2138589
+location	L’Eliana	39.5659086	-0.5302784
+location	Maale-Edumim	31.7705643	35.2987457
+location	Maale Iron	32.5494975	35.15448566167521
+location	Maalot Tarshicha	33.0150	35.2760
+location	Maarssen	52.1384846	5.040082
+location	Maasgouw	51.1577134	5.894547348825503
+location	Maasmechelen	50.9635024	5.696445
+location	Maastricht	50.85798545	5.6969881818221095
+location	Mabu'Im	31.4492727	34.6547505
+location	Macachín	-37.1383719	-63.66658565290297
+location	Macaé	-22.3712958	-41.7866922
+location	Macael	37.3309751	-2.3024387
+location	Macaiba	-5.8561372	-35.3523774
+location	Macanet de la Selva	41.7774442	2.7309225
+location	Macapá	0.0401529	-51.0569588
+location	Macara	-4.3490568	-79.91614162495434
+location	Macas	-2.3046252	-78.1175466
+location	Macatuba	-22.50022	-48.710229
+location	Macchia D'Isernia	41.561624	14.167119
+location	Macchiagodena	41.559826	14.407824
+location	Maceio	-9.586654	-35.721537
+location	Machagai	-26.92930105	-60.05823272462102
+location	Machala	-3.262571666551047	-79.95848682428372
+location	Machali	-34.182453	-70.6511584
+location	Machelen	50.903182	4.444013
+location	Macon	46.299425	4.822063
+location	Macon County	39.8455208	-88.9602376
+location	Macon County AL	32.366606	-85.6660307
+location	Macon County IL	39.8455208	-88.9602376
+location	Macoupin County	39.2420653	-89.925212
+location	Macouria	5.0130354	-52.4744678
+location	Macuco	-21.9849747	-42.2539464
+location	Macul	-33.49194265	-70.59973215756841
+location	Madampe	7.4954162	79.8413815
+location	Madaripur	23.1675473	90.2049733
+location	Madera County	37.1716264	-119.7737991
+location	Madhukhali	23.5434411	89.6255061
+location	Madison	43.062839	-89.448317
+location	Madison County	43.7740801	-111.6304151
+location	Madison County AL	34.7736807	-86.5675095
+location	Madison County ID	43.7740801	-111.6304151
+location	Madison County IL	38.811063	-89.9017112
+location	Madison County MS	32.6308318	-90.0040817
+location	Madison County MT	45.2963203	-111.8930287
+location	Madison County NY	42.875882	-75.6802581
+location	Madison County TX	30.9551586	-95.9507234
+location	Madison CT	41.356100	-72.642246
+location	Madison Parish	32.3614697	-91.255051
+location	Madre de Deus	-12.7424741	-38.6152913
+location	Madrid	40.444140	-3.680235
+location	Madrid CO	4.734291	-74.262272
+location	Madrigueras	39.2367	-1.8001
+location	Madronera	39.4253942	-5.757169
+location	Madunice	48.4779835	17.7808815
+location	Madurai	9.9261153	78.1140983
+location	Maffe	50.3537887	5.3115516
+location	Maffle	50.61733955	3.800246476043756
+location	Mafil	-39.6659792	-72.9521276
+location	Mafra	38.9369782	-9.3282374
+location	Mafra BR	-26.1150943	-49.8035982
+location	Mafra PT	38.9369782	-9.3282374
+location	Magadan	59.5604768	150.7988617
+location	Magden	47.5283737	7.8116008
+location	Mage	-22.6604221	-43.0426162
+location	Maggiolo	-33.7237065	-62.2465621
+location	Magnesia	39.30122565	23.035284886790997
+location	Magura	23.488333	89.42
+location	Mahajanga	-15.7181492	46.3172577
+location	Maharagama	6.8472783	79.9266082
+location	Mahasamund	21.1882332	82.48484762499999
+location	Mahboobnagar	17.7203392	79.6280587
+location	Mahbubnagar	16.7434538	77.9923191
+location	Mahebourg	-20.4111041	57.7060616
+location	Mahemdavad	22.8256	72.7571
+location	Mahesana	23.6015557	72.3867981
+location	Mahisagar	23.1916967	73.6626352964019
+location	Mahiyangana	7.3207383	80.9908898
+location	Mahon	39.9148	4.2231
+location	Mahoning County	40.9830133	-80.7826416
+location	Mahuva	21.0914409	71.7621979
+location	Maianga	-8.8267755	13.2303908
+location	Maicao	11.4048743	-72.31316022980582
+location	Maine Et Loir	47.6899508	-0.1643039
+location	Maine Et Loire	47.38863045	-0.3909097146387368
+location	Maintal	50.143872	8.8371444
+location	Mainz	50.0012314	8.2762513
+location	Maipu	-33.5094409	-70.756182
+location	Maipu AR	-32.965942850000005	-68.79347072773086
+location	Mairena Aljarafe	37.347290	-6.052941
+location	Mairinque	-23.5401247	-47.1846323
+location	Mairipora	-23.3186111	-46.5866667
+location	Maisons Alfort	48.8012045	2.4309703
+location	Maizières Les Metz	49.210252	6.1600345
+location	Majadahonda	40.473055	-3.8724138
+location	Majdal Bani Fadil	32.083611	35.362778
+location	Makassar	-5.1342962	119.4124282
+location	Makati City	14.5567949	121.0211226
+location	Makhachkala	42.9830241	47.5048717
+location	Mala Kamienica	50.9109873	15.5449186
+location	Malá nad Hronom	47.8547884	18.6795793
+location	Mala Trna	48.4541461	21.6818295
+location	Malaba	0.632706	34.269398
+location	Malabo	3.752828	8.780061
+location	Malacatancito	15.23788995	-91.49703810339342
+location	Malacky	48.4347503	17.020348
+location	Malaga	36.718690	-4.432799
+location	Malagon	39.1688771	-3.8512824
+location	Malargue	-35.4752134	-69.585934
+location	Malatina	49.185823	19.4324205
+location	Malauzat	45.8481	3.0542
+location	Malbork	54.0287383	19.039396385383558
+location	Malčice	48.5787381	21.8515883
+location	Malcov	49.3040576	21.057481
+location	Malda	25.0057449	88.1398483
+location	Maldegem	51.197062	3.450921
+location	Maldyty	53.9203373	19.741694
+location	Malerzowice Wielkie	50.58294	17.49461
+location	Malewicze Gorne	53.4008735	23.6112554
+location	Malgrat de Mar	41.6459118	2.7414054
+location	Malheur County	43.1023481	-117.6916892
+location	Maliano	43.41845	-3.83623
+location	Maligawatta	6.935291149999999	79.8721047873205
+location	Malinau	2.6185545	115.69049695186618
+location	Malinová	50.0478149	13.6669222
+location	Malinovo	48.1531521	17.2936692
+location	Malintrat	45.8129661	3.1875698
+location	Mallabia	43.1895207	-2.5298369
+location	Malle	51.304141	4.715731
+location	Malmedy	50.4265348	6.0276059
+location	Maloszow	50.4166667	20.15
+location	Malpartida de Plasencia	39.9811621	-6.0437752
+location	Malsar	21.8897035	73.3114051
+location	Malujowice	50.8474841	17.3809892
+location	Malvinas Argentinas	-37.9626549	-57.5915446
+location	Maly Cepcin	48.9027596	18.8391483
+location	Maly Krtis	48.1896389	19.35296
+location	Maly Lapas	48.306185850000006	18.17019433587574
+location	Mamoudzou	-12.7805856	45.2279908
+location	Mamuju	-2.6757443	118.8885839
+location	Mana	48.154395	18.2867476
+location	Manacapuru	-3.2996768	-60.6213528
+location	Manacor	39.5697	3.2095
+location	Manado	1.487271	124.842838
+location	Manage	50.49373705	4.2432909165236055
+location	Manah	22.7903348	57.6096159
+location	Manama	26.2235041	50.5822436
+location	Mananitas	9.083986	-79.3978291
+location	Manaquiri	-3.4305885	-60.4593078
+location	Manati	18.4271372	-66.4929477
+location	Manaus	-3.126424	-60.019807
+location	Mancherial	18.8761795	79.4449696
+location	Manchester	41.7759	-72.5215
+location	Mandaguari	-23.5224849	-51.6787511
+location	Mandailing	3.3224455	99.1298137
+location	Mandsaur	24.077683	75.067604
+location	Mandvi	21.254369	73.303536
+location	Manfredonia	41.6254728	15.9095926
+location	Mangalore	12.8698101	74.8430082
+location	Mangaratiba	-22.9600193	-44.04111
+location	Mangrol	21.575642	72.8565391
+location	Mangueira	-16.6017274	-49.2617098
+location	Mangueirinha	-25.9412009	-52.1740852
+location	Manhattan	40.778542	-73.969920
+location	Manhuacu	-20.2574434	-42.0340769
+location	Manicoré	-5.804618	-61.289483
+location	Maniewo	52.59461	16.86322
+location	Manikganj	23.871163	89.9987833
+location	Manila City	14.5907332	120.9809674
+location	Manises	39.492989	-0.4621429
+location	Manitowoc County	44.0998341	-87.827992
+location	Manizales	5.058776	-75.498753
+location	Manlleu	41.9999811	2.2841159
+location	Mannekensvere	51.1258003	2.8183418
+location	Mannheim	49.489591	8.467236
+location	Manning	48.07126875	13.662845949249277
+location	Manosque	43.8338026	5.7826657
+location	Manresa	41.7288939	1.8286765
+location	Mansa	23.428814	72.656249
+location	Mansa IN	23.425103	72.6583024
+location	Mansa ZM	-11.2006743	28.8893922
+location	Mansilla Mayor	42.5093156	-5.4436183
+location	Manta	-1.0321775	-80.82221666609834
+location	Mantes-la-Jolie	48.9891971	1.7140683
+location	Manzat	45.9615586	2.9406189
+location	Mao	39.8894819	4.2661641
+location	Maputo City	-25.9710058	32.5644748
+location	Mar del Plata	-37.9977225	-57.5482703
+location	Marabá	-5.3462821	-49.1007401
+location	Maracai	-22.6112679	-50.6670685
+location	Maracaju	-21.6163005	-55.164605
+location	Maracana	-0.7666582	-47.4537818
+location	Maracanau	-3.8779438	-38.6247697
+location	Maracena	37.2079	-3.6329
+location	Maragogi	-9.0118278	-35.222512
+location	Marange Silvange	49.2160771	6.1164164
+location	Marapoama	-21.2574769	-49.1314719
+location	Marataizes	-21.0443673	-40.8272204
+location	Marathon County	44.8914036	-89.7748098
+location	Marau	-28.4493053	-52.2002156
+location	Marbach SG	47.3919868	9.5686092
+location	Marcelino Vieira	-6.2938597	-38.1622228
+location	Marcelova	47.7912423	18.2839913
+location	Marchal	37.2963627	-3.2021995
+location	Marchamalo	40.6688655	-3.2021136
+location	Marchfeld	48.268050099999996	16.71917628959887
+location	Marchienne-au-Pont	50.40897075	4.40234038367136
+location	Marchtrenk	48.1907992	14.1117625
+location	Marcinelle	50.394727	4.427537
+location	Marciszow	50.8521325	16.0088241
+location	Marcos Juarez	-34.9005082	-58.5668469
+location	Marcq	50.6903571	4.0173479
+location	Marechal Candido Rondon	-24.5582532	-54.0587821
+location	Marechal Deodoro	-9.709715	-35.896731
+location	Maria Chiquita	9.4422956	-79.7526862
+location	Mariakerke	51.072918	3.680642
+location	Mariana	-20.3781468	-43.4174862
+location	Mariano Roque Alonso	-25.210867	-57.532031
+location	Mariazell	47.7717395	15.3174781
+location	Marica	-5.1280488	-42.8331206
+location	Marica (Maranhão)	-8.00195277894477	-34.8866844168472
+location	Marica (Rio de Janeiro)	-22.917535280952503	-42.81950517495139
+location	Maricopa County	33.34883	-112.49123
+location	Marignane	43.4162729	5.2146275
+location	Marijampole	54.5562536	23.3503665
+location	Marilia	-22.217108	-49.95006
+location	Marilles	50.7072943	4.9529173
+location	Marin County	38.077277	-122.719060
+location	Marina de Cudeyo	43.4195639	-3.749259321692027
+location	Marinette County	45.3834983	-88.0409574
+location	Maringa	-23.425269	-51.9382078
+location	Maringues	45.9210457	3.328959
+location	Marinilla	6.1781321	-75.30746437196609
+location	Marion County	44.924528	-122.798248
+location	Marion County AL	34.1128132	-87.8544031
+location	Marion County FL	29.2182454	-82.0626948
+location	Marion County IL	38.6477381	-88.9232112
+location	Marion County IN	39.7810289	-86.1365457
+location	Marion County MO	39.8080573	-91.6318781
+location	Marion County MS	31.2247688	-89.8217717
+location	Marion County OH	40.5885271	-83.1895249
+location	Marion County OR	44.8964425	-122.7203248
+location	Marion County SC	34.0572007	-79.3987578
+location	Marion County TX	32.7931661	-94.344488
+location	Maripasoula	3.643385087483412	-54.03331837441771
+location	Mariposa County	37.570148	-119.9036592
+location	Mariquina	-39.497403	-73.04271375277717
+location	Marizopolis	-6.8440704	-38.3473088
+location	Marke	50.8070452	3.2336226
+location	Marken	52.4578746	5.1068263
+location	Marki	52.336375200000006	21.12071915152803
+location	Markt Piesting	47.865336	16.112727215644977
+location	Marlboro County	34.5810346	-79.6742033
+location	Marlin	31.3076024	-96.8923535
+location	Marmande	44.5007939	0.164274
+location	Marquette County	43.8122244	-89.3926785
+location	Marquette County MI	46.4481521	-87.6305899
+location	Marquette County WI	43.8122244	-89.3926785
+location	Marracuene	-25.7301368	32.65863466179495
+location	Marratxí	39.6272	2.7572
+location	Marsat	45.8772222	3.0825
+location	Marseille	43.2961743	5.3699525
+location	Marshall	43.167355	-89.066568
+location	Marshall County	34.3396046	-86.3301801
+location	Marshall County AL	34.3396046	-86.3301801
+location	Marshall County IL	41.0324537	-89.2998456
+location	Marshall County MS	34.7329208	-89.4725635
+location	Marshall County TN	35.4814932	-86.7711675
+location	Marszowice	50.1811429	20.0936447
+location	Mart	31.5423911	-96.8336015
+location	Martigues	43.4057279	5.0548176
+location	Martin	49.0724921	18.929193
+location	Martina Franca	40.7042378	17.3399908
+location	Martincek	49.091788	19.3368052
+location	Martinopolis	-22.146153	-51.170949
+location	Martinova	48.2982116	20.1713644
+location	Martires	-8.8411802	13.2367468
+location	Martires Kifangondo	-8.8411802	13.2367468
+location	Martorelles	41.52851	2.2374755
+location	Marumbi	-23.7070343	-51.6408276
+location	Maryanovka	54.960659	72.637947
+location	Marynowy	54.17084	19.09458
+location	Masarac	42.3509939	2.9723618
+location	Maskovce	49.02358615	21.99419712101821
+location	Maslow Pierwszy	50.90319	20.7280294
+location	Mason County	47.4251	-123.1951
+location	Mason County IL	40.2302271	-89.8660433
+location	Mason County WA	47.3429635	-123.1822758
+location	Masquefa	41.5026351	1.8110722
+location	Massa di Somma	40.8476313	14.3743024
+location	Massac County	37.2177417	-88.7163312
+location	Massalaves	39.1437319	-0.523232
+location	Massalfassar	39.5579365	-0.3258587
+location	Massama	38.75563785	-9.28189049097309
+location	Massamagrell	39.5703995	-0.3302101
+location	Massanassa	39.4108561	-0.4000846
+location	Massanes	41.7654696	2.6528719
+location	Massemen	50.9809343	3.8735741
+location	Massenhoven	51.1990199	4.6349603
+location	Masunga	-20.620707	27.445115
+location	Mat-Su	61.382704	-150.251175
+location	Mata	43.27942	-4.03024
+location	Matadepera	41.6012311	2.0275199
+location	Matagorda County	28.8879823	-96.0035095
+location	Matamoros	25.8520977	-97.5017951
+location	Matamorosa	42.9811686	-4.1487879
+location	Matanuska-Susitna Valley	62.3402481	-149.4793288
+location	Matao	-21.6033611	-48.3660603
+location	Mataquescuintla	14.5273599	-90.188602
+location	Mataram	-8.5837726	116.10685
+location	Mataro	41.5398348	2.4448926
+location	Mateiros	-10.5462254	-46.417423
+location	Mateo Iturralde	9.032976446684449	-79.49611275876926
+location	Matera	40.447641899999994	16.47357384028852
+location	Mateur	37.0385985	9.6676974
+location	Matina	10.009750749999998	-83.33949719306517
+location	Matki	53.8350372	20.3450702
+location	Matoury	4.8496712	-52.3268695
+location	Matrei am Brenner	47.128405	11.452845
+location	Matriz de Camaragibe	-9.154373	-35.524302
+location	Mattersburg	47.7368423	16.3980488
+location	Matzikama	-31.575081409878294	18.566338958032276
+location	Matzingen	47.5199826	8.934077
+location	Maua	-23.664006	-46.442663
+location	Maués	-3.3795798	-57.7196072
+location	Maui County	20.7580586	-156.3105232
+location	Maule	-35.521347	-71.6918891
+location	Maullin	-41.6160139	-73.5950711
+location	Maurage	50.455601	4.099269
+location	Maury County	35.6285992	-87.0736684
+location	Mavalane	-25.932045	32.5850819
+location	Maxent	47.9823348	-2.0331515
+location	Maxeville	48.7119046	6.1641314
+location	Máximo Paz	-34.9370091	-58.6192087
+location	Maxixe	-23.86996285	35.310326824828735
+location	Mayaguez	18.2011161	-67.1391124
+location	Mayenne	48.1507819	-0.6491273812007092
+location	Maykop	44.6062079	40.104053
+location	Mayrhofen	47.163296	11.862115
+location	Mazan	44.0565965	5.1281078
+location	Mazancowice	49.8597451	18.9907737
+location	Mazatlan	23.2313053	-106.4153144
+location	Mazcuerras	43.29764	-4.20947
+location	Mazet-Saint-Voy	45.0471901	4.2447342
+location	Maziarze Stare	51.1322752	21.3006443
+location	Mbao	14.7299	-17.3258
+location	Mbini	1.577253	9.7832297
+location	Mbour	14.411794	-16.9657124
+location	McCone County	47.5823259	-105.8467942
+location	McCormick County	33.8795325	-82.2797719
+location	Mccracken County	37.0335839	-88.7107201
+location	McCulloch County	31.1699604	-99.3885277
+location	McDonough County	40.4376858	-90.6780272
+location	McHenry County	42.3294391	-88.4605713
+location	Mckinley County	35.6438394	-108.1515609
+location	McLean County IL	40.4631789	-88.8196613
+location	Mclennan County	31.5487691	-97.2189254
+location	McMinn County	35.444223	-84.624875
+location	Meagher County	46.6305891	-110.8988278
+location	Meaux	48.9582708	2.8773541
+location	Mechelen-aan-de-Maas	50.9764002	5.645665449842765
+location	Mecklenburg County	35.2356385	-80.8139485
+location	Mecklenburg County NC	35.2356385	-80.8139485
+location	Meco	40.553746	-3.3281561
+location	Medan	3.5896654	98.6738261
+location	Medellin	6.254779	-75.578125
+location	Medford	42.3264181	-122.8718605
+location	Medianeira	-25.2954233	-54.0940666
+location	Medina County OH	41.1000764	-81.9382517
+location	Medina County TX	29.2836281	-99.1126826
+location	Medjugorje	43.1905339	17.6775328
+location	Medrano	42.3828173	-2.5538784
+location	Medvedzie	49.3417948	19.53357086713877
+location	Medvezhyegorsk	62.915024	34.473339
+location	Medzilaborce	49.2711323	21.9039645
+location	Meensel-Kiezegem	50.8966808	4.9167699
+location	Meer	51.4471565	4.7390521
+location	Meerbeek	50.8825784	4.58593
+location	Meerbeke	50.81972985	4.0458501718007795
+location	Meerhout	51.1317433	5.0772388
+location	Meerle	51.4743516	4.8051679
+location	Meerssen	50.904709	5.735147732240853
+location	Meerstad	53.2238933	6.657085110466282
+location	Meeuwen	51.0979038	5.5193526
+location	Meeuwen-Gruitrode	51.0979038	5.5193526
+location	Meggen	47.0470746	8.3733992
+location	Mehsana	23.601262849999998	72.37415155167554
+location	Mehun sur Yevre	47.1462117	2.2214381
+location	Meise	50.9341625	4.3287322
+location	Meizhou	24.212443	116.104148
+location	Mejillones	-23.1002342	-70.4483076
+location	Melbourne	-37.839042	145.076343
+location	Meldert	50.7881599	4.8372377
+location	Melesse	48.2175823	-1.6962403
+location	Meliana	39.5286	-0.3478
+location	Mélin	50.7400918	4.8286208
+location	Melipilla	-33.6855134	-71.2145796
+location	Melk	48.1472806	15.2642089
+location	Melle	51.00303	3.7988833
+location	Mellet	50.503949	4.480401
+location	Mels	47.0467333	9.4192932
+location	Melsbroek	50.9170725	4.4758811
+location	Melsele	51.2211394	4.2821446
+location	Meltingen	47.3877576	7.5898528
+location	Membach	50.618449	5.994495
+location	Menard County IL	40.0166667	-89.7858065
+location	Menarguens	41.7300771	0.7438658
+location	Menat	46.1038476	2.9047921
+location	Mendaro	43.2525004	-2.3858392
+location	Mendes	-22.5269113	-43.7332604
+location	Mendes Pimentel	-18.6611641	-41.4020716
+location	Mendillorri	42.8106542	-1.623558
+location	Mendocino County	39.3176491	-123.4126399
+location	Mendonca	-21.1838813	-49.579059
+location	Mendoza	-32.8894155	-68.8446177
+location	Menen	50.7937353	3.167040611100269
+location	Menetrol	45.8725	3.125
+location	Menominee County	45.0154357	-88.7089153
+location	Menorca	39.9496	4.1104
+location	Mentawai	-0.5941681	100.1679253
+location	Meppel	52.711744350000004	6.197307325163717
+location	Mequon	43.226666	-87.973033
+location	Meran	46.6695547	11.1594185
+location	Merangin	-2.1811376	101.637826
+location	Merced County	37.1641544	-120.7678602
+location	Mercedes	10.0231317	-84.0501518
+location	Mercer County	41.2019729	-90.7398717
+location	Mercer County IL	41.2019729	-90.7398717
+location	Mercer County NJ	40.2807177	-74.7033717
+location	Mercer County OH	40.4367866	-84.6109122
+location	Mercer Island	47.5602073	-122.22014226861951
+location	Merchtem	50.9591981	4.2327769
+location	Merelbeke	50.9945	3.7456
+location	Meriden	41.539616	-72.794843
+location	Meridiano	-20.3547223	-50.172574
+location	Merignac	44.8422361	-0.6469599
+location	Merksem	51.2438894	4.4397179
+location	Merksplas	51.3580597	4.8627541
+location	Merlischachen	47.0655534	8.4071994
+location	Merlo	-34.6604988	-58.7321695
+location	Meruelo	43.4442752	-3.582411776463331
+location	Mesa County	39.0589084	-108.565996
+location	Mesía	43.1034876	-8.2273808
+location	Mesquita	-22.783092	-43.4293599
+location	Messeix	45.6155014	2.5403548
+location	Messelbroek	50.9952269	4.9385703
+location	Messias Targino	-6.0772948	-37.511712
+location	Messina	38.1937571	15.5542082
+location	Meta	3.297576	-73.053515
+location	Metan	-25.4971644	-64.9709701
+location	Meteti	8.5151878	-77.9417372
+location	Mettet	50.3212094	4.6584949
+location	Metz	49.1196964	6.1763552
+location	Metzerlen	47.4659714	7.4658445
+location	Meudon la Forêt	48.787126	2.227098
+location	Meulebeke	50.94856695	3.2860508081312485
+location	Meuse	49.01296845	5.428669076639772
+location	Mevaseret Tzion	31.80108502978225	35.14980100278765
+location	Mevo Horon	31.8501774	35.0354628
+location	Mexicali	32.6248622	-115.448325
+location	Meyenheim	47.9140437	7.3528308
+location	Miajadas	39.1501902	-5.9090558
+location	Miami	25.760439	-80.206459
+location	Miami-Dade County	25.6364246	-80.4989467
+location	Miami Gardens	25.9420377	-80.2456045
+location	Miami Platja	41.010183	0.9378257
+location	Miaty	52.53533	17.79776
+location	Michal nad Zitavou	48.1845316	18.2828845
+location	Michalki	53.6511665	20.7595838
+location	Michalova	48.7626694	19.7778938
+location	Michalovce	48.7514383	21.9211949
+location	Michalow	50.4900096	20.456102
+location	Michalowice	50.1603193	19.9801697
+location	Micigozd	50.8985745	20.458752
+location	Middelburg	51.4997302	3.6136962
+location	Middelburg BE	51.2557439	3.4148228
+location	Middelburg NL	51.4997302	3.6136962
+location	Middelkerke	51.183316950000005	2.806352008124807
+location	Middleburg	-31.503308617977982	25.002808709164615
+location	Middlesex County	42.485452	-71.3968261
+location	Middlesex County CT	41.4510811	-72.5528113
+location	Middlesex County MA	42.485452	-71.3968261
+location	Middlesex County NJ	40.4279708	-74.3963102
+location	Middleton	43.105596	-89.509368
+location	Midland County MI	43.634525	-84.3840821
+location	Midland County TX	31.83688	-102.0103767
+location	Midvaal	-26.629495	28.08942685185185
+location	Midwolda	53.1949605	7.012555
+location	Midwoud	52.7184236	5.0758874
+location	Miechow	50.3566016	20.0276912
+location	Miedniewice	52.0838449	20.3024898
+location	Miedzyborz	51.397711	17.6650165
+location	Miedzychod	52.6046468	15.8935386
+location	Miedzylesie	52.2063738	21.1751597
+location	Miedzyrzecz	52.43638	15.56926966359266
+location	Miedzyrzecze Dolne	49.8542389	18.9422338
+location	Miedzyrzecze Gorne	49.8422559	18.9406155
+location	Miedzywodzie	54.0068476	14.6953599
+location	Mielec	50.280247349999996	21.46313425491699
+location	Mielno	54.2590065	16.0539997
+location	Miengo	43.4306997	-4.0000308
+location	Mieres	43.234995749999996	-5.769931957999365
+location	Mierki	53.5852067	20.3243613
+location	Mierzyn	53.4304584	14.4652479
+location	Miguel Egas	0.2315084	-78.2648169
+location	Miguel Pereira	-22.4539417	-43.4691978
+location	Miguelturra	38.9648147	-3.8898604
+location	Mijdrecht	52.2060181	4.8648168
+location	Mikhalevo	56.99046942207534	40.78544769773125
+location	Miklesz	51.4073096	18.6421852
+location	Mikolajki Pomorskie	53.8506181	19.1658001
+location	Mikowice	50.4414852	16.6056805
+location	Milaczew	52.3917421	18.1038223
+location	Milaczewek	51.9381375	18.4338374
+location	Milagres	-7.3106846	-38.9447146
+location	Milagro	-1.049376	-79.643679
+location	Milakowo	54.0101675	20.0711213
+location	Milam County	30.7626867	-96.9981706
+location	Milan	45.474	9.177
+location	Milanowek	52.1237468	20.66934425925369
+location	Milejów-Osada	51.2229727	22.9226977
+location	Milford	41.2307	-73.0640
+location	Milha	-5.6834601	-39.1970885
+location	Milheeze	51.51711345	5.7912856850085275
+location	Millau	44.1006693	3.0777594
+location	Millen	50.78487592829171	5.556110272676037
+location	Milnerton	-33.871201766733314	18.515420188107576
+location	Miloradz	54.01432	18.91803
+location	Miloslavov	48.0990612	17.3014502
+location	Milow	52.0856131	14.8484241
+location	Milwaukee County	43.008019	-87.937899
+location	Mimoso do Sul	-21.0628724	-41.3640478
+location	Minas	-38.9712949	-68.0266721
+location	Minderhout	51.4174934	4.7636002
+location	Mineiros do Tiete	-22.4133188	-48.450554
+location	Mineral County	38.4815162	-118.498262
+location	Mineral County MT	47.1330265	-114.9202341
+location	Mineral County NV	38.4815162	-118.498262
+location	Mingogil	38.4609	-1.7411
+location	Minnehaha County	43.6680284	-96.7837626
+location	Minsk Mazowiecki	52.17959585	21.56945595388331
+location	Mira Estrela	-19.9806298	-50.136873
+location	Mira-Sol	41.46911225	2.062468978333334
+location	Miracema	-21.4123651	-42.1965147
+location	Miracema do Tocantins	-9.5617939	-48.3966536
+location	Miralcamp	41.6049685	0.8801705
+location	Miramar	25.9861	-80.3036
+location	Miramar AN	-8.8093346	13.2490368
+location	Miramar AO	-8.8093346	13.2490368
+location	Miramar ES	38.950734883088124	-0.14098684172177312
+location	Miranda	-20.2405943	-56.3770344
+location	Miranda do Norte	-3.5653459	-44.5809128
+location	Mirandopolis	-21.1328313	-51.1029422
+location	Mirante do Paranapanema	-22.2925861	-51.907143
+location	Mirassol	-20.8141411	-49.507449
+location	Mirassolandia	-20.6147204	-49.462817
+location	Mirefleurs	45.6938269	3.2240835
+location	Miremont	45.8993557	2.7140485
+location	Miroslawiec	53.34171	16.09094
+location	Mirpur	23.8223	90.3654
+location	Mirzapur	24.9356347	82.64770129811649
+location	Mirzec	51.1362408	21.0570374
+location	Mislata	39.4751444	-0.4179125
+location	Missoula County	46.9653891	-113.9232612
+location	Mistelbach	48.5694535	16.5720327
+location	Mitchells Plain	-34.050556	18.618056
+location	Mitu	1.2523268	-70.2308883
+location	Mixco	14.6307175	-90.6061595
+location	Międzyzdroje	53.9282745	14.448903
+location	Mladá Boleslav	50.414296	14.913877
+location	Mlynek	51.0352046	21.1978587
+location	Mmathethe	-25.319968	25.271216
+location	Mniow	51.0121708	20.4857784
+location	Mobile County	30.6488242	-88.194642
+location	Moca	47.7600179	18.4050954
+location	Mocamedes	-15.195064	12.1458085
+location	Mochales	41.0960514	-2.0146711
+location	Moclin	37.3402105	-3.7858164
+location	Mocoa	1.1466295	-76.6482327
+location	Mococa	-21.464731	-47.002405
+location	Modasa	23.4643	73.2988
+location	Modesto	37.6390972	-120.9968782
+location	Modhubag	23.7572429	90.41239862393974
+location	Modi'in Illit	31.9324487	35.0433428
+location	Modiin	31.9085744	35.0069297
+location	Modliszewice	51.2036318	20.3655712
+location	Modoc County	41.5450487	-120.7435998
+location	Modrzewiowa	50.1743323	20.1296519
+location	Modrzyca	51.8333427	15.7142412
+location	Mödling	48.0855922	16.2833526
+location	Möhlin	47.560991	7.8431299
+location	Moen	50.7685806	3.3975585
+location	Moerfelden-Walldorf	49.9923836	8.5622468
+location	Moerkerke	51.2454679	3.3410211
+location	Mörschwil	47.4675534	9.4227493
+location	Mogadishu	2.0372877000000003	45.331527872587145
+location	Mogale City	-25.9949382	27.5366082
+location	Moghbazar	23.75021266574977	90.40815048811284
+location	Mogi Das Cruzes	-23.5393	-46.2167
+location	Mogi-Guacu	-22.372222	-46.9425
+location	Mogi Mirim	-22.433009	-46.9581629
+location	Mogilany	49.9413293	19.8877676
+location	Mogilno	52.657341	17.9500677
+location	Mogro	43.4272044	-3.9714117
+location	Moha	50.5471619	5.1878867
+location	Mohadebpur	24.9177354	88.7511472
+location	Mohakhali	23.7794534	90.4045517
+location	Mohali	30.700371669376754	76.69634773710384
+location	Mohammadpur	23.7660	90.3586
+location	Mohave County	35.7218038	-113.8271174
+location	Moia	41.8130391	2.0978412
+location	Moita	38.6523995	-8.9935314
+location	Mojmirovce	48.2078306	18.0619653
+location	Moju	-1.889926	-48.766765
+location	Mokajny	53.9415216	19.3809552
+location	Mol	51.217746	5.187479
+location	Molenbeek-Saint-Jean	50.853857	4.323479
+location	Molenbeek-Wersbeek	50.91120585	4.937613218940903
+location	Molenbeersel	51.169533832738075	5.737494043040284
+location	Molenlanden	51.891504350000005	4.836502649912571
+location	Molenstede	50.999889	5.012097
+location	Molina	-35.1139703	-71.2799798
+location	Molina de Aragon	40.8435978	-1.8879403
+location	Molins de Rei	41.4138087	2.0159626
+location	Molledo	43.15187	-4.0428
+location	Mollerussa	41.6330928	0.895495
+location	Molles	46.1113	3.55824
+location	Mollet del Valles	41.5393484	2.2130934
+location	Mollis	47.0942576	9.0752066
+location	Molėtų rajono savivaldybės	55.231056499999994	25.419573375494885
+location	Momignies	50.0087898	4.2142084834115705
+location	Mompia	43.4405511	-3.9188524
+location	Mon	26.75	94.833333
+location	Monachil	37.1324336	-3.5395284
+location	Moncada	39.5450484	-0.3941015
+location	Moncada y Reixach	41.4823115	2.1869985
+location	Monceau-sur-Sambre	50.416209	4.376445
+location	Mondejar	40.3229399	-3.1089503
+location	Mondragon	43.0656783	-2.4900779
+location	Mondsee	47.825511899999995	13.379975277329851
+location	Mongagua	-24.0959454	-46.6234361
+location	Monistrol de Montserrat	41.6105028	1.8452698
+location	Monjas	14.5031439	-89.8721351
+location	Monki	53.4065738	22.7983772
+location	Monmouth County	40.2932319	-74.1671114
+location	Monnickendam	52.4570766	5.0373214
+location	Mono County	37.9533927	-118.9398758
+location	Monona	43.056000	-89.330773
+location	Monovar	38.4387815	-0.8396316
+location	Monroe County	43.940837	-90.605424
+location	Monroe County AL	31.5593935	-87.3781004
+location	Monroe County FL	25.0405135	-80.8337157
+location	Monroe County IL	38.2722313	-90.1792484
+location	Monroe County NY	43.150094	-77.6810141
+location	Monroe County PA	41.0400423	-75.3249475
+location	Monroe County WI	43.9416755	-90.6397264
+location	Monsefu	-6.8777743	-79.8720043
+location	Monstreux	50.59334615	4.285908437565672
+location	Mont-de-l'Enclus	50.7456511	3.5110542
+location	Mont-de-Marsan	43.8911318	-0.500972
+location	Mont-Ras	41.9080196	3.144796
+location	Mont-Saint-Guibert	50.6365628	4.6127019
+location	Mont-Sainte-Geneviève	50.3759782	4.2379139
+location	Mont-sur-Marchienne	50.382618300000004	4.40509560686098
+location	Montagano	41.644929	14.675129
+location	Montagne Blanche	-20.2863031	57.6614154
+location	Montagnieu	45.5247	5.45541
+location	Montague County	33.6205753	-97.7215754
+location	Montagut I Oix	42.26772535	2.529677070940421
+location	Montaigut	46.1807398	2.808294
+location	Montauban	44.0175835	1.3549991
+location	Montboudif	45.371019	2.7322039
+location	Montcenis	46.7904888	4.3884346
+location	Monte Abrão	38.759971	-9.265530
+location	Monte Alegre	-1.9989108	-54.0727694
+location	Monte Alegre de Goias	-13.2552059	-46.892813
+location	Monte Alegre de Minas	-18.870278	-48.880556
+location	Monte Alegre de Sergipe	-10.0657473	-37.62356148016381
+location	Monte Aprazivel	-20.7625702	-49.7088402
+location	Monte Azul Paulista	-20.90649	-48.638717
+location	Monte Azul Pulista	-20.907310507676332	-48.63952516793169
+location	Monte Buey	-36.2897923	-61.18332024592689
+location	Monte Cristo	-34.47112345	-58.53043541331664
+location	Monte Maiz	-37.3271922	-59.1342888
+location	Monte Vera	-31.5168247	-60.6758789
+location	Montefalcone nel Sannio	41.866634	14.638225
+location	Monteiro	-7.8920179	-37.1232051
+location	Montejos del Camino	42.5843866	-5.6892021
+location	Montelimar	44.5579391	4.750318
+location	Montemitro	41.8880266	14.6467497
+location	Montemor-o-Novo	38.6531933	-8.21527878722609
+location	Montenegro	-29.6826112	-51.4687455
+location	Montérégie	45.3872317844	-73.1007662636
+location	Monterey County CA	36.176354	-121.254507
+location	Monteria	8.747483	-75.880941
+location	Monteros	-27.1653249	-65.4972201
+location	Montes Claros	-16.7273538	-43.8717676
+location	Montes Claros de Goias	-16.0059459	-51.3978781
+location	Montes de Oca	9.9377936	-84.033874
+location	Montes De Oro	10.14694585	-84.72716208188078
+location	Montesa	38.9481556	-0.6492732
+location	Montesquiu	42.108728	2.2086111
+location	Montfermeil	48.8992679	2.5660399
+location	Montgat	41.4666983	2.2789654
+location	Montgomery County AL	32.1672192	-86.1999118
+location	Montgomery County IL	39.2052633	-89.5057126
+location	Montgomery County MD	39.1406267	-77.2075612
+location	Montgomery County NC	35.3299572	-79.8979019
+location	Montgomery County NY	42.8941269	-74.4099745
+location	Montgomery County OH	39.6837328	-84.2854817
+location	Montgomery County PA	40.2154361	-75.3702305
+location	Montgomery County TN	36.4803824	-87.3786221
+location	Montgomery County TX	30.301949	-95.5065944
+location	Montignies-sur-Sambre	50.401302	4.478466
+location	Montigny le Bretonneux	48.7739	2.0360
+location	Montigny-le-Tilleul	50.374917	4.371814
+location	Montigny Les Metz	49.0999832	6.153041
+location	Montijo	38.74502535	-8.628858514902682
+location	Montijo PA	7.9930494	-81.0546478
+location	Montijo PT	38.74502535	-8.628858514902682
+location	Montilla	37.5811178	-4.6414726
+location	Montillana	37.5001419	-3.6723589
+location	Montlucon	46.3399276	2.6067229
+location	Montmelo	41.5515189	2.2480812
+location	Montmorillon	46.4249573	0.8682027
+location	Montmorin	45.6949585	3.3607158
+location	Montornes del Valles	41.542545	2.2670557
+location	Montpellier	43.6112422	3.8767337
+location	Montreuil	48.8623357	2.4412184
+location	Montreuil Juigne	47.5291981	-0.6099197
+location	Montreux-Chateau	47.607677	6.994181
+location	Montseny	41.7593697	2.3952061
+location	Montserrat	39.3576494	-0.6031
+location	Montval sur Loir	47.69545275	0.44213227296009794
+location	Monza	45.5834418	9.2735257
+location	Monze	-16.278664639244255	27.476123144042734
+location	Monzon	41.9143981	0.1922412
+location	Moody	31.3082273	-97.3613977
+location	Moorsel	50.9477279	4.0983893
+location	Moorsele	50.8518106	3.148910676542254
+location	Moorslede	50.89008225	3.0732110598481244
+location	Moquegua	-17.1938025	-70.9345636
+location	Mora	9.8714773	-84.2810456
+location	Moradabad	28.8638424	78.80577833091104
+location	Moral de Calatrava	38.8293937	-3.5793395
+location	Moraleja	40.0684627	-6.6604617
+location	Moravany nad Vahom	48.6021432	17.8621354
+location	Moravia	10.0139444	-84.0094218
+location	Moravske Lieskove	48.8184752	17.7927419
+location	Morbi	22.8176662	70.8345928
+location	Mordelles	48.0733304	-1.8485204
+location	Moreda	43.1706329	-5.7419089
+location	Morehouse Parish	32.813203	-91.810337
+location	Moreno	-34.6396556	-58.7898326
+location	Moreno AR	-34.6396556	-58.7898326
+location	Moreno BR	-8.108706	-35.08354
+location	Moretele	-25.4661957	28.3046216
+location	Morgan County AL	34.4296848	-86.8529584
+location	Morgan County IL	39.7062265	-90.190335
+location	Moriensart	50.66674152036121	4.508157051966334
+location	Morigaon	26.2479886	92.3227833
+location	Morlaix	48.5824932	-3.8331972
+location	Morlanwelz	50.450138	4.246584
+location	Morningside	-29.8183613	31.0180771
+location	Morón	-34.6510527	-58.6217416
+location	Morona	-2.4303097	-77.880192010847
+location	Morrinhos	-17.7333689	-49.105908
+location	Morris County	40.8679538	-74.5601181
+location	Morris County NJ	40.8679538	-74.5601181
+location	Morris County TX	33.0738633	-94.7392197
+location	Morro Agudo	-20.7276692	-48.052795
+location	Morro Bento	-8.8963944	13.2010539
+location	Morro Da Fumaca	-28.6522275	-49.2133979
+location	Morro Reuter	-29.5389519	-51.0818864
+location	Morrow County	40.4574358	-82.7771661
+location	Morrow County OH	40.4574358	-82.7771661
+location	Morrow County OR	45.360901	-119.6052459
+location	Morshansk	53.442902	41.813099
+location	Mortera	43.232776	-3.4586273
+location	Mortsel	51.1704119	4.4566996
+location	Moryn	52.8558027	14.3968046
+location	Moscas Del Paramo	42.251586	-5.8039703
+location	Moscow	55.929035	37.518668082948246
+location	Mosina	52.2455834	16.8472591
+location	Moskalenki	54.939468	71.92588
+location	Mosovce	48.908686	18.8859287
+location	Mossel Bay	-34.1832022	22.1536248
+location	Mostazal	-33.94685255	-70.59810241413152
+location	Mostoles	40.3238525	-3.8649214
+location	Mostova	48.1401623	17.6785943
+location	Motilleja	39.1804849	-1.7907731
+location	Motril	36.7450888	-3.5207655
+location	Mouans-Sartoux	43.6203852	6.9703991
+location	Moulins	46.5660526	3.3331703
+location	Moultrie County	39.6391442	-88.6087498
+location	Moulvibazar	24.4843	91.7685
+location	Mount Horeb	43.008707	-89.730497
+location	Mount-Vernon	41.851953	-72.440345
+location	Mouscron	50.738645	3.23861
+location	Moussy Le Neuf	49.065806	2.601697
+location	Moutier	47.2796142	7.3704192
+location	Moya	28.1107662	-15.583223
+location	Mozac	45.8940829	3.0953843
+location	Mozyr	52.0475464	29.2667179
+location	Mragowski	53.8108457	21.40278094456329
+location	Mrkonjic Grad	44.4166023	17.0842585
+location	Mrowino	52.5139312	16.7011172
+location	Mszana	49.96895	18.529
+location	Mszana Dolna	49.681078150000005	20.0764990708178
+location	Mszanowo	53.4431118	19.6063241
+location	Muaro Bungo	-1.4185048500000002	102.09232918493007
+location	Muehlacker	48.9487272	8.8492931
+location	Muelheim	51.4272925	6.8829192
+location	Müllendorf	47.836253049999996	16.445354714852037
+location	Münchenstein	47.5187909	7.6174515
+location	Münster	51.958677	7.616881
+location	Muizen	51.0108505	4.5143485
+location	Muko Muko	-3.6497591	102.2170141
+location	Mukono	0.35477685	32.74046606627749
+location	Mulchen	-37.7200884	-72.2441345
+location	Mulhouse	47.7467	7.3389275
+location	Multanovo	46.3287752	48.7792766
+location	Multnomah County	45.517630	-122.536942
+location	Mumbai	19.0759899	72.8773928
+location	Mumbai Suburban	19.13095765	72.88593095460952
+location	Munchwilen	47.4777697	8.9976456
+location	Mundo Novo	-13.7729429	-50.281378
+location	Munger	25.22081165	86.51720367235285
+location	Munich	48.155742	11.549380
+location	Munshiganj	23.5483797	90.5349722
+location	Munster	48.9154719	6.9037077
+location	Muntendam	53.1351684	6.8706286
+location	Muradpur	22.5939539	91.6477561
+location	Muranska Huta	48.778768	20.1105543
+location	Murat	46.4008462	2.9084037
+location	Murat le Quaire	45.597743	2.7337149
+location	Murau	47.11958265	14.225504559328828
+location	Murbach	47.9233168	7.1571622
+location	Murcia	37.9922	-1.1307
+location	Muret	43.4599858	1.3262332
+location	Muriae	-21.130556	-42.366389
+location	Murici	-9.306823	-35.942798
+location	Muridke	31.8010863	74.2540999
+location	Muriedas	43.4314171	-3.8584093
+location	Murmansk	68.970665	33.07497
+location	Muro	39.734505	3.055198
+location	Murol	45.5738254	2.9426341
+location	Muromtsevo	56.369392	75.237198
+location	Muros	42.8074	-9.0461
+location	Murowana Goslina	52.5758465	17.0097914
+location	Murshidabad	24.1745993	88.2721335
+location	Murska Sobota	46.6574562	16.16118585
+location	Murtal	47.23281755	14.713063164515841
+location	Muscatine County IA	41.4776121	-91.1210053
+location	Muscoda	43.189115	-90.439704
+location	Museros	39.5738	-0.3607
+location	Muskiz	43.31259665	-2.667014112202941
+location	Musques	43.3230375	-3.1243029
+location	Musselshell County	46.4728903	-108.4473635
+location	Muszkowice	50.64165	16.9622
+location	Mutamba	-8.8150577	13.2323702
+location	Mutata	7.3429226	-76.50409456256443
+location	Mutilva	42.789102	-1.616814
+location	Mutne	49.4596226	19.32275
+location	Mutne Dulov	48.979356411156566	18.245537483074184
+location	Mutrah	23.618733	58.5657654
+location	Muttenz	47.525113	7.6477401
+location	Muzaffarnagar	29.44800635	77.74068502568672
+location	Myjava	48.75408065	17.57651278309739
+location	Mymensingh	24.7482129	90.4099158
+location	Myslakowice	50.8365551	15.7871345
+location	Myślenice	49.834608	19.9384283
+location	Mysliborz	52.924825	14.8664799
+location	Mysliborz (Wielkopolskie)	52.22876	18.06043
+location	Mysliborz (Zachodniopomorskie)	52.924825	14.8664799
+location	Myszkow	50.5646661	19.32486156630843
+location	Myto Pod Dumbierom	48.8556374	19.62969423799256
+location	Mzimba	-11.845635	33.56919890520855
+location	Mzuzu	-11.4607518	34.0226422
+location	N'Dorola	11.7661625	-4.8181526
+location	Naarden	52.2953	5.1604
+location	Naast	50.553695	4.099133
+location	Nablus	32.2280665	35.2370416
+location	Nacogdoches County	31.5970503	-94.5927451
+location	Nadborowo	52.8935024	17.5329562
+location	Nadia	23.48454125	88.55676307470536
+location	Nadiad	22.6916	72.8634
+location	Nadolice Wielkie	51.0846172	17.2375659
+location	Nagapattinam	10.805627600000001	79.824659783024
+location	Nagarkurnool	16.415762649999998	78.68304333132829
+location	Nagaur	27.0607859	74.17667537582712
+location	Naglowice	50.6783328	20.1061001
+location	Nagoszyn	50.1346984	21.422939
+location	Nagoya	35.1851045	136.8998438
+location	Nagpur	21.1498134	79.0820556
+location	Najera	42.416745	-2.7336874
+location	Nakhal	23.395468	57.8289398
+location	Nakło	53.1386896	17.5998891
+location	Nalanda	25.1364914	85.44365464855682
+location	Nalbari	26.4405198	91.4356973
+location	Nalda	42.3351254	-2.4882778
+location	Nalgonda	16.8579636	79.21749353315548
+location	Nalinnes	50.3249486	4.4466922
+location	Nama Khoi	-29.390525	18.101967701908958
+location	Namakkal	11.284224850000001	78.16615283668403
+location	Namakwa	-30.488880899999998	19.942216005294117
+location	Náměšť nad Oslavou	49.20930535	16.158590934775468
+location	Namestovo	49.423550250000005	19.458483687700223
+location	Namysłów	51.0766258	17.7185619
+location	Nana	47.8131412	18.7002497
+location	Nancagua	-34.6527427	-71.1953819
+location	Nanchang	28.707143	115.874137
+location	Nancy	48.6921	6.1844
+location	Nandayure	9.9013949	-85.3300634985622
+location	Nanded	19.17257215	77.29141237169956
+location	Nanikon	47.3696093	8.6923683
+location	Nankana Sahib	31.4446506	73.6933253
+location	Nantes	47.203649	-1.552453
+location	Não-Me-Toque	-28.4575507	-52.8196547
+location	Naogaon	24.808119150000003	88.95266066504688
+location	Napa County	38.4898675	-122.3218414
+location	Napiwoda	53.4070488	20.484961
+location	Naples	40.857678	14.229949
+location	Narail	23.175	89.505
+location	Narandiba	-22.4080573	-51.5251755
+location	Naranjo	10.1052617	-84.39948072395714
+location	Narayanganj	23.6238108	90.4999662
+location	Narayanganj Sadar	23.61991735	90.50270192289844
+location	Narbonne	43.1837661	3.0042121
+location	Nargana	9.4442179	-78.585351
+location	Naria Upazila	23.3045178	90.4046095
+location	Narmada	21.738303950000002	73.62736015921328
+location	Naro-Fominsk	55.3879473	36.7398309
+location	Narsingdi	23.9156451	90.6981963
+location	Nashik	20.0112475	73.7902364
+location	Nassau County	40.7333	-73.58010
+location	Nassau County NY	40.7430237	-73.56882214900722
+location	Nastatten	50.199081	7.858179
+location	Natal	-5.805398	-35.2080905
+location	Natales	-51.7262003	-72.5059982
+location	Natchitoches Parish	31.6464192	-93.1427138
+location	Natividade	-21.040694	-41.9817534
+location	Natividade Da Serra	-23.3783786	-45.4438173
+location	Natore	24.4111297	88.9973561
+location	Natternbach	48.39766	13.74806
+location	Nauders	46.89014505	10.542293187555815
+location	Nauheim	49.9452137	8.4535626
+location	Navajo County	35.1819775	-110.3549451
+location	Navalmoral de la Mata	39.8928306	-5.5401199
+location	Navarcles	41.7531567	1.9033612
+location	Navarrete	42.4289697	-2.5616234
+location	Navarro County	32.0279525	-96.4985456
+location	Navas	41.8989233	1.8767736
+location	Navas de San Juan	38.183649	-3.3137589
+location	Navatejera	42.627611	-5.565247
+location	Navegantes	-26.8898813	-48.6495828
+location	Navidad	-33.9534175	-71.8306741
+location	Navimumbai	19.0308262	73.0198537
+location	Navirai	-23.0622152	-54.2018319
+location	Navolato	24.748912750000002	-107.7560440587446
+location	Navotas City	14.6571862	120.9479692
+location	Navsari	20.952407	72.9323831
+location	Nawabgonj	23.678953221842516	90.15874814295695
+location	Nawty	54.0622124	19.8692486
+location	Nazaré	-13.0345586	-39.0062515
+location	Nazareth	32.7066301	35.3048161
+location	Nazran	43.2320774	44.7540128
+location	Ndalatando	-9.2513735	14.1254422
+location	Ndola	-12.9693056	28.6365894
+location	Nebaj	15.6089199	-91.18000877027623
+location	Nechi	7.9838411	-74.68428522913838
+location	Nechvalova Polianka	49.0697609	22.0929084
+location	Necochea	-38.5545494	-58.7392624
+location	Necocli	8.4920297	-76.65446581673163
+location	Neded	48.0184397	17.9740566
+location	Neder-Over-Heembeek	50.8925777	4.3768928
+location	Nederweert	51.2918913	5.74814642346813
+location	Neemach	24.467521	74.875900
+location	Neerglabbeek	51.0894138	5.6159685
+location	Neerharen	50.907778	5.680982
+location	Neerlinter	50.8398549	5.0210895
+location	Neeroeteren	51.0885745	5.7052955
+location	Neerpelt	51.228889	5.431667
+location	Neerwinden	50.765746	5.0368679
+location	Negombo	7.2094282	79.833117
+location	Negreira	42.9105	-8.7363
+location	Neiva	2.933160	-75.277542
+location	Nelito Soares	-8.8309049	13.2591297
+location	Nellore	14.4493717	79.9873763
+location	Nelson Mandela Bay	-33.98916975	25.672838422792537
+location	Ñemby	-25.3924542	-57.5471112
+location	Nemours	48.268026	2.6953079
+location	Nemšová	48.9646151	18.1175713
+location	Nendeln	47.1973842	9.5430689
+location	Ner Chowk	31.6075891	76.9142821
+location	Neratovice	50.2598479	14.5175086
+location	Neringa	55.3064493	20.9963702
+location	Nerja	36.7468565	-3.8790164
+location	Neschers	45.5889848	3.1635232
+location	Neschwil	47.4295716	8.7879574
+location	Neshoba County	32.7237573	-89.103199
+location	Neslusa	49.3100483	18.7486916
+location	Nesslau	47.21436275	9.187116980739692
+location	Nesvady	47.9285197	18.1285528
+location	Netanya	32.3286181	34.8566246
+location	Netivot	31.4213546	34.5884252
+location	Netolice	49.0493797	14.1962532
+location	Neu-Isenburg	50.0552494	8.695738
+location	Neuburg an der Donau	48.7371951	11.1795268
+location	Neufmaison	50.528807	3.793244
+location	Neufvilles	50.568107	4.004889
+location	Neuilly sur Seine	48.884683	2.2695658
+location	Neukirchen	47.8759297	13.7096878
+location	Neuquen	-38.9549825	-68.0592356
+location	Neusiedl Am See	47.917685000000006	16.8291317779467
+location	Neusiedl An Der Zaya	48.6004802	16.7888478
+location	Neutraubling	48.9879681	12.1937046
+location	Nevada County	39.3540335	-120.8089843
+location	Nevele	51.0343	3.5474
+location	Nevers	46.9876601	3.1577203
+location	Neves Paulista	-20.842992	-49.635767
+location	New Berlin	42.969065	-88.129847
+location	New Castle County	39.6620572	-75.5663132
+location	New Delhi	28.6138954	77.2090057
+location	New Fairfield	41.4661	-73.4856
+location	New Hanover County	34.2751052	-77.8818627
+location	New Haven County	41.312452	-72.928412
+location	New Hyde Park	40.7308451	-73.6805499
+location	New Jersey	40.0757384	-74.4041622
+location	New Juaben South	6.09090481771626	-0.25862706083855574
+location	New London County	41.4915013	-72.1237666
+location	New Orleans	29.9511	-90.0715
+location	New Rochelle	40.9115	-73.7824
+location	New York City	40.695065	-73.993461
+location	New York County	40.7896239	-73.9598939
+location	Newark	39.6852191	-75.7508289
+location	Newberry County	34.3266879	-81.5830086
+location	Newton County	30.8118989	-93.740504
+location	Newton County IN	40.939576	-87.3966953
+location	Newton County TX	30.8118989	-93.740504
+location	Newtown	41.411793	-73.311831
+location	Nez Perce County	46.3959861	-116.8072307
+location	Ngor	14.7487915	-17.5149607
+location	Niagara County	43.2042439	-78.7676017
+location	Nice	43.7009358	7.2683912
+location	Nicolas Romero	19.63422625	-99.3695564379207
+location	Nicoya	10.147393	-85.452562
+location	Nidau	47.1250287	7.241157
+location	Nidderau	50.2290263	8.8762327
+location	Nidzicki	53.37347615	20.4883074922381
+location	Niechanowo	52.4643201	17.6777258
+location	Niederbayern	48.7364422	12.1925349
+location	Niederhasli	47.4812949	8.4858049
+location	Niederurnen	47.1257569	9.0547397
+location	Niederuzwil	47.4451709	9.1421696
+location	Niel	51.1098649	4.3303396
+location	Niemcza	50.7163426	16.8350398
+location	Niepołomice	50.033182	20.2168012
+location	Niepruszewo	52.3858822	16.6040814
+location	Nieuw Annerveen	53.070554200000004	6.780379598026716
+location	Nieuwendijk	51.7774	4.8743
+location	Nieuwerkerken	50.882291	5.20403
+location	Nieuwpoort	51.144191899999996	2.728191316916685
+location	Nieuwrode	50.9494124	4.8329514
+location	Niewierz	52.44993	16.34573
+location	Niewodnica Koscielna	53.0836113	23.0463769
+location	Nijar	36.962894	-2.2063758
+location	Nijlen	51.1611887	4.670951731704948
+location	Nijmegen	51.842574850000005	5.838960628748229
+location	Niketan	23.7733159	90.409755
+location	Nikunja	23.8242795	90.4191806
+location	Nilópolis	-22.8080114	-43.4138222
+location	Nilphamari	25.9339275	88.8534588
+location	Nîmes	43.8374249	4.3600687
+location	Nimtola	23.7431995	90.3641602
+location	Nimy	50.4759358	3.9545894
+location	Ninhue	-36.3936781	-72.3977559
+location	Ninove	50.82264720151501	4.009625830721895
+location	Niort	46.3241132	-0.4649403
+location	Nipkowie	53.7103416	19.3118724
+location	Nipoa	-20.9126469	-49.7791476
+location	Niquen	-36.28149585	-71.95265473856855
+location	Nir-Tzvi	31.9525352	34.8625062
+location	Nirmal	19.091520950000003	78.39660898429065
+location	Nisia Floresta	-6.0902674	-35.2085026
+location	Nisko	50.5198985	22.139886
+location	Nissewaard	51.82787345	4.305284305924035
+location	Niteroi	-22.912156	-43.060953
+location	Nizamabad	18.75	78.25
+location	Nizhnevartovsk	60.9339411	76.5814274
+location	Nizhny Novgorod	56.328571	44.003506
+location	Nizhny Tagil	57.905149	59.9508466
+location	Nizhnyaya Omka	55.43359	74.938004
+location	Nizna	49.3102206	19.5229882
+location	Nizne Ladickovce	49.0221973	21.9017946
+location	Nizny Hrabovec	48.8540567	21.7503714
+location	Nizwa	22.9323884	57.5311
+location	Nkangala	-25.642815	29.83853918023201
+location	Nkhata Bay	-11.608449199999999	34.04156908448276
+location	Noain	42.758167	-1.632185
+location	Noakhali	22.5313205	91.1775744276286
+location	Nof Hagalil	32.7023065	35.3183216
+location	Nogent-l'Artaud	48.9651	3.3183
+location	Nogoya	-32.3985574	-59.787777
+location	Nohanent	45.8089403	3.0563114
+location	Noia	42.7843	-8.8883
+location	Noida	28.552876	77.394687
+location	Noisy le Roi	48.852116	2.055226
+location	Noja	43.4813309	-3.5210066
+location	Nokere	50.8853618	3.5108474
+location	Nonoai	-27.3660882	-52.7717853
+location	Noorderwijk	51.141115	4.8402651
+location	Noordscheschut	52.7208497	6.5345138
+location	Nootdorp	52.0440	4.3909
+location	Nord Pas de Calais	50.49741872406692	2.5198357723783866
+location	Norderstedt	53.7089898	9.9891914
+location	Norena	43.394016	-5.703602308901823
+location	Norfolk	52.666667	1.0
+location	Norfolk County	42.1538607	-71.1828015
+location	Norfolk VA	36.8462923	-76.2929252
+location	Norg	53.0663002	6.459462
+location	North 24 Parganas	22.722907	88.734582
+location	North and Middle Andaman	12.61123865	92.83165406414926
+location	North-Branford	41.3276	-72.7673
+location	North Goa	15.4939104	73.8241103
+location	North Haven	41.383683	-72.858134
+location	North Shajahanpur	23.7457901	90.4217076
+location	North Tripura	24.092147599999997	92.24512135019847
+location	Northampton County	36.4168078	-77.3642227
+location	Northampton County NC	36.4168078	-77.3642227
+location	Northampton County PA	40.7451356	-75.3289302
+location	Northamtonshire	52.324226	-0.872799
+location	Northern Alaska	67.3274	-161.0159
+location	Northern Queensland	-17.758290	142.643075
+location	Northford	41.392896	-72.791640
+location	Nossa Senhora Da Gloria	-10.2188811	-37.4199759
+location	Nossa Senhora de Lourdes	-10.0786746	-37.0572176
+location	Nossa Senhora do Socorro	-10.8553115	-37.1264863
+location	Nossegem	50.877645	4.507645
+location	Notre-Dame-de-Sanilhac	45.13292945	0.7080364376276143
+location	Nottinghamshire	53.139677	-1.027527
+location	Nova Alianca	-21.0163728	-49.4981128
+location	Nova Alvorada do Sul	-21.4587274	-54.3760634
+location	Nova America Da Colina	-23.3315888	-50.7182735
+location	Nova Andradina	-22.2477565	-53.3480621
+location	Nova Araça	-28.6604116	-51.7424776
+location	Nova Bana	48.4245994	18.6413651
+location	Nova Bassano	-28.7304074	-51.7034689
+location	Nova Brescia	-29.2158737	-52.0290188
+location	Nova Cruz	-6.482111	-35.4332326
+location	Nova Dubnica	48.9358736	18.1457351
+location	Nova Europa	-21.7808203	-48.5661712
+location	Nova Floresta	-6.4554313	-36.2040005
+location	Nova Friburgo	-22.2800004	-42.5325303
+location	Nova Granada	-20.5345426	-49.3186951
+location	Nova Hartz	-29.5842391	-50.9043246
+location	Nova Holinda	-4.003124927676892	-58.589094526426976
+location	Nova Iguacu	-22.7561	-43.4607
+location	Nova Lesna	49.122787	20.2677459
+location	Nova Lubovna	49.2757	20.6833682
+location	Nova Odessa	-22.783186	-47.294059
+location	Nova Olinda do Norte	-3.8926889	-59.0953046
+location	Nova Ponte	-19.1692213	-47.6717642
+location	Nova Santa Rita	-29.8489972	-51.2764275
+location	Nova Serrana	-19.875834	-44.984166
+location	Nova Timboteua	-1.2052428	-47.3935775
+location	Nova Trento	-27.2862616	-48.9302652
+location	Nova Vida	-8.89561755	13.231665327600382
+location	Nova Vieska	47.8706104	18.4596592
+location	Novais	-20.9941576	-48.9188283
+location	Novaky	48.7164472	18.5408304
+location	Nove Mesto nad Vahom	48.7633248	17.8303857
+location	Nové Strašecí	50.1532192	13.9004279
+location	Nove Zamky	47.9861843	18.1631415
+location	Novelda	38.3842144	-0.7674146
+location	Novi Pazar	43.136667	20.512222
+location	Novi Sad	45.2551338	19.8451756
+location	Novo Cabrais	-29.7347439	-52.9499851
+location	Novo Hamburgo	-29.6905705	-51.1429035
+location	Novo Horizonte	-21.4674564	-49.2235377
+location	Novo Mesto	45.8040475	15.1696684
+location	Novo Repartimento	-4.2519172	-49.9524257
+location	Novoanninsky	50.53345265	42.683562499999994
+location	Novofedorovka	45.0943138	33.5752494
+location	Novokiyevsky Uval	51.668640121329766	128.9251319110109
+location	Novokuznetsk	53.757607	87.136101
+location	Novomoskovsk	54.011013	38.290943
+location	Novorossiysk	44.7239578	37.7690711
+location	Novosibirsk	55.0282171	82.9234509
+location	Novot	49.4280349	19.2634843
+location	Novovarshavka	54.170616	74.696037
+location	Novy Oskol	50.7644104239453	37.87350251852188
+location	Nowa Pasleka	54.4302848	19.7709351
+location	Nowa Sarzyna	50.3198578	22.3433771
+location	Nowa Sol	51.8033431	15.706238052443426
+location	Nowa Wieś	49.7148488	21.2420101
+location	Nowa Wioska	52.2080556	18.9352778
+location	Nowe Brynki	53.2928175	14.5214182
+location	Nowe Goluszowice	50.1839731	17.7943289
+location	Nowe Kusy	54.0494732	19.5890078
+location	Nowe Miasteczko	51.6908103	15.7311977
+location	Nowe Ostrowite	53.6263714	17.6230335
+location	Nowe Warpno	53.7252724	14.2809332
+location	Nowiec	53.9338174	19.3323977
+location	Nowizna	50.760257	16.614698
+location	Nowodworski	54.2587964320777	19.104574031039586
+location	Nowodziel	53.4756118	23.6782871
+location	Nowogrod	53.2280804	21.8797908
+location	Nowogrod Bobrzanski	51.7986474	15.2365032
+location	Nowomiejski	53.43573635	19.54927877039548
+location	Nowy Dwor Gdanski	54.2146299	19.1150846
+location	Nowy Kielbow	51.5834524	20.9892971
+location	Nowy Sacz	49.61030395	20.71595521113809
+location	Nowy Staw	54.1342754	19.0086861
+location	Nowy Tomysl	52.3177643	16.1291553
+location	Noyal Chatillon sur Seiche	48.0425725	-1.6619865
+location	Noyal Pontivy	48.0676349	-2.882738
+location	Nsork	1.1310535	11.2712687
+location	Nueces County	27.7153774	-97.6199942
+location	Nürensdorf	47.4492605	8.6470753
+location	Nueva Esperanza	8.1236721	-80.71636003659773
+location	Nueva Loja	0.0850662	-76.883564
+location	Nuevo Rocafuerte	-0.9191774	-75.4023208
+location	Nugegoda	6.8699688	79.8882835
+location	Nuglar	47.47110495	7.6942386559422395
+location	Nules	39.8532265	-0.1550092
+location	Nunningen	47.3939723	7.6197691
+location	Ñuñoa	-33.4543304	-70.60058198319726
+location	Nuoro	40.1276831	9.342322797142703
+location	Nuremberg	49.453872	11.077298
+location	Nussdorf Am Attersee	47.8832538	13.5237703
+location	Nymburk	50.186331	15.0417306
+location	Nysa	50.4738029	17.3324733
+location	Oak Creek	42.878698	-87.901041
+location	Oakland County	42.6618842	-83.3804439
+location	Obanos	42.6808183	-1.7851016
+location	Oberbayern	47.9998178	11.7500977
+location	Oberdorf	47.3938149	7.7515654
+location	Oberhofen	46.901188	7.6924357
+location	Obernai	48.4623358	7.4817123
+location	Oberndorf bei Schwanenstadt	48.0564079	13.7607085
+location	Oberpullendorf	47.5012609	16.5054577
+location	Oberriet	47.320756	9.5675673
+location	Oberterzen	47.1023459	9.2559061
+location	Obertrum Am See	47.937594950000005	13.072933599487843
+location	Obertshausen	50.0726702	8.847775
+location	Oberwang	47.8676472	13.4324268
+location	Oberwart	47.2861513	16.2124214
+location	Oberweis	47.9500316	13.8186028
+location	Oberwil	47.5136942	7.5527853
+location	Oberwil BL	47.5136942	7.5527853
+location	Oberwölz	47.203977	14.2811889
+location	Obidos	39.3619514	-9.157153
+location	Obidos BR	-1.901072	-55.520812
+location	Obidos PT	39.3619514	-9.157153
+location	Objazda	54.6061069	17.043362
+location	Oborniki	52.6455252	16.8099756
+location	Obourg	50.4760289	4.0062232
+location	Obrastsovo-Travino	45.9595171	48.0037682
+location	Obregon	30.3600213	-108.9290777
+location	Obrzycko	52.70200015	16.530104807130158
+location	Ocana	8.1758238	-73.3670106
+location	Occidental	9.8659296	-83.9270675
+location	Ocean County	39.977818	-74.3319287
+location	Ochiltree County	36.2559217	-100.8138152
+location	Oconee County	34.7622221	-83.1099645
+location	Oconto County	44.9988053	-88.2480072
+location	Odivelas	38.7953835	-9.18782210264363
+location	Öblarn	47.4611236	13.9909816
+location	Oed	48.2105525	15.9494085
+location	Oedelem	51.1690329	3.3388064
+location	Oeiras	38.7124971	-9.271300382407272
+location	Oelegem	51.2110687	4.5972162
+location	Oetingen	50.7720719	4.0614624
+location	Oevel	51.1387	4.9043
+location	Offenbach	50.02173999392697	8.820681945789987
+location	Offenbach Am Main	50.1055002	8.7610698
+location	Oftersheim	49.3695728	8.5829567
+location	Oftringen	47.3126595	7.92099
+location	Ogijares	37.1200	-3.6079
+location	Ogle County	42.0397014	-89.3138599
+location	Ogle County IL	42.0397014	-89.3138599
+location	Ohlsdorf	47.9611479	13.7927962
+location	Ohradzany	48.9988555	21.8409872
+location	Ohrid	41.1170203	20.8017387
+location	Oisterwijk	51.568179	5.211873
+location	Ojacastro	42.3467292	-3.0049378
+location	Ojedo	43.1610018	-4.6111361
+location	Okaloosa County	30.6765961	-86.6037748
+location	Okanogan County	48.361262	-119.5833869
+location	Okara	30.8091281	73.4493301
+location	Okhaldhunga	27.33630235	86.44894555904452
+location	Okiep	-29.5968707	17.8796318
+location	Oksa	50.72838	20.10219
+location	Oktibbeha County	33.4131096	-88.8937318
+location	Oktyabr'skoye	45.2931604	34.128563
+location	Okunica	53.1955	14.9351
+location	Okuniew	52.2722806	21.3063932
+location	Olavarría	-36.8939975	-60.3227331
+location	Oława	50.95709295	17.290269769664455
+location	Olby	45.744596	2.8668699
+location	Old Dhaka	23.72164421566825	90.38330422737843
+location	Oldebroek	52.45673635	5.951864370961877
+location	Oldenzaal	52.30853685	6.914603743122237
+location	Oldham County	35.3907651	-102.6193428
+location	Olecki	54.1471432	22.343437088695246
+location	Olecko	54.0398024	22.4934246
+location	Olen	51.163420	4.888294
+location	Olendy	52.6965419	22.7596715
+location	Olesa de Montserrat	41.543053	1.8931874
+location	Olesnica	51.2102428	17.38294699262042
+location	Olesno	50.8766575	18.4219452
+location	Olewin	50.2781056	19.6046392
+location	Olhos-D''Agua	-17.3988426	-43.5715884
+location	Olhos-d'Água	-17.3988426	-43.5715884
+location	Olhovka	57.2180167	60.6855879
+location	Olimpia	-20.736634	-48.910625
+location	Olinda	-7.9986401	-34.8459552
+location	Oliva	38.9198	-0.1188
+location	Oliva AR	-32.0424889	-63.5670199
+location	Olivedos	-6.991036	-36.2437286
+location	Olkusz	50.2788158	19.5596307
+location	Olleria	38.9146	-0.5506
+location	Olmen	51.1403431	5.1478972
+location	Olmonty	53.08359	23.1626386
+location	Olmsted County	43.999812	-92.3765614
+location	Olobok	51.73697	17.7381718
+location	Olost	41.9852931	2.0941621
+location	Olot	42.1822177	2.4890211
+location	Olpad	21.3401	72.7554
+location	Olsztyn	53.774711	20.481482
+location	Oltarzew	52.2117748	20.7641995
+location	Omaha	41.2587459	-95.9383758
+location	Omal	50.6554534	5.1969427
+location	Omar Torrijos	9.062602649999999	-79.51952295729717
+location	Omsk	54.991375	73.371529
+location	Oncativo	-34.6945628	-58.3680391
+location	Onda	39.9621514	-0.2593846
+location	Onda Verde	-20.6071428	-49.2950997
+location	Ondavské Matiašovce	48.9362182	21.7458667
+location	Ondřejov	49.9045659	14.7831213
+location	Oneida County	43.2144051	-75.4039155
+location	Oneida County NY	43.2144051	-75.4039155
+location	Oneida County WI	45.6879163	-89.4779558
+location	Ongole	15.5075545	80.06080046754784
+location	Onondaga County	43.0268	-76.1784
+location	Ontario County	42.8580624	-77.295025
+location	Ontoria	43.30984	-4.21334
+location	Onze-Lieve-Vrouw-Waver	51.0624896	4.5798347
+location	Ooigem	50.8931388	3.3367124
+location	Oostduinkerke	51.1156338	2.6812656
+location	Oosteeklo	51.1929943	3.687828
+location	Oosterwolde	52.9889778	6.2907791
+location	Oosterzele	50.9456388	3.8032713
+location	Oostham	51.104087	5.1769241
+location	Oostkamp	51.1532024	3.2344535
+location	Oostmalle	51.300438	4.734269
+location	Oostnieuwkerke	50.9404849	3.0592908
+location	Oostrozebeke	50.931551	3.338685
+location	Opalenica	52.3088119	16.4124256
+location	Opatow	50.8017661	21.4238281
+location	Opglabbeek	51.0429949	5.581962
+location	Opgrimbie	50.943054367746875	5.680873544887415
+location	Ophain-Bois-Seigneur-Isaac	50.6658971	4.3480069
+location	Ophoven	51.1271135	5.8015396
+location	Oplotki	51.5865135	18.742208
+location	Opmeer	52.704381749999996	4.928568037131412
+location	Opole	50.678792900000005	17.929884436033525
+location	Opole Lubelskie	51.1475365	21.9664152
+location	Opwijk	50.9690529	4.1896665
+location	Or Haner	31.5566083	34.602628
+location	Or-Yehuda	32.0309712	34.8523936
+location	Oral	51.222382	51.373421
+location	Oran	-23.33267565	-64.31654187702753
+location	Orange County CA	33.689584	-117.788718
+location	Orange County FL	28.495156	-81.3111658
+location	Orange County NC	36.0605095	-79.1172679
+location	Orange County NY	41.394693	-74.289170
+location	Orange County TX	30.1228634	-93.9041169
+location	Orangeburg County	33.4054944	-80.778429
+location	Oravska Jasenica	49.4170157	19.42047790498072
+location	Oravska Lesna	49.3689979	19.1852951
+location	Oravska Polhora	49.5166666	19.4499999
+location	Oravske Vesele	49.4666666	19.3833332
+location	Oravsky Biely Potok	49.2859876	19.5530158
+location	Orbeil	45.5617334	3.2792178
+location	Orcet	45.7067	3.17459
+location	Orchowo	52.5063314	18.0147496
+location	Orcines	45.7853457	3.0113839
+location	Ordes	43.076756	-8.407816
+location	Ordizia	43.0539687	-2.1795046
+location	Oreamuno	9.9974653	-83.84570319897304
+location	Orechova	48.7044045	22.2262685
+location	Oregon City	45.3573429	-122.6067583
+location	Oregon WI	42.927835	-89.380569
+location	Orejo	43.40318395	-3.743228763381925
+location	Orekhovo-Zuyevo	55.8083278	38.9790038
+location	Orellana	-0.6013233499999999	-76.55625798976627
+location	Orenburg	51.767452	55.097118
+location	Orgiva	36.9004942	-3.4238759
+location	Oria	37.483858850000004	-2.292270054440231
+location	Oriente	-22.1525442	-50.0935645
+location	Orindiuva	-20.1819444	-49.3508333
+location	Oris	42.065576	2.212260540120897
+location	Orlandia	-20.720278	-47.886667
+location	Orléans	47.9027336	1.9086066
+location	Orleans County	43.2244513	-78.2272835
+location	Orleans Parish	30.0801436	-89.9319134
+location	Orleans Parish LA	30.0801436	-89.9319134
+location	Orlowo	52.7728216	16.8245874
+location	Ormalingen	47.4696552	7.8755353
+location	Orodara	10.9821014	-4.9148962
+location	Oropesa	40.0932103	0.1353519
+location	Oros	-6.2427541	-38.9141151
+location	Orosi	9.795924	-83.8537988
+location	Oroso	42.9948	-8.3636
+location	Orot	31.7407214	34.734914
+location	Orotina	9.913179	-84.523659
+location	Orrius	41.5551821	2.3549387
+location	Orsay	48.703347	2.187373
+location	Orsk	51.2305015	58.4738015
+location	Orta Nova	41.32993	15.710656
+location	Orthez	43.4874963	-0.7738363
+location	Ortuella	43.3105667	-3.0555981
+location	Oruna	43.4023668	-3.9493584
+location	Orvin	47.1606885	7.212695
+location	Oryol	52.9685433	36.0692477
+location	Orzysz	53.809833	21.9473601
+location	Osa	8.89140555	-83.40701199979404
+location	Osasco	-23.5372	-46.7962
+location	Oscadnica	49.4357777	18.8838235
+location	Oscar Bressane	-22.314874	-50.281118
+location	Osieczany	49.8414451	19.9798684
+location	Osijek	45.5548719	18.6953719
+location	Osno Lubuskie	52.455132	14.8682003
+location	Osnolubuskie	52.45459385883402	14.874004126991062
+location	Osorio	-29.8890733	-50.2740498
+location	Osorno	-40.5733223	-73.1359011
+location	Oss	51.762396	5.530563
+location	Ostrava	49.8349139	18.2820084
+location	Ostroda	53.7028052	19.962863844011487
+location	Ostrodzki	53.6	19.5786111
+location	Ostrow	52.2016667	18.1216667
+location	Ostrow (Łódzkie)	51.9259414	19.433536
+location	Ostrow (Malopolskie)	50.1344444	20.8313889
+location	Ostrow (Wielkopolskie)	51.6471864	17.80376070395092
+location	Ostrowek	52.167398	18.9779247
+location	Ostrowiec Swietokrzyski	50.95020905	21.411509244172763
+location	Ostrozki	54.243118	18.4606394
+location	Ostrzeszow	51.4257664	17.9331788
+location	Oswaldo Cruz	-21.7962773	-50.879119
+location	Oswego County	43.4112973	-76.1279841
+location	Oswiecim	50.0336707	19.260079835793633
+location	Otavalo	0.22276364999999998	-78.24542744351957
+location	Otero County	32.5059533	-105.8063662
+location	Otmice	50.5579208	18.1502056
+location	Otmuchow	50.46553145	17.13236551741759
+location	Otsego County	42.5984272	-75.0142701
+location	Ottawa	45.421106	-75.690308
+location	Ottenburg	50.7522298	4.6153442
+location	Ottignies	50.666357	4.5690502
+location	Ottignies-Louvain-la-Neuve	50.6654216	4.5674107
+location	Ottonville	49.2186146	6.5222675
+location	Otura	37.0913	-3.6345
+location	Otwock	52.1161661	21.293454716820303
+location	Ouachita Parish	32.4790511	-92.1615004
+location	Oud-Heverlee	50.8376275	4.6629253
+location	Oud-Turnhout	51.319510	5.004179
+location	Oudenaken	50.7804875	4.1958992
+location	Oudenburg	51.201183150000006	3.006108952018163
+location	Oudsbergen	51.0680799	5.557165
+location	Oudtshoorn	-33.5902954	22.204206
+location	Ougrée	50.5992632	5.5389943
+location	Ouricuri	-7.884432	-40.0833221
+location	Ourinhos	-22.9777918	-49.868204
+location	Ouro Branco	-20.5230256	-43.6917329
+location	Ouro Branco MG	-20.5230256	-43.6917329
+location	Ouro Branco RN	-6.703294	-36.9429599
+location	Ouro Verde	-21.4892638	-51.7025981
+location	Outagamie County	44.41603	-88.4602005
+location	Outes	42.8428093	-8.9084798
+location	Outgaarden	50.7664942	4.9192485
+location	Ouvidor	-18.2296167	-47.8351544
+location	Ovalle	-30.6030819	-71.2029894
+location	Overijse	50.769757	4.532583
+location	Overpelt	51.219149	5.383722
+location	Overport	-29.837791950000003	30.990248958511735
+location	Overvecht	52.1177281	5.1094214
+location	Oviedo	43.3533424	-5.879514339526834
+location	Owyhee County	42.4677336	-116.1590085
+location	Oxford	51.7520131	-1.2578499
+location	Oxford County	44.4694529	-70.7782375
+location	Oyonnax	46.2476592	5.673359347171946
+location	Ozarow	50.8864089	21.6656244
+location	Ozaukee County	43.407672	-87.926654
+location	Ozdany	48.3779422	19.904099342365605
+location	Ozyorsk	55.76046	60.705101
+location	Paal	51.031859	5.166158
+location	Pabianice	51.6662312	19.35925466859993
+location	Pabna	24.0129	89.2591
+location	Pacajus	-4.171073	-38.464988
+location	Pacaraima	4.4791253	-61.1471016
+location	Pacho	5.135952	-74.156902
+location	Pacific County	46.5334929	-123.768029
+location	Pacific County WA	46.5334929	-123.768029
+location	Paco	14.5793612	120.9950209
+location	Paco do Lumiar	-2.5325902	-44.1591104
+location	Pacora	9.0827803	-79.288579
+location	Paczkow	50.4636773	17.0057683
+location	Padang	-0.9247587	100.3632561
+location	Padang Panjang	-0.46333235933252004	100.39990564477131
+location	Padang Pariaman	-0.5467895814081101	100.22910882144373
+location	Padova	45.4077172	11.8734455
+location	Padra	22.2411191	73.0857027
+location	Padre Hurtado	-33.5673051	-70.8020467
+location	Padre las Casas	-38.7674245	-72.5956312
+location	Padrón	42.7381	-8.6608
+location	Padul	37.0222913	-3.6274938
+location	Paillaco	-40.0706715	-72.8727124
+location	Pailon	-17.6592379	-62.719661
+location	Paimpol	48.7794818	-3.0484022
+location	Paine	-33.8101102	-70.7390236
+location	Paiporta	39.4288431	-0.4193767
+location	Paipote	-27.4147265	-70.2749806
+location	Pajan	-1.70407915	-80.42129748047982
+location	Pajara	36.9941187	-5.2353096
+location	Pajeczno County	51.1408981	19.019363191126182
+location	Pajonal	8.5937539	-80.254955
+location	Pakawie	52.68502	16.23844
+location	Pakostov	49.093197	21.8232761
+location	Pakpattan	30.3422503	73.3891875
+location	Pakur	24.6379064	87.8556962
+location	Palacios de la Valduerna	42.3279483	-5.9389711
+location	Palafrugell	41.9183618	3.1619905
+location	Palamos	41.8495354	3.1278785
+location	Palampur	32.0893012	76.5098926962527
+location	Palanga	55.9229818	21.0682657
+location	Palanpur	24.173368	72.432000
+location	Palapye	-22.536888	27.123513
+location	Palarikovo	48.0441287	18.0695797
+location	Palata	41.8905148	14.785357
+location	Palau Solita i Plegamans	41.5873942	2.1806823
+location	Palaudalba	41.5887669	2.1985989
+location	Paledzie	52.3701023	16.7364634
+location	Palekh	56.802418	41.853912
+location	Palembang	-2.9888297	104.756857
+location	Palencia	42.409632200000004	-4.616100410293067
+location	Palencia GT	14.68356905	-90.31109872732664
+location	Palermo	38.1112268	13.3524434
+location	Palestina	-20.389344	-49.4320384
+location	Palghar	19.68086385	72.82537342511341
+location	Palhoca	-27.6447774	-48.6646323
+location	Palleja	41.4223425	1.9969904
+location	Palm Beach County	26.6279798	-80.4494174
+location	Palma	39.5696	2.6502
+location	Palma BR	-19.4364967	-43.9331557
+location	Palma de Gandia	38.9251	-0.2215
+location	Palma de Mallorca	39.577847	2.650605
+location	Palma del Rio	37.6949622	-5.2804262
+location	Palma ES	39.5768033	2.6538742
+location	Palmacia	-4.1478012	-38.8460317
+location	Palmanova	39.5237047	2.5383777
+location	Palmar	8.9379895	-83.42871199112112
+location	Palmares	-8.684226	-35.589032
+location	Palmares CR	10.046546	-84.43557991130497
+location	Palmares Paulista	-21.085369	-48.803656
+location	Palmas	-10.1835604	-48.3337793
+location	Palmeira	-25.4269718	-49.9987787
+location	Palmeira Dos Indios	-9.4076249	-36.6323616
+location	Palmela	38.569601	-8.9011653
+location	Palmira	3.534069	-76.297658
+location	Palol D'Onyar	41.9540376	2.8450181
+location	Pals	41.9709891	3.1460371
+location	Palu	-0.8957793	119.8679974
+location	Palwal	28.12502575	77.35831300773046
+location	Pamanes	43.3562905	-3.7741084
+location	Pampa del Indio	-26.048588	-59.92678409099645
+location	Pamplona	42.808441	-1.648651
+location	Pamplona CO	7.3763195	-72.6481984
+location	Pamplona ES	42.8184538	-1.6442556
+location	Panadura	6.7123961	79.9074569
+location	Pancevo	44.8705686	20.6399643
+location	Panchagarh	26.32215705	88.5477309406956
+location	Panchkula	30.616216450000003	77.04197804321875
+location	Panchmahal	23.1283012	73.6057591
+location	Panes	43.323424	-4.583991
+location	Panevezys	55.7344985	24.3578055
+location	Pangsha Upazila	23.7909362	89.425505
+location	Panguipulli	-39.6419909	-72.3333801
+location	Pannes	48.0188506	2.6693801
+location	Panola County	32.1920	-94.3154
+location	Panola County MS	34.3793392	-89.9601925
+location	Panola County TX	32.1367712	-94.3130073
+location	Panthapath	23.7511561	90.3872285
+location	Papaichton	3.8089857	-54.1506334
+location	Papeete	-17.5373835	-149.5659964
+location	Papum Pare	27.286366649999998	93.61875168206382
+location	Paracambi	-22.6109158	-43.7096912
+location	Paracatu	-17.2174056	-46.8707514
+location	Paracito	9.9939017	-84.0252872
+location	Paracuru	-3.41436	-39.030028
+location	Paradiso	45.9897313	8.9461979
+location	Paragominas	-2.99564	-47.3548942
+location	Paraguacu Paulista	-22.4203497	-50.5792099
+location	Paraiba do Sul	-22.1636384	-43.2916915
+location	Paraibuna	-23.3864203	-45.6626797
+location	Paraiso	9.731299199999999	-83.7734840019595
+location	Paraiso BR	-21.015911	-48.776105
+location	Paraiso CR	9.731299199999999	-83.7734840019595
+location	Paraiso Das Aguas	-19.0219279	-53.0122646
+location	Paraiso do Tacantins	-10.174591036185339	-48.8851868150314
+location	Parana	-31.7330145	-60.5298511
+location	Paranagua	-25.5148822	-48.5226695
+location	Paranamirim	-5.909627427956433	-35.237883160322916
+location	Paranapua	-20.1033995	-50.5858761
+location	Paranavai	-23.08165	-52.461724
+location	Paranhos	-23.8927851	-55.4287213
+location	Paraopeba	-19.2756823	-44.4034123
+location	Parati	-23.2196461	-44.7154196
+location	Paray le Monial	46.450559	4.1177959
+location	Parczew	51.639	22.9
+location	Pardesia	32.3070353	34.9097723
+location	Pardines	45.5622469	3.1737867
+location	Pardubice	50.0385812	15.7791356
+location	Pareci Novo	-29.6386722	-51.3961969
+location	Paredones	-34.6476395	-71.9008463
+location	Parent	45.6235094	3.2294652
+location	Parets del Valles	41.5729887	2.2329289
+location	Pariaman	-0.6263889	100.1177778
+location	Parintins	-2.6344567	-56.7319324
+location	Pariquera-Acu	-24.7146891	-47.8802361
+location	Paris	48.853884	2.341738
+location	Park County MT	45.5027347	-110.52981
+location	Parker County	32.7599475	-97.7935767
+location	Parla	40.2373	-3.7740
+location	Parmer County	34.4901153	-102.768021
+location	Parnaiba	-2.9147515	-41.7661953
+location	Parnamirim	-5.9153334	-35.2679913
+location	Parobe	-29.624257	-50.83118
+location	Parque de las Castillas	40.68746134675178	-3.3727751720985197
+location	Parque Lefevre	9.015279	-79.485133
+location	Parque Real	9.073041	-79.415980
+location	Parrita	9.54712105	-84.36634395935779
+location	Parsowek	53.21531	14.70473
+location	Parszow	51.0747132	20.934615
+location	Partizanske	48.6264092	18.3730067
+location	Pasay City	14.5436995	120.9946503
+location	Paschim Bardhaman	23.64260775	87.16448126068323
+location	Paschim Medinipur	22.3599134	87.41331447600871
+location	Pasco County	28.2996183	-82.4522702
+location	Paslek	54.0626346	19.6565365
+location	Paslieres	45.9314279	3.4962468
+location	Passa E Fica	-6.4356697	-35.6434459
+location	Passaic County	40.955105	-74.229353
+location	Passira	-7.976317	-35.5817327
+location	Passo de Camaragibe	-9.2367833	-35.4901015
+location	Passo Fundo	-28.2550598	-52.3966606
+location	Pasto	1.2146286	-77.2782516
+location	Pastrana	40.4178968	-2.9225859
+location	Pasuruan	-7.6419894	112.906694
+location	Pasym	53.6521615	20.7917422
+location	Patagones	-41.1332769	-71.3781736
+location	Patalillo	9.9732654	-84.0267539
+location	Patan	23.77405735	71.68373465668734
+location	Patergassen	46.8167402	13.8661158
+location	Paterna	39.5039227	-0.4421014
+location	Paterson	40.9167654	-74.171811
+location	Patiala	30.2090874	76.3398720856221
+location	Pato Branco	-26.2295984	-52.6712474
+location	Patos	-7.0258285	-37.2766817
+location	Patos de Minas	-18.6041453	-46.5096698
+location	Patrocinio	-18.9408294	-46.9926624
+location	Patrocinio Paulista	-20.6383609	-47.2801241
+location	Patu	-6.1006213	-37.6385148
+location	Paty do Alferes	-22.4272703	-43.4219523
+location	Patzicia	14.632440299999999	-90.92936960655643
+location	Pau	43.2957547	-0.3685668
+location	Pau Brasil	-15.4645802	-39.6518409
+location	Pau Dos Ferros	-6.1124964	-38.2062628
+location	Paulhac	45.0067892	2.9046136
+location	Paulhenc	44.8895151	2.8174107
+location	Paulista	-7.9340069	-34.868407
+location	Pauri Garhwal	29.84591115	78.70766746320547
+location	Pavas	9.949444100000001	-84.13606387665581
+location	Pavia	45.036854649999995	9.137825082826026
+location	Pavlovce nad Uhom	48.6128015	22.0691252
+location	Pavon Arriba	-33.3121233	-60.8225642
+location	Pawlow	50.9621212	21.1205169
+location	Pawłowice	49.9608911	18.7161904
+location	Pawlowko	53.6816601	17.6136696
+location	Payakumbuh	-0.2249721	100.6318259
+location	Payette County	44.0374651	-116.7651123
+location	Peabiru	-23.9142123	-52.3455598
+location	Pearl River County	30.7761973	-89.5984726
+location	Pecna	52.182	16.80252
+location	Pecos	31.4143185	-103.4949011
+location	Pecos County	30.7857437	-102.8065415
+location	Pécrot	50.7716031	4.6501601
+location	Peddapalli	18.62065305	79.49501710882896
+location	Peddapally	16.3760198	78.4053687
+location	Pederneiras	-22.351086	-48.778113
+location	Pedras de Fogo	-7.3988977	-35.112176
+location	Pedras de Maria Da Cruz	-15.605833	-44.391944
+location	Pedregal	9.1302704	-79.4594271
+location	Pedreira	-22.741347	-46.894846
+location	Pedreiras	-4.8167966	-42.188169
+location	Pedrezuela	40.7451088	-3.6030185
+location	Pedro Afonso	-8.9757351	-48.1733282
+location	Pedro Aguirre Cerda	-33.49340995	-70.67690706456402
+location	Pedro de Toledo	-24.2769071	-47.23393
+location	Pedro Martinez	37.5014235	-3.2303678
+location	Pedrola	41.7874421	-1.2142283
+location	Peel en Maas	51.33064175	5.979363705773345
+location	Peer	51.128120	5.458372
+location	Pehuenches	-38.9624082	-68.0804978
+location	Peize	53.148934	6.4933571
+location	Pekanbaru	0.5262455	101.4515727
+location	Pelarco	-35.3836634	-71.4469824
+location	Pelczyce	53.04218	15.30591
+location	Peligros	37.2306631	-3.6279744
+location	Pellenberg	50.8705848	4.7939828
+location	Pelotas	-31.7699736	-52.3410161
+location	Pelt	51.210014	5.420519
+location	Pemba	-12.9735663	40.5214905
+location	Pemuco	-36.9767274	-72.0987839
+location	Peñacastillo	43.4458084	-3.8659624
+location	Penacova	40.2702086	-8.2810743
+location	Penaflor	-33.6058638	-70.8785306
+location	Penagos	43.3413728	-3.8068404
+location	Penalolen	-33.48622465	-70.50929029561439
+location	Penapolis	-21.4192406	-50.0765588
+location	Pencahue	-35.396134	-71.7993832
+location	Pend Oreille County	48.5188671	-117.2778631
+location	Penelles	41.7585402	0.9652356
+location	Penha	-26.775418	-48.6465251
+location	Peniche	39.337225149999995	-9.312852835582468
+location	Penobscot County	45.2930166	-68.5957766
+location	Peñol	6.2541153000000005	-75.23635342556997
+location	Penonome	8.67998305	-80.24925600570114
+location	Penza	53.200001	45.0
+location	Peoria County	40.8021278	-89.7713762
+location	Pepin County	44.6351571	-92.0101928
+location	Peralta	42.337833	-1.799176
+location	Perambalur	11.2287716	78.8182555496278
+location	Pereira	4.804771	-75.717885
+location	Pereira Barreto	-20.6378509	-51.1052172
+location	Perez	-32.9982237	-60.7708529
+location	Perez Zeledon	9.355504	-83.624556
+location	Pergamino	-33.897495	-60.575046
+location	Perico	-24.3938068	-65.11528896134641
+location	Perignat sur Allier	45.7290686	3.2329941
+location	Perigueux	45.1909365	0.7184407
+location	Peritoro	-4.3723643	-44.3317455
+location	Perm	58.014965	56.246723
+location	Perpezat	45.6787928	2.7742636
+location	Perpignan	42.6985304	2.8953121
+location	Perquenco	-38.4212493	-72.3778344
+location	Perry County	38.0772859	-89.3760499
+location	Perry County AL	32.6421387	-87.2876639
+location	Perry County IL	38.0772859	-89.3760499
+location	Pershing County	40.3913722	-118.4778996
+location	Perth	-31.942741	115.841171
+location	Peruibe	-24.3218105	-46.9977452
+location	Péruwelz	50.535464	3.566154
+location	Pervouralsk	56.904858	59.943119
+location	Perwez	50.6234469	4.8134719
+location	Pesqueira	-8.3574471	-36.6968238
+location	Pessac	44.805615	-0.6308396
+location	Pessat Villeneuve	45.9266575	3.1576837
+location	Petacciato	42.011439	14.860928
+location	Petah Tikva	32.0877639	34.8859985
+location	Petrer	38.485008	-0.7703987
+location	Petrolandia	-8.9701861	-38.2213655
+location	Petrolina	-9.3817334	-40.4968875
+location	Petropavlovsk-Kamchatsky	53.0199838	158.6471356
+location	Petropolis	-22.5112	-43.1779
+location	Petrova Ves	48.7225042	17.1614557
+location	Petrovany	48.9166204	21.2616031
+location	Petrozavodsk	61.790039	34.390007
+location	Pettenbach	47.9614255	14.0161792
+location	Pettneu Am Arlberg	47.13119495	10.353063484739884
+location	Peumo	-34.3959163	-71.1694264
+location	Peutie	50.9271744	4.4551981
+location	Pewaukee	43.061507	-88.237950
+location	Pezinok	48.2854539	17.270194
+location	Pfaffenhofen	49.3676719	11.660786
+location	Pfaffenweiler	48.0336388	8.4195787
+location	Pfaffing	48.02085625	13.467814947202752
+location	Pfarrkirchen	48.4320329	12.9386266
+location	Pfarrwerfen	47.4570287	13.205675
+location	Pfeffingen	47.4579858	7.589006
+location	Pfunden	46.9984543	10.5829968
+location	Pfunds	46.9984543	10.5829968
+location	Pfungstadt	49.8023181	8.5987671
+location	Philadelphia County	40.0114538	-75.1326504
+location	Phoenix	33.433362	-112.068786
+location	Phthiotis	38.88734025	22.368030084606932
+location	Piaseczno	52.0747377	21.0270885
+location	Piaski	51.8848287	17.0741589
+location	Piaskow	51.0745472	21.5243699
+location	Piastow	52.185592299999996	20.847823206203856
+location	Piatkowa	49.62747298368105	20.76057627275201
+location	Piatt County	39.967291	-88.6072399
+location	Picagres	9.9058692	-84.345546
+location	Picanya	39.4353965	-0.4358777
+location	Picassent	39.363519	-0.4611789
+location	Pichidegua	-34.3586378	-71.2829135
+location	Pichilemu	-34.3851693	-72.0046606
+location	Pickaway County	39.6725327	-83.0373284
+location	Pickens County	34.8882592	-82.7193824
+location	Pickens County AL	33.2948421	-88.1244034
+location	Pickens County SC	34.8882592	-82.7193824
+location	Picon	39.0635433	-4.077399354767059
+location	Piece	53.8846363	18.2151789
+location	Piechowice	50.827706500000005	15.57653885499911
+location	Piecowice	51.1442284	17.2175821
+location	Piedade	-23.7074096	-47.4252319
+location	Piedrabuena	39.0344592	-4.1753284
+location	Piedras Blancas	8.7823809	-83.2417516
+location	Pielagos	43.357425	-3.9602596
+location	Pien	-26.0988916	-49.4297904
+location	Pierce County WA	47.0022547	-122.2117983
+location	Pierce County WI	44.7186568	-92.3786114
+location	Pierre-Bénite	45.7028321	4.8241323
+location	Pierzchaly	54.2960269	19.8372315
+location	Piestany	48.5895247	17.8213848
+location	Pieszyce	50.7124412	16.581609
+location	Pietna	50.44613	17.96239
+location	Pietno	52.01929	18.35298
+location	Pietracatella	41.5811599	14.8737322
+location	Pietramontecorvino	41.541631	15.127541
+location	Pignols	45.6447255	3.283029
+location	Pike County	31.7615793	-85.9259465
+location	Pike County AL	31.7615793	-85.9259465
+location	Pike County IL	39.6108707	-90.8538306
+location	Pike County MS	31.1712493	-90.4093394
+location	Pike County PA	41.340546	-75.008326
+location	Pikine	14.751544	-17.396413
+location	Pikkolovo	59.699724818705235	30.137854541905703
+location	Pila	53.1511324	16.7380343
+location	Pilar	-7.264034	-35.252326
+location	Pilar AR	-34.4570918	-58.9141609
+location	Pilar BR	-7.264034	-35.252326
+location	Pilawa Gorna	50.68291525	16.751068021685484
+location	Pilchowo	53.4983702	14.4794935
+location	Piles	38.9407693	-0.1325845
+location	Pilibhit	28.495207649999998	80.10754080018077
+location	Piliyandala	6.8018439	79.9227034
+location	Pilon	9.3576891	-79.7931333
+location	Pilsbach	48.040517699999995	13.67654094943951
+location	Pima County	32.1112624	-111.6546163
+location	Pinal County	32.8085851	-111.4426212
+location	Pinczow	50.5201929	20.5256241
+location	Pindamonhangaba	-22.9340165	-45.462938
+location	Pindorama	-21.1853	-48.90861
+location	Pindushi	62.9177751	34.5791755
+location	Pine County	46.0820957	-92.7542126
+location	Pineda de Bages	41.7597912	1.8365883
+location	Pineda de Mar	41.6276807	2.6898707
+location	Pinellas County	27.8778904	-82.7329309
+location	Pingxiang	27.632413	113.892981
+location	Pinhais	-25.4443488	-49.1900307
+location	Pinhao	-25.6960895	-51.6566366
+location	Pinheiral	-22.5129436	-44.001435
+location	Pinilla de Jadraque	41.0202461	-2.9430528
+location	Pinogana	8.4990736	-77.9720053
+location	Pinos Puente	37.2515	-3.7496
+location	Pinoso	38.4021056	-1.041617
+location	Pinsdorf	47.9339958	13.7698312
+location	Piotrkow Trybunalski	51.412841400000005	19.688801329018943
+location	Pioz	40.462515	-3.1754698
+location	Piquete	-22.6138451	-45.1777096
+location	Piracaia	-23.052545	-46.359374
+location	Piracema	-20.5091579	-44.4754464
+location	Piracicaba	-22.72528	-47.64917
+location	Pirai	-22.6287489	-43.8981758
+location	Pirangi	-21.0969076	-48.663862
+location	Pirapemas	-3.7270563	-44.2267429
+location	Pirapora	-17.3493765	-44.9507904
+location	Pirapozinho	-22.2738742	-51.4998867
+location	Pirassununga	-21.9980468	-47.4280861
+location	Pirauba	-21.276945	-43.025834
+location	Pires do Rio	-17.3006277	-48.2793037
+location	Pirojpur	22.50956015	90.00725950308801
+location	Pirque	-33.6348808	-70.5729961
+location	Písařov	50.0049678	16.8015028
+location	Pisarzowice	49.8835716	19.145428
+location	Pisek	49.3089887	14.147769
+location	Piski	53.680787800000004	21.822211854231615
+location	Piskorowice	50.2350864	22.5301271
+location	Pitahaya	9.9373912	-84.0920344
+location	Pitanga	-24.759586	-51.7637582
+location	Pitangueiras	-21.013203	-48.220951
+location	Pitkin County	39.2037774	-106.8695332
+location	Pitrufquen	-38.9863089	-72.6372553
+location	Pitt County	35.611481	-77.3707461
+location	Pittem	50.999964750000004	3.262273003445322
+location	Pittsburgh	40.433375	-79.996990
+location	Pium	-10.4421368	-49.1747741
+location	Placer County	39.1012064	-120.7650606
+location	Placido de Castro	-10.3239154	-67.1824196
+location	Plaine Magnien	-20.4297123	57.6607501
+location	Planaltina	-15.6181947	-47.6555703
+location	Planalto	-21.0342886	-49.9286556
+location	Planalto Alegre	-27.0721133	-52.8667023
+location	Plancenoit	50.66254755	4.421212418273594
+location	Plaquemines Parish	29.4291161	-89.5123524
+location	Plasencia	40.0302938	-6.0902595
+location	Platja D'Aro	41.81709575	3.0696425219210752
+location	Plauzat	45.6216069	3.1497092
+location	Plavec	49.2620199	20.8447641
+location	Plavecký Štvrtok	48.3746452	16.9990157
+location	Playa Grande	15.9874734	-90.7811164
+location	Pleasant Hill	38.794218	-94.24767233975314
+location	Plerin	48.5348817	-2.7695752
+location	Plesivec	48.547137	20.4006607
+location	Plessis Trevise	48.8091528	2.5732616
+location	Pleszew	51.8960985	17.7865673
+location	Plewiska	52.3665196	16.809783
+location	Plock	52.520284	19.690317
+location	Ploegsteert	50.725900	2.880261
+location	Plonsk	52.626415300000005	20.364279247920496
+location	Plottier	-38.9523098	-68.2270197
+location	Płoty	53.8030947	15.2663988
+location	Ploudalmezeau	48.5415	-4.6578
+location	Plouzane	48.3817165	-4.6212044
+location	Plumas County	39.9430988	-120.8059521
+location	Plymouth County	41.9426657	-70.7618592
+location	Plzeň	49.7477415	13.3775249
+location	Pniewo	53.21738	14.49317
+location	Poa	-23.5249082	-46.3445663
+location	Poas	10.106127149999999	-84.2405137045792
+location	Pobiedziska	52.4773387	17.2870352
+location	Poção	-8.186709	-36.7023901
+location	Poco Branco	-5.6224378	-35.6615774
+location	Pococi	10.502688299999999	-83.65590110493497
+location	Pocos de Caldas	-21.7900318	-46.5647928
+location	Pocri	7.639097	-80.14664878634369
+location	Podbiel	49.3074639	19.4864266
+location	Podbrezova	48.8114617	19.5286427
+location	Poddebice	51.8931973	18.9517348
+location	Poděbrady	50.1430072	15.1191453
+location	Podgorzyn	50.8317543	15.6835944
+location	Podhajska	48.1038202	18.3396236
+location	Podhorany (Prešov)	49.0868945	21.348898237321016
+location	Podlesne	54.1131377	22.0218984
+location	Podmachocice	50.8905171	20.7873982
+location	Podolinec	49.256989	20.5351371
+location	Podolsk	55.4308841	37.5453056
+location	Podporozhye	62.126776076077526	36.80029529603531
+location	Pöggstall	48.3182492	15.185430124250704
+location	Pöndorf	47.9969423	13.3696421
+location	Pörtschach	46.6560824	14.5723054
+location	Pogorze	54.557956450000006	18.481311262201153
+location	Pogorzela	51.8224142	17.2310362
+location	Pogwizdow	49.8035035	18.5997983
+location	Pohronsky Ruskov	47.97535465	18.645135718003026
+location	Pointe Coupee Parish	30.6194283	-91.5740887
+location	Poissy	48.927439	2.0428293
+location	Poitiers	46.5802596	0.340196
+location	Pojuca	-12.4260268	-38.3266573
+location	Pokrov	55.91581240124317	39.18013779526692
+location	Pokrovskoe	56.468866873986094	61.61641917600969
+location	Pola de Lena	43.157313	-5.8283716633015885
+location	Polana Canico	-25.93562415746149	32.611144767703294
+location	Polanco	43.38461	-4.01642
+location	Polevskoy	56.442108	60.165859
+location	Poliakovce	49.2553598	21.4062902
+location	Police	53.5486435	14.5657399
+location	Police nad Metují	50.5368703	16.2335044
+location	Polinya	41.5581661	2.1584568
+location	Polk County	45.4318573	-92.407472
+location	Polk County IA	41.6765808	-93.5921448
+location	Polk County OR	44.879673	-123.4599594
+location	Polk County TX	30.7642828	-94.8192175
+location	Polk County WI	45.4318573	-92.407472
+location	Polkowice	51.5039288	16.0713371
+location	Pollenca	39.8792073	3.0157098
+location	Pollionnay	45.7659276	4.6607806
+location	Polokwane	-23.9058333	29.4613889
+location	Polonnaruwa	7.9395357	81.0003387
+location	Polop	38.6226795	-0.1275385
+location	Polski Swietow	50.3870727	17.3492986
+location	Poltar	48.4308293	19.7923921
+location	Pomaluengo	43.309977	-3.9302223
+location	Pomar De Valdivia	42.7745019	-4.1674162
+location	Pombal	-6.7711315	-37.7988646
+location	Ponce	18.011564	-66.613958
+location	Pondera County	48.2443094	-112.1206742
+location	Pons	45.5792284	-0.5471901
+location	Pont-à-Celles	50.51552395	4.3827158869125675
+location	Pont d'Inca	39.5983	2.6928
+location	Pont de Vilomara	41.7015043	1.8726147
+location	Pont Du Chateau	45.7971315	3.2492577
+location	Ponta Grossa	-25.0891685	-50.1601812
+location	Ponta Pora	-22.5286917	-55.723426
+location	Pontal	-21.0239714	-48.0393457
+location	Pontaumur	45.8680597	2.6755139
+location	Ponte Alta	-27.483497	-50.376404
+location	Pontecesures	42.7207856	-8.652991
+location	Pontejos	43.40711	-3.8001
+location	Pontevedra	42.6075172	-8.4714942
+location	Pontinha	38.7622108	-9.1968418
+location	Pontivy	48.0695882686933	-2.9639488211463747
+location	Pontoise	49.049228	2.098595
+location	Pontos	42.1858949	2.9172363
+location	Pontotoc County MS	34.2114655	-89.0382651
+location	Ponts	41.9160096	1.1882504
+location	Popayan	2.458755	-76.606118
+location	Pope County	37.3933531	-88.5904425
+location	Popenguine	14.5548157	-17.1129421
+location	Poperinge	50.854747	2.692635
+location	Popławy	52.7292735	22.8560017
+location	Popowko	52.63039	16.67122
+location	Poppel	51.445671	5.042493
+location	Poprad	49.0541521	20.2976401
+location	Poptun	16.32120005	-89.56145465494458
+location	Porciuncula	-20.9627278	-42.0405703
+location	Pordenone	45.9562503	12.6597197
+location	Pordic	48.56955725	-2.8189686278528208
+location	Poreba	50.21438	19.79704
+location	Porecatu	-22.753724	-51.37949
+location	Porosly	53.1467241	23.0531554
+location	Porosoozero	62.97679216520059	32.3164308411593
+location	Porqueres	42.122682299999994	2.725494527830609
+location	Port Chester	41.0018	-73.6657
+location	Port Colony	22.3093706	91.7929836
+location	Port Nolloth	-29.248889	16.870833
+location	Port Washington	43.382722	-87.885911
+location	Portage County	44.4604931	-89.5108818
+location	Portalban	46.9180986	6.9559587
+location	Portão	-29.6932554	-51.2331837
+location	Porter County	41.4457032	-87.0724971
+location	Portezuelo	-36.5274438	-72.4285922
+location	Portland	45.5202471	-122.6741949
+location	Porto Alegre	-30.0324999	-51.2303767
+location	Porto Belo	-27.1542415	-48.5424395
+location	Porto Da Folha	-9.9152762	-37.2791369
+location	Porto Feliz	-23.2125392	-47.5240065
+location	Porto Ferreira	-21.8529134	-47.4794943
+location	Porto Real	-22.4198366	-44.2897974
+location	Porto Seguro	-16.443473	-39.064251
+location	Porto Uniao	-26.2336416	-51.082771
+location	Porto-Vecchio	41.5921091	9.2761531
+location	Porto Velho	-8.7494525	-63.8735438
+location	Porto Xavier	-27.9061459	-55.1395757
+location	Portobelo	9.5006933	-79.61066220584127
+location	Portocannone	41.9151406	15.0092678
+location	Portoviejo	-1.0528066	-80.4534269
+location	Portugalete	43.317356	-3.021671
+location	Porúbka (Zilina)	49.154945	18.7255229
+location	Porvenir	-53.2956738	-70.3687401
+location	Porzecze	50.9969136	20.3646556
+location	Posada de la Valduerna	42.3113416	-6.0215444
+location	Posadas	-27.398263749999998	-55.924015527060114
+location	Poste La Fayette	-20.1186767	57.7516918
+location	Potenza	40.5183188	15.820959951106293
+location	Potes	43.1536831	-4.623428
+location	Potirendaba	-21.0457369	-49.3767154
+location	Potosi	0.7340175	-77.40917648770488
+location	Potter County TX	35.3683354	-101.8776577
+location	Potworow	50.5289618	16.7534839
+location	Povazska Bystrica	49.1159316	18.4469936
+location	Povenets	62.848721	34.820995
+location	Povina	49.3110622	18.812491
+location	Povo Grande	-5.6149565	12.1961052
+location	Powder River County	45.3655661	-105.5982213
+location	Powell County MT	46.9109569	-113.0294193
+location	Power County	42.6769078	-112.8869775
+location	Powidz	52.4125881	17.9169686
+location	Poyarkovo	49.621155	128.65097
+location	Poznachowice Górne	49.8249601	20.1295342
+location	Poznan	52.4006632	16.91973259178088
+location	Poznan-Wilda	52.4016269	16.9115788
+location	Pozo Alcon	37.7020186	-2.9327448
+location	Pozo Almonte	-20.2597061	-69.7861372
+location	Pozo de Guadalajara	40.4954105	-3.1806297
+location	Pozoblanco	38.3780204	-4.848573
+location	Pozos	9.9502456	-84.1911063
+location	Pozuelo de Alarcon	40.4346528	-3.814834
+location	Pozuelo de Calatrava	38.9119565	-3.8371496
+location	Pożarowo	52.6876228	16.2654827
+location	Prachatice	49.0131123	13.9977479
+location	Pradejon	42.331616	-2.067126
+location	Pradopolis	-21.3597815	-48.0746603
+location	Pradzona	54.00248	17.33321
+location	Prague-Miskovice	50.1643364	14.5414996
+location	Praha 17	50.0710617	14.3002613
+location	Praha 2	50.074545	14.4428032
+location	Praha 3	50.0842953	14.4687584
+location	Praha 4	50.04895	14.4417517
+location	Praha 5	50.0756334	14.4062009
+location	Praha 6	50.098769	14.3961962
+location	Praha 8	50.1029249	14.4769295
+location	Praha 9	50.1234799	14.4978254
+location	Praia Grande	-24.005833	-46.402778
+location	Praia Grande SC	-29.1966831	-49.9491971
+location	Praia Grande SP	-24.005833	-46.402778
+location	Prainha	-1.8072874	-53.4797942
+location	Prairie County	46.8103971	-105.3390398
+location	Prakasam	15.5	79.5
+location	Prakovce	48.8167474	20.8999535
+location	Prambachkirchen	48.3164376	13.9072152
+location	Prantij	23.4367	72.8528
+location	Prata do Piauí	-5.6692702	-42.2067899
+location	Prats de Lluçanès	42.0085421	2.0298689
+location	Pratteln	47.5192013	7.6944741
+location	Pravia	43.4896744	-6.1138664
+location	Pregassona	46.01905	8.9744329
+location	Premia de Dalt	41.5076668	2.3437394
+location	Premia de Mar	41.4926822	2.3605846
+location	Premilhat	46.3140123	2.5370983
+location	Prenda	-8.8368115	13.2226291
+location	Presidencia de la Plaza	-27.00416935	-59.8430992986941
+location	Presidente Bernardes	-22.0064609	-51.5542973
+location	Presidente Epitacio	-21.765074	-52.11114
+location	Presidente Figueiredo	-2.0486359	-60.0236658
+location	Presidente Getulio	-27.0426247	-49.6210429
+location	Presidente Kennedy	-8.5340643	-48.5060747
+location	Presidente Kennedy ES	-21.1000137	-41.0436113
+location	Presidente Kennedy TO	-8.5340643	-48.5060747
+location	Presidente Perón	-34.6322427	-58.6422754
+location	Presidente Prudente	-22.1225167	-51.3882528
+location	Presidente Venceslau	-21.8744	-51.8443
+location	Presidio County	29.9883766	-104.2336552
+location	Pretoria	-25.7459374	28.1879444
+location	Příbram	49.6901444	14.0103663
+location	Price County	45.676627	-90.368792
+location	Prichsenstadt	49.8181263	10.3513154
+location	Prievaly	48.558454	17.3493194
+location	Prievidza	48.7718361	18.6234916
+location	Prijedor	44.9805039	16.7131197
+location	Prilep	41.3446796	21.5505496
+location	Primavera	-8.3308449	-35.3523034
+location	Primavera do Leste	-15.5614127	-54.2993946
+location	Primavera PA	-0.9406522	-47.116728
+location	Primavera PE	-8.3308449	-35.3523034
+location	Primeiro de Maio	-22.851714	-51.029251
+location	Primero de Julio	14.6689778	-90.5691009
+location	Prince Albert	-33.222626	22.030331
+location	Prince George's County	38.803929	-76.8518695
+location	Pringsewu	-5.36668925	104.97221206481078
+location	Pringy	45.95475725	6.119092163980504
+location	Privas	44.723301	4.594575
+location	Profondeville	50.3762043	4.8675024
+location	Progreso	-32.0334928	-61.2117497
+location	Progress	49.7428748	129.6753189
+location	Prokhorovka	51.03581823614324	36.73063400760547
+location	Promissao	-21.5404913	-49.8574709
+location	Promna-Kolonia	51.6958397	20.9287897
+location	Propria	-10.212427	-36.8372254
+location	Prospect	41.5023	-72.9787
+location	Prostějov	49.4724	17.1068
+location	Proszowice	50.1926479	20.2917555
+location	Provence	43.66473079064977	6.155280148468886
+location	Providence County	41.8677428	-71.5814834
+location	Providencia	-33.4288379	-70.61133725589745
+location	Provins	48.5602959	3.2988089
+location	Pruchna	49.8662823	18.6835263
+location	Prudnik	50.3217212	17.5801041
+location	Pruhonice	49.9952056	14.564819030506728
+location	Pruszcz	53.3294095	18.1993931
+location	Pruszcz Gdanski	54.25785495	18.65011494396544
+location	Pruszkow	52.17203175	20.801120489954947
+location	Pruszowice	51.1874571	17.1336232
+location	Przebedowo	52.5875864	17.0207048
+location	Przeclaw	52.36513	18.04642
+location	Przeclaw (Wielkopolskie)	52.36513	18.04642
+location	Przeclaw (Zachodniopomorskie)	53.3768469	14.4723853
+location	Przedborowa	50.64178	16.72432
+location	Przedmiescie Dalsze	51.1421764	21.7151163
+location	Przelek	53.6025128	17.4822567
+location	Przemysl	49.9543946	21.0042362
+location	Przeworsk	50.054495200000005	22.50137899352015
+location	Przezmierowo	52.4260662	16.7873751
+location	Przeźmierowo	52.4260662	16.7873751
+location	Przybedza	49.63138	19.12977
+location	Przyborow	51.4354544	16.4581589
+location	Przybyslawice	50.3785205	19.8829526
+location	Przybyszew	51.664084	20.8550539
+location	Przylek Duzy	51.84325	19.90793
+location	Przylesie	51.6609782	16.5374196
+location	Przylesie (Dolnośląskie)	51.6609782	16.5374196
+location	Przylesie (Opolskie)	50.7918473	17.3903932
+location	Przyszowa	49.6412253	20.5041741
+location	Przywidz	54.1968155	18.3236359
+location	Pskov	57.817398	28.334368
+location	Ptičie	48.9048806	21.9583193
+location	Pu'Er	22.807007	100.971896
+location	Pubol	42.0145055	2.9827318
+location	Puchov	49.123928	18.3239559
+location	Puck	54.7144128	18.406782113987507
+location	Pucon	-39.2731173	-71.9777605
+location	Pudahuel	-33.4193729	-70.86335607718577
+location	Puducherry	11.9340568	79.8306447
+location	Pudukkottai	10.5	78.833333
+location	Puebla de Don Fadrique	37.9578472	-2.4348912
+location	Puebla de Lillo	43.0082517	-5.2742117
+location	Puebla del Caraminal	42.6046249	-8.9402045
+location	Pueblo Esther	-33.0788574	-60.5640762
+location	Pueblo Nuevo	9.0342599	-79.833315
+location	Pueblo Nuevo EC	-0.9699476885494638	-80.29563904334763
+location	Pueblo Nuevo GT	15.9693794	-91.009262
+location	Pueblo Nuevo PA	9.01222585555162	-79.51284728055232
+location	Pueblonuevo de Miramontes	40.059856	-5.3786458
+location	Puente Alto	-33.6095279	-70.5754736
+location	Puente Madre	42.4519229	-2.4219485
+location	Puente San Miguel	43.3598835	-4.0876115
+location	Puente Viesgo	43.2989919	-3.9649215
+location	Puerto Armuelles	8.2725603	-82.8604458
+location	Puerto Baquerizo Moreno	-0.902599	-89.610191
+location	Puerto Barrios	15.7275154	-88.5952506
+location	Puerto Caimito	8.8730234	-79.7161814
+location	Puerto Carreno	6.1879711	-67.4894667
+location	Puerto Cortes	9.02269455	-83.56518644848431
+location	Puerto del Son	42.726023	-9.0049123
+location	Puerto Gral San Martin	-32.7025575	-60.7616873
+location	Puerto Lopez	-1.5440814	-80.74452395771863
+location	Puerto Madero	-34.6103764	-58.3622067
+location	Puerto Montt	-41.4718121	-72.939621
+location	Puerto Nariño	-3.7897260062514477	-70.35599924696716
+location	Puerto Natales	-51.7262826	-72.5062409
+location	Puerto Rico	18.2214149	-66.41328179513847
+location	Puerto Santa Maria	36.526984	-6.288553
+location	Puerto Tirol	-27.376511100000002	-59.08500094165363
+location	Puerto Vallarta	20.6407176	-105.220306
+location	Puerto Varas	-41.317802	-72.9829073
+location	Puerto Viejo	10.4541312	-84.0096613
+location	Puerto Vilelas	-27.5171208	-58.9405157
+location	Puerto Williams	-54.9354961	-67.6067034
+location	Puertollano	38.6852161	-4.1111749
+location	Puigcerda	42.4317966	1.9278693
+location	Puigmolto	41.24943425	1.769275695268508
+location	Puigverd d'Agramunt	41.7780434	1.1215633
+location	Puilboreau	46.1853	-1.11435
+location	Pulaski County	37.2314232	-89.1183427
+location	Pulaski County AR	34.7550166	-92.3003472
+location	Pulaski County IL	37.2314232	-89.1183427
+location	Puławy	51.4262598	21.985301401055878
+location	Pulderbos	51.2160122	4.6900839
+location	Pulianas	37.2225	-3.6075
+location	Pulle	51.2033571	4.7117525
+location	Pune	18.6452489	73.92318563785392
+location	Punta Arenas	-53.162664	-70.9080552
+location	Puntarenas	9.9780257	-84.831251
+location	Purasca	45.9779043	8.8510918
+location	Purba Bardhaman	23.391717	87.90621212355462
+location	Purba Medinipur	22.06382145	87.74573460267038
+location	Purgstall An Der Erlauf	48.05225975	15.134779617930125
+location	Puri	19.8076083	85.8252538
+location	Puriscal	9.733365599999999	-84.4094350689388
+location	Purmerend	52.4997208	4.964420036889974
+location	Purral	9.9552442	-84.0322962
+location	Purulha	15.236334	-90.2356932
+location	Purulia	23.29614645	86.34210770023
+location	Purullena	37.3147739	-3.1892077
+location	Purwakarta	-6.5607313	107.4439799
+location	Purwokerto	-7.31924965	112.17989315068222
+location	Pushkin	59.722256	30.415731
+location	Pushkino	56.0104274	37.8461892
+location	Puszczykowo	52.277297250000004	16.8559431249181
+location	Puteaux	48.8841522	2.2368863
+location	Putnam County	41.424102	-73.753622
+location	Putnam County IL	41.2025915	-89.2676414
+location	Putnam County NY	41.426996	-73.760156
+location	Putnam County OH	41.0677672	-84.1686932
+location	Puttalam	8.0301856	79.8286583
+location	Putte	51.0570823	4.6310473
+location	Puurs	51.071998449999995	4.286192867879716
+location	Puurs-Sint-Amands	51.066411	4.2812346
+location	Puy Guillaume	45.9598042	3.4755085
+location	Puyo	-1.4683687	-77.9924408
+location	Puzol	39.6153	0.3043
+location	Pyatigorsk	44.039775	43.0706669
+location	Pyrenees-Orientales	42.625894	2.5065089946931507
+location	Pyrzyce	53.1457	14.89267
+location	Qalansawe	32.29096118679203	34.97779331755409
+location	Qalqilia	32.195214326842695	34.982113638102625
+location	Qalqilya	32.190085	34.9745684
+location	Qatif	26.53265675	50.02891107288407
+location	Qingdao	36.171557	120.398496
+location	Quaraí	-30.3818093	-56.4526576
+location	Quaregnon	50.437973	3.859235
+location	Quart	41.9401591	2.8413516
+location	Quart de Poblet	39.4827253	-0.4438854
+location	Quartier Militaire	-20.246329	57.599302
+location	Quatipuru	-0.8948725	-47.0049317
+location	Quatis	-22.4066444	-44.2577453
+location	Quatre Bornes	-20.265311850000003	57.47915391687644
+location	Quedas do Iguacu	-25.453001	-52.9090429
+location	Queens	40.717328	-73.795709
+location	Queens County	40.652492699999996	-73.7914214158161
+location	Queimadas	-7.3640404	-35.9016644
+location	Queimados	-22.720854	-43.583396
+location	Quellon	-43.1200305	-73.6203025
+location	Queluz	38.757221	-9.258745
+location	Queluz BR	-22.5371881	-44.7752585
+location	Queluz PT	38.7549578	-9.25724478121169
+location	Quepos	9.4130419	-84.06497644024513
+location	Quesada	10.3441844	-84.41820363830183
+location	Quetzaltenango	14.8464612	-91.5194208
+location	Quevaucamps	50.720840	3.289101
+location	Quevedo	-1.396433	-79.549465
+location	Quévy	50.369910	3.951226
+location	Quezaltepeque	14.61148735	-89.44776513890977
+location	Quezon City	14.6509905	121.0486155
+location	Quiba	-8.041845899999998	14.349175430080138
+location	Quibala	-9.7989313	14.528201
+location	Quibdo	5.691789	-76.654649
+location	Quicama	-9.8026143	13.922788212314451
+location	Quiévrain	50.4048739	3.6829049
+location	Quijano	43.369238	-3.9572846
+location	Quijas	43.3502379	-4.1325973
+location	Quilicura	-33.35518825	-70.74437318862914
+location	Quilleco	-37.4709734	-71.9803093
+location	Quillon	-36.7443758	-72.4764427
+location	Quillota	-32.879997	-71.2473555
+location	Quilmes	-34.7206	-58.2546
+location	Quilpue	-33.0498135	-71.4415282
+location	Quimper	47.9960325	-4.1024782
+location	Quimperle	47.8692882	-3.5505644
+location	Quinssaines	46.327	2.51472
+location	Quinta Normal	-33.4283044	-70.69994963332789
+location	Quintana	-22.0705513	-50.308652
+location	Quintana de Raneros	42.5485607	-5.6328788
+location	Quintana ES	43.1825007701333	-3.5685955907350277
+location	Quirinopolis	-18.4471859	-50.4546981
+location	Quiros	43.1519817	-5.9724397974829895
+location	Quissama	-22.107205	-41.4723411
+location	Quitilipi	-26.8731862	-60.21298056452938
+location	Quito	-0.2201641	-78.5123274
+location	Qurayyat	23.2610439	58.9202694
+location	Qusra	32.085278	35.33
+location	Raalte	52.3874327	6.307848238791079
+location	Raanana	32.1862752	34.8692427
+location	Rabca	49.4833334	19.4833333
+location	Rabcice	49.506494	19.5205062
+location	Rabnita	47.7534702	28.9780857
+location	Raciborz	50.0904247	18.215141180318078
+location	Račice	50.4612952	14.3510711
+location	Raciechowice	49.8448681	20.1371442
+location	Racine	42.721147	-87.800333
+location	Racine County	42.7260523	-87.7825242
+location	Radhanagar	23.938678	91.0022825
+location	Radhanpur	23.8315668	71.6103884
+location	Radnovce	48.34445615	20.20681839876174
+location	Radom	51.397849	21.151218
+location	Radomsko	51.071061	19.44984640627979
+location	Radonice	50.1430605	14.6102607
+location	Radostow	52.8672	14.2308
+location	Radun	53.1406548	15.5029093
+location	Radvaň nad Laborcom	49.1300993	21.9276122
+location	Radzyń Podlaski	51.77566625	22.624946716255053
+location	Rafael Fernandes	-6.1892485	-38.2238647
+location	Rafaela	-31.2526923	-61.4916758
+location	Rafelbunyol	39.5884632	-0.3325421
+location	Ragama	7.0284392	79.9219776
+location	Rahat	31.3933637	34.7546784
+location	Rahmatganj	23.7134024	90.392844
+location	Raigad	18.4928092	73.13807095426539
+location	Raipur	21.2379469	81.6336833
+location	Raisen	23.25	78.083333
+location	Raiwand	31.2535608	74.2205805
+location	Rajbari	23.73983725	89.5704133269708
+location	Rajbari Sadar Upazila	23.713921388616516	89.65462375606356
+location	Rajec Poduchowny	51.4256997	21.2431597
+location	Rajecke Teplice	49.1275286	18.6828969
+location	Rajgród	53.7304739	22.6976173
+location	Rajkot	22.3039	70.8022
+location	Rajpara	21.6398651	69.61189678366469
+location	Rajpipla	21.8697448	73.5048135
+location	Rajshahi	24.3715513	88.5921038
+location	Rakowe Pole	54.1867471	19.1782759
+location	Rakowo	54.15067	19.20633
+location	Ralls County	39.552012	-91.547611
+location	Ramada	38.80800875	-9.196383669904645
+location	Ramales de la Victoria	43.257411	-3.4646482
+location	Ramallah	31.903646311459497	35.20351496013824
+location	Ramanathapuram	9.3895523	78.85907071521498
+location	Ramat Gan	32.0686867	34.8246812
+location	Ramat-Hasharon	32.1431276	34.8380853
+location	Rambouillet	48.6452851	1.819207
+location	Ramegnies-Chin	50.6514464	3.3358734
+location	Ramenskoye	55.5709361	38.2282099
+location	Ramillies	50.6366892	4.9148994
+location	Ramla	31.9279988	34.8623473
+location	Rammingen	48.5175043	10.1722215
+location	Ramotswa	-24.8710435	25.8651566
+location	Ramsau Am Dachstein	47.4217532	13.6531171
+location	Ramsau im Zillertal	47.203746	11.876947
+location	Ramsel	51.031568	4.832886
+location	Rancagua	-34.170249	-70.7407427
+location	Rancharia	-22.2294981	-50.8922333
+location	Ranchi	23.3700354	85.3250132
+location	Randall County	34.9444713	-101.8850309
+location	Randan	46.0158949	3.354087
+location	Randolph County	38.0472916	-89.8107962
+location	Randolph County AL	33.2651763	-85.4693961
+location	Randolph County IL	38.0472916	-89.8107962
+location	Randolph County NC	35.7142874	-79.7975166
+location	Rangamati	22.817729149999998	92.21970726375808
+location	Rangareddy	17.133395399999998	78.3970978701631
+location	Rangel	-8.8252637	13.2661023
+location	Rangersdorf	46.8623341	12.9575269
+location	Rangunia	22.467938700895342	92.05247980545658
+location	Raniewo	53.74945	19.17994
+location	Ranipet	12.9272641	79.3330076
+location	Rankin County	32.2338702	-89.9484651
+location	Rankovce	48.809834	21.4596444
+location	Rankweil	47.2731056	9.63150938085392
+location	Ransart	50.461008	4.476094
+location	Ranst	51.1962373	4.563813424474654
+location	Raon l Etape	48.406984	6.8437227
+location	Rapides County	31.3635131	-92.5868095
+location	Rapides Parish	31.204868	-92.527191
+location	Rapovce	48.27038235	19.683632880964655
+location	Rapperswil	47.2269198	8.8245459
+location	Rasht	37.2793607	49.5846102
+location	Raslavice	49.1495809	21.3191619
+location	Rastislavice	48.1380649	18.0734754
+location	Ratíškovice	48.923900	17.161986
+location	Ratmalana	6.815259449999999	79.86677775
+location	Ratnagiri	17.282607900000002	73.4569787039826
+location	Ratnapura	6.6803691	80.4022975
+location	Raubling	47.7892574	12.1100042
+location	Ravalli County	46.0757223	-114.1139453
+location	Ravels	51.416526	5.022319
+location	Rawa Mazowiecka	51.758285900000004	20.25099803272574
+location	Rawicz	51.6101629	16.8583657
+location	Rawson	-43.2991348	-65.1056655
+location	Raychikhinsk	49.78709434760068	129.4093657319707
+location	Reagan County TX	31.3458428	-101.5295291
+location	Real de Montroy	39.3342846	-0.608392
+location	Rebecq	50.670468	4.133291
+location	Reboleira	38.7523013	-9.2240282
+location	Rebollar De Los Oteros	42.4123554	-5.4492515
+location	Reboucas	-25.6259339	-50.6946598
+location	Rebstein	47.398476	9.5822387
+location	Recife	-8.0584933	-34.8848193
+location	Recoleta	-33.405882899999995	-70.63270330089452
+location	Reconquista	-29.164815431133192	-59.65623470460911
+location	Recreio	-21.5248205	-42.4689256
+location	Recz	53.2601536	15.5467648
+location	Red River County	33.571979	-95.0429674
+location	Red River Parish	32.0835604	-93.3111105
+location	Reda	54.6210145	18.32170890341879
+location	Redczyce	52.91337	17.74438
+location	Redding	40.5863563	-122.3916754
+location	Redencao	-8.025294	-50.031687
+location	Redkowice	54.5578	17.63864
+location	Redmond	44.2726203	-121.1739212
+location	Redon	47.6510682	-2.0842143
+location	Reet	51.1017566	4.4129446
+location	Refugio County	28.3171012	-97.2394101
+location	Regau	47.991944	13.688056
+location	Regencos	41.9523563	3.1687852
+location	Regente Feijo	-22.218131	-51.30545
+location	Regetovka	49.4214264	21.2723229
+location	Regina	4.3125906	-52.1324061
+location	Registro	-24.497942	-47.844895
+location	Reguisheim	47.8932253	7.3543762
+location	Rehovot	31.8952532	34.8105616
+location	Reiden	47.2460194	7.9730383
+location	Reigoldswil	47.3974255	7.6918178
+location	Reims	49.253754	4.035860
+location	Reinach	47.4935369	7.5910891
+location	Reinosa	43.0010076	-4.1378363
+location	Rekem	50.9284078	5.662609475536591
+location	Rekkem	50.7861863	3.1627429
+location	Rekowo	54.1140085	16.5040925
+location	Relegem	50.8998481	4.2808363
+location	Rembau	2.5888688	102.0943404
+location	Remire-Montjoly	4.9050148	-52.2771642
+location	Renaico	-37.67176	-72.583393
+location	Renascenca	-26.158837	-52.970349
+location	Renca	-33.4035274	-70.73093305460753
+location	Renedo	43.354601450000004	-3.9538952987855325
+location	Renedo de Pielago	43.35345277376454	-3.950141560382286
+location	Renens	46.5349093	6.5928442
+location	Rengo	-34.4088744	-70.8616583
+location	Rennes	48.1173	1.6778
+location	Rensselaer County	42.7091389	-73.5107732
+location	Reocín	43.35017945	-4.115622211730858
+location	Requena	39.4880777	-1.1001643
+location	Requinoa	-34.2848586	-70.8175128
+location	Resende	-22.4683626	-44.4463494
+location	Resistencia	-27.4511235	-58.9865196
+location	Retamar	38.0397389	-3.0806417
+location	Retie	51.268101	5.078413
+location	Retinne	50.6304629	5.6976792
+location	Retiro	6.06171475	-75.51064152773847
+location	Retiro CL	-36.0554429	-71.7650623
+location	Retiro CO	6.06171475	-75.51064152773847
+location	Retirolandia	-11.4935873	-39.4245887
+location	Reus	41.1555564	1.1076133
+location	Reutte	47.456572550000004	10.700811364115278
+location	Revda	56.8000651	59.9086688
+location	Revuca	48.6833333	20.1166667
+location	Rewica Szlachecka	51.7433537	19.9279798
+location	Rezh	57.370647	61.4042865
+location	Rheinbach	50.6256808	6.9491436
+location	Rheineck	47.4706336	9.584108
+location	Rheinfelden	47.5543859	7.7922905
+location	Rheintal	47.146290300000004	9.50123767530243
+location	Rhone Alpes	44.3766015	4.6990547
+location	Ri-Bhoi	25.87640255	91.85675741641606
+location	Ri Bhoi District	25.9181941	91.8760660272236
+location	Riaba	3.3854557	8.7629712
+location	Riachao	-6.5408387	-35.6608948
+location	Riachao do Dantas	-11.0704439	-37.726446
+location	Riachao do Jacuipe	-11.8071084	-39.3816843
+location	Riacho de Santana	-6.2633948	-38.3143424
+location	Riacho Dos Cavalos	-6.4355877	-37.6560108
+location	Riachuelo	-10.7323307	-37.1863203
+location	Riachuelo RN	-5.8121386	-35.8234357
+location	Riachuelo SE	-10.7323307	-37.1863203
+location	Rianjo	42.6924	-8.7812
+location	Rianxo	42.6488711	-8.8173676
+location	Ribeira	42.5541	-8.9922
+location	Ribeirao Bonito	-22.0692867	-48.1781765
+location	Ribeirao Das Neves	-19.7672898	-44.0875436
+location	Ribeirao do Sul	-22.7861813	-49.9285258
+location	Ribeirao Dos Indios	-21.8378246	-51.602158
+location	Ribeirao Pires	-23.7129388	-46.4150871
+location	Ribeirao Preto	-21.178333	-47.8066671
+location	Ribeiropolis	-10.5405577	-37.4368783
+location	Ribera de Arriba	43.304672	-5.910467714297559
+location	Ribera De Montardit	42.38456802106662	1.1157426073870254
+location	Ribnik	44.4042025	16.8112782
+location	Říčany	49.99144789993997	14.656143375191796
+location	Ricardone	-32.7706222	-60.7840699
+location	Richland Center	43.339975	-90.385959
+location	Richland County IL	38.7060457	-88.0949352
+location	Richland County MT	47.8314138	-104.559421
+location	Richland County OH	40.776322	-82.5302254
+location	Richland County SC	34.0190006	-80.9176832
+location	Richland County WI	43.4060	-90.3748
+location	Richland Parish	32.4196791	-91.8105911
+location	Richmond County	40.5795	-74.1502
+location	Richmond County GA	33.385076	-82.09207958530698
+location	Richmond County NY	40.564209	-74.12530461995391
+location	Richtersveld	-27.92537575	17.08797835418535
+location	Rickenbach	47.6209218	7.9788595
+location	Rickenbach CH	47.0156619	8.6669086
+location	Ried	48.2041603	13.3432833
+location	Rieden	47.2202194	9.0482995
+location	Riego de la Vega	42.388342	-5.9826151
+location	Riehen	47.5816927	7.6479737
+location	Riells I Viabrea	41.75748485	2.5302183574725428
+location	Riemst	50.805092	5.589712
+location	Rijkevorsel	51.355735	4.766466
+location	Rijswijk	52.03739335	4.322502837527406
+location	Rillaar	50.9757406	4.8928649
+location	Rimavska Sobota	48.3833603	20.0180584
+location	Rincao	-21.5881095	-48.0724258
+location	Rincon	18.3396565	-67.2506517
+location	Rincon de la Victoria	36.717712	-4.278570
+location	Rincon de Soto	42.2346465	-1.8504938
+location	Rinconada	-32.8725135	-70.7125102123506
+location	Riniken	47.4939693	8.1876762
+location	Río Abajo	9.0631987	-79.5444326
+location	Rio Arriba County	36.5488273	-106.8155233
+location	Rio Azul	9.8920277	-84.0345244
+location	Rio Azul BR	-25.726644	-50.790534
+location	Rio Azul CR	9.8920277	-84.0345244
+location	Rio Bonito	-22.7108378	-42.6271864
+location	Rio Branco	-32.588689	-53.3780831
+location	Rio Branco BR	-9.9765362	-67.8220778
+location	Rio Branco UY	-32.588689	-53.3780831
+location	Rio Bueno	-40.3336678	-72.9567617
+location	Rio Ceballos	-37.9098911	-57.7709387
+location	Rio Claro	-22.418843	-47.567420
+location	Rio Claro RJ	-22.7229997	-44.1359986
+location	Rio Claro SP	-22.4099468	-47.5603801
+location	Rio Cuarto	-34.5811989	-58.6873043
+location	Rio Das Flores	-22.1683478	-43.5858689
+location	Rio Das Ostras	-22.5269448	-41.944972
+location	Rio Das Pedras	-22.8441256	-47.6065667
+location	Rio de Janeiro	-22.89445	-43.2099
+location	Rio de Mouro	38.7723602	-9.3256835
+location	Rio do Sul	-27.2162607	-49.643654
+location	Rio Espera	-20.9060615	-43.3764832
+location	Rio Fortuna	-28.1335539	-49.1048223
+location	Rio Gallegos	-51.62749345310375	-69.27690105608417
+location	Rio Grande	-53.7856766	-67.7016369
+location	Rio Grande AR	-54.234309	-67.1352849
+location	Rio Grande BR	-32.0334252	-52.0991297
+location	Rio Grande Da Serra	-23.743724	-46.397084
+location	Rio Hato	8.3789084	-80.1641302
+location	Rio Ibanez	-46.302076799999995	-72.38411544842492
+location	Rio Indio	9.5758884	-79.5290428
+location	Rio Largo	-9.477829	-35.839435
+location	Rio Maior	39.350401950000006	-8.911176402248575
+location	Rio Manso	-20.2752112	-44.3287784
+location	Rio Negrinho	-26.259075	-49.517746
+location	Rio Novo do Sul	-20.8641487	-40.9384378
+location	Rio Paranaiba	-19.196447	-46.2410263
+location	Rio Pardo	-21.5915943	-46.8954143
+location	Rio Preto Da Eva	-2.6990647	-59.7012494
+location	Rio Rufino	-27.861691	-49.7806323
+location	Rio San Pedro	36.5235	-6.2259
+location	Rio Segundo	-34.8197937	-58.3453538
+location	Rio Tercero	-34.5619338	-58.6612413
+location	Rio Tinto	-6.803828	-35.077569
+location	Rio Verde	-21.8210975	-46.9240867
+location	Riobamba	-1.6731483	-78.6486465
+location	Riohacha	11.544634	-72.9069784
+location	Riolobos	39.9208114	-6.3040059
+location	Riom	45.893068	3.1136667
+location	Riom Es Montagnes	45.2832492	2.6594544
+location	Rionegro	6.1536166	-75.3741691
+location	Riopar	38.4982	-2.4172
+location	Riorges	46.0437504	4.0337193
+location	Riozinho	-29.6404582	-50.4596262
+location	Ripoll	42.1982391	2.1932496
+location	Ripollet	41.4993372	2.1573095
+location	Rishon-Letsion	31.9635712	34.8101149
+location	Rishpon	32.1995547	34.8244371
+location	Risnovce	48.3675323	17.8948501
+location	Riudarenes	41.8218536	2.7163817
+location	Riudellots de la Selva	41.8954981	2.8022296
+location	Rivadavia	-33.1959388	-68.4662317
+location	Rivas-Vaciamadrid	40.3519	-3.5357
+location	Rive de Gier	45.5288401	4.6187386
+location	River Hills	43.1742	-87.9243
+location	Riverside	41.0338	-73.5785
+location	Riverside County	33.7871393	-117.0109705
+location	Rixensart	50.7156	4.531
+location	Rixheim	47.7441969	7.3968786
+location	Riyadh	24.705304	46.738279
+location	Rizal	14.65	121.25
+location	Roanne	46.0345572	4.0729178
+location	Robertson County	31.0339058	-96.5079742
+location	Robertson County TN	36.4996336	-86.8519164
+location	Robertson County TX	31.0339058	-96.5079742
+location	Rochedo	-20.4769832	-28.8516786
+location	Rochefort	50.1588503	5.2233447
+location	Rochefort BE	50.1663541	5.0705752
+location	Rochefort FR	45.9438412	-0.9687519
+location	Rochefort Montagne	45.6838904	2.8050875
+location	Rock County	42.654281	-89.079857
+location	Rock Island County	41.4411786	-90.5766144
+location	Rockhampton	-23.378823	150.509921
+location	Rockingham County	42.9966675	-71.1003143
+location	Rockingham County NC	36.3926798	-79.744144
+location	Rockingham County NH	42.9966675	-71.1003143
+location	Rockland County	41.1489	-73.9830
+location	Rockwall County	32.8923464	-96.4066987
+location	Roda de Ter	41.9814126	2.3096755
+location	Roden	53.1405378	6.4275196
+location	Rodersdorf	47.4806046	7.4566901
+location	Rodez	44.3513062	2.5727883
+location	Roding	49.1887934	12.5224323
+location	Rodniki	57.105225	41.72839
+location	Rodrigo Luque	8.1316307	-80.9826617
+location	Rodrigues Alves	-7.7380283	-72.6509379
+location	Rodriguez	14.731081	121.1454645
+location	Roedermark	49.9798913	8.8088274
+location	Roerdalen	51.14172275	5.992474016651388
+location	Roermond	51.1933903	5.9882649
+location	Roesbrugge-Haringe	50.9150531	2.6262588
+location	Röschenz	47.4239414	7.4759958
+location	Rogers	30.9315763	-97.2267205
+location	Roggenburg	47.433867	7.3402588
+location	Rogierowko	52.4776055	16.752574
+location	Rogity	54.389477	19.8717409
+location	Rogow	51.1638889	19.6544444
+location	Rogow (Łódzkie)	51.1638889	19.6544444
+location	Rogow (Opolskie)	50.51711	17.93954
+location	Rogowo	51.7387847	17.0014623
+location	Rogozno	52.7523023	16.9936288
+location	Rois	42.7608618	-8.6902929
+location	Roitham	47.9609879	13.5873954
+location	Roitham am Traunfall	48.0281477	13.84351130934489
+location	Rokietnica	52.5103217	16.7421238
+location	Rolandia	-23.3119901	-51.3674145
+location	Rolante	-29.6527945	-50.5769391
+location	Rolde	52.98438	6.64876
+location	Romagnat	45.7280876	3.098485
+location	Romanovka	56.8913679	60.3752134
+location	Romans-sur-Isere	45.0458886	5.0528681
+location	Rome	41.881118	12.492817
+location	Romille	48.2153539	-1.89245
+location	Romilly sur Aigre	47.97931976811195	1.2832676652928432
+location	Romilly sur Seine	48.5195734	3.7264161
+location	Romny	50.718391	129.290924
+location	Romorantin	47.3592182	1.7434925
+location	Ronchin	50.6056749	3.0778827
+location	Ronda	36.7421339	-5.1665916
+location	Rondonopolis	-23.8893663	-54.4079702
+location	Ronse	50.745879	3.607614
+location	Roorkee	29.8693496	77.8902124
+location	Roosbeek	50.8350419122941	4.862739026223957
+location	Roosdaal	50.8341383	4.0972238
+location	Roosendaal	51.5331484	4.4561276
+location	Roosevelt County	48.3069516	-104.9709901
+location	Ropczyce	50.0528608	21.6116324
+location	Rorbas	47.5303235	8.5771089
+location	Rorschach	47.4779686	9.4914025
+location	Rorschacherberg	47.4687555	9.4945663
+location	Rosana	-22.5788641	-53.0552246
+location	Rosario	-32.9595004	-60.6615415
+location	Rosario AR	-32.9493088016599	-60.68393912672859
+location	Rosario BR	-2.9405903	-44.2491088
+location	Rosario de la Frontera	-25.7985752	-64.9739247
+location	Rosario de Lerma	-24.53873	-65.89910908517965
+location	Rosario do Sul	-30.2527151	-54.9179382
+location	Rosarito	32.3648126	-117.055626
+location	Rose Hill	-20.234269	57.4693447
+location	Rosebud	31.0747037	-96.9755638
+location	Rosebud County	46.3894251	-106.6296053
+location	Rosegg	46.5898126	14.0200876
+location	Rosenau	47.6375154	7.5371474
+location	Rosenheim	47.8539273	12.127262
+location	Roses	42.2632018	3.1755328
+location	Rosh Haayin	32.0952929	34.9533225
+location	Roshchino	60.256651	29.6051421
+location	Rosières	50.7343111	4.5528471
+location	Rosina	49.1833755	18.7666847
+location	Rosko	52.8733838	16.3176484
+location	Roskovce	49.2391159	21.8475076
+location	Ross	39.312296	-84.6507966
+location	Rostock	54.0784362	12.132504
+location	Rostov-On-Don	47.2213858	39.7114196
+location	Rota	36.627796	-6.368951
+location	Roteiro	-9.8334935	-35.9777132
+location	Rotenturm An Der Pinka	47.2526536	16.2428502
+location	Rothenfluh	47.4608887	7.914597
+location	Rothrist	47.3029125	7.8826232
+location	Rotselaar	50.9514713	4.7094054
+location	Rotterdam	51.9244	4.4777
+location	Rottevalle	53.1452083	6.1030877
+location	Rottweil	48.165531	8.6251283
+location	Roubaix	50.6915893	3.1741734
+location	Roucourt	50.528622	3.586797
+location	Rouen	49.4432	1.1000
+location	Round Rock	30.508235	-97.6788934
+location	Roussillon	45.3735991	4.8124049
+location	Roux	50.441818350000005	4.390705563894007
+location	Rouziers-de-Touraine	47.5175967	0.6488459
+location	Rovaniemi	66.501553	25.728919
+location	Rovigo	44.97720615	12.274190436964231
+location	Rovinka	48.097582	17.2361107
+location	Rowan County NC	35.6315952	-80.5171754
+location	Royan	45.6245332	-1.0287636
+location	Royat	45.7643631	3.0477919
+location	Roznava	48.6620675	20.5328607
+location	Rozubowice	49.7347979	22.8453008
+location	Rubi	41.4936194	2.0319476
+location	Rublevo	55.78618381737727	37.35547752300387
+location	Rucewo	53.8	19.5333333
+location	Ruda Śląska	50.270303	18.864375646334572
+location	Ruddervoorde	51.0953149	3.2048308
+location	Rudna U Prahy	50.035702900000004	14.234282834408601
+location	Rudnik	49.9112681	20.1069071
+location	Rudolfsheim Fünfhaus	48.1954752	16.32630072151544
+location	Rudraprayag	30.3009965	79.06287964782695
+location	Rudziczka	50.0393136	18.7544775
+location	Rudzienko	52.2960208	21.6653857
+location	Rueda	-33.3355941	-60.4589616
+location	Rümmingen	47.6419637	7.6429253
+location	Rüstorf	48.0416013	13.7896687
+location	Rufina Alfaro	9.068903	-79.456339
+location	Rufunsa	-15.0813281	29.6344169
+location	Ruili	24.0200662	97.8554177
+location	Ruiloba	43.38064	-4.25244
+location	Ruinen	52.7641537	6.3600084
+location	Ruisbroek	50.7900129	4.2980824
+location	Ruiselede	51.0630592	3.3787805823544046
+location	Ruma	45.0078322	19.8187834
+location	Rumanova	48.3413282	17.874342819261656
+location	Rumbeke	50.9333267	3.1541566
+location	Rumia	54.570081	18.384623870396354
+location	Rumiñahui	-0.39888	-78.43681065983627
+location	Rummen	50.8906644	5.1646763
+location	Rumoroso	43.3862402	-3.9961492
+location	Rumst	51.0792853	4.4240472
+location	Runnels County TX	31.8282551	-99.9779922
+location	Rupandehi	27.54877355	83.40335273463867
+location	Rupelmonde	51.1283692	4.2906315
+location	Rupnagar	31.09168085	76.5272673916138
+location	Ruropolis	-4.1014311	-54.9086853
+location	Rusk	31.7960064	-95.1502214
+location	Rusk County	32.051377	-94.7906553
+location	Rusk County TX	32.051377	-94.7906553
+location	Rusk County WI	45.4589749	-91.1240967
+location	Russas	-4.9354279	-37.9783838
+location	Russkaya Polyana	53.780357	73.882103
+location	Rustaq	23.777294849999997	57.78447565275601
+location	Rusy	54.4241469	19.830552
+location	Rutherford County NC	35.3994626	-81.9023191
+location	Rutherford County TN	35.8563421	-86.4205249
+location	Ruthi	47.2955927	9.537187
+location	Ruza	55.6998907	36.1946992
+location	Ruzomberok	49.0815718	19.3034168
+location	Ryazan	54.6295687	39.7425039
+location	Rybiczyzna	51.1138414	21.3355456
+location	Rybnik	50.0955793	18.5419933
+location	Rybno	53.759	21.13594
+location	Rychliki	53.9859225	19.5267889
+location	Rychnov nad Kněžnou	50.1631069	16.274837
+location	Ryczywol	52.8125184	16.8325798
+location	Ryn	53.9386839	21.5440643
+location	Rynarcice	51.474985	16.2128957
+location	Rzecko	53.1734767	15.5312779
+location	Rzeczniow	51.1268037	21.4425767
+location	Rzepin	50.9797019	21.1162704
+location	Rzeszotary	49.9387076	19.9789951
+location	Rzeszow	50.013064	22.016143457294312
+location	Rzhev	56.2565207	34.328649
+location	S'Agaro	41.7947494	3.0560269
+location	Sa Pobla	39.7699388	3.0250102
+location	Saalfelden	47.4268102	12.8297861
+location	Saalfelden am Steinernen Meer	47.4266166	12.8481048
+location	Saavedra	-38.8304315	-73.28487301691246
+location	Sabadell	41.5421013	2.1138977
+location	Sabaneta	6.151838	-75.616992
+location	Sabanilla	10.0749363	-84.2151914
+location	Sabanitas	9.3468997	-79.8033588
+location	Sabara	-19.8900372	-43.8107916
+location	Sabarkantha	24.0294885	73.0459884
+location	Sabine Parish	31.5223049	-93.5265161
+location	Sabinov	49.1086665	21.09476493751165
+location	Sacavem	38.794386700000004	-9.108563857720288
+location	Sacramento County	38.494406	-121.301826
+location	Sacurov	48.819611	21.6950491
+location	Sadipur	24.643219	91.6874
+location	Sadkowice-Kolonia	51.0921031	21.7267582
+location	Sador	22.693161	89.775469
+location	Sady	52.4485883	16.7229112
+location	Sagamihara	35.56559	139.236215
+location	Sagrada Familia	-34.9990365	-71.3817116
+location	Sagunt	39.6801	-0.2784
+location	Sahagun	42.3719042	-5.0313138
+location	Sahibganj	25.2820998	87.61850784289338
+location	Sahy	48.0694559	18.9493378
+location	Saidabad	18.3242258	79.4783324
+location	Saignelegier	47.2557997	6.9963585
+location	Saignes	45.3352148	2.4791426
+location	Saint-Affrique	43.9580035	2.8866641
+location	Saint Andre le Coq	45.9647	3.3108
+location	Saint-Astier	45.1389735	0.5227944
+location	Saint-Aunes	43.6394182	3.9637108
+location	Saint-Avold	49.1043397	6.7071754
+location	Saint Beauzire	45.8516333	3.1790056
+location	Saint-Benoit	-21.033188	55.7131508
+location	Saint Bonnet Pres Riom	45.9306	3.1139
+location	Saint-Brieuc	48.5141134	-2.7603283
+location	Saint-Chély-d'Apcher	44.8011363	3.2757824
+location	Saint Christophe	44.9576485	6.1763805
+location	Saint-Cloud	48.8437412	2.219344
+location	Saint Croix County	45.0312388	-92.4679305
+location	Saint-Denis	48.935773	2.3580232
+location	Saint-Denis de la Réunion	-20.8799889	55.448137
+location	Saint-Didier-Sous-Aubenas	44.6077	4.41455
+location	Saint-Die-des-Vosges	48.2873153	6.9477708
+location	Saint Dizier	48.6371125	4.9473513
+location	Saint-Doulchard	47.0999731	2.3729675
+location	Saint-Etienne	45.4401467	4.3873058
+location	Saint-Etienne-de-Saint-Geoirs	45.3398756	5.3440159
+location	Saint Etienne Du Rouvray	49.3831	1.09163
+location	Saint Floret	45.5515749	3.1048674
+location	Saint-Gaudens	43.1077682	0.7247218
+location	Saint-Gely-Du-Fesc	43.6913873	3.803981
+location	Saint Genes Champanelle	45.7193702	3.0202426
+location	Saint-Genis-Les-Ollieres	45.7601	4.72654
+location	Saint Germain des Fosses	46.2067884	3.4320562
+location	Saint Germain en Laye	48.938032	2.094734
+location	Saint-Ghislain	50.483208	3.802415
+location	Saint Gilles (Bretagne)	48.1539357	-1.8299928
+location	Saint-Gilles (Occitanie)	43.677007	4.4318488
+location	Saint-Gilles BE	50.8249958	4.3454841
+location	Saint-Gilles-Croix-de-Vie	46.692985	-1.9254545
+location	Saint Gregoire	48.1524129	-1.685398
+location	Saint Herblain	47.2233007	-1.6346964
+location	Saint-Hubert	50.0251428	5.3738561
+location	Saint-Jean-de-Bournay	45.501892	5.1389879
+location	Saint-Josse-ten-Noode	50.8508197	4.3691634
+location	Saint Julien de Coppel	45.6942661	3.3097958
+location	Saint-Julien-en-Genevois	46.1444789	6.0812467
+location	Saint-Just-Saint-Rambert	45.49188504999999	4.251298165486943
+location	Saint Landry County	30.6174002	-92.0035057
+location	Saint-Laurent-Du-Var	43.6690101	7.1906969
+location	Saint-Louis	-21.2840124	55.4135962
+location	Saint Louis County	38.632980	-90.472478
+location	Saint-M'Herve	48.1784037	-1.1169757
+location	Saint Malo	48.6454528	-2.015418
+location	Saint Mandé	48.8432633	2.4185126
+location	Saint-Martin-D'Hères	45.1836683	5.75448
+location	Saint Mary Parish	29.692329	-91.442465
+location	Saint Maur des Fosses	48.8033057	2.4853015
+location	Saint-Même-le-Tenu	47.03333775	-1.7985316146199368
+location	Saint-Mexant	45.2850988	1.6580437
+location	Saint Nazaire	47.2733517	-2.2138905
+location	Saint Omer	50.7515771	2.2534183
+location	Saint Ouen l'Aumone	49.044765	2.1059841
+location	Saint-Ouen-sur-Seine	48.911729	2.334267
+location	Saint-Paul	-21.0006099	55.2771585
+location	Saint-Paul-lès-Dax	43.724929	-1.0514009646205347
+location	Saint Perreux	47.66862	-2.10844
+location	Saint-Petersburg	59.938732	30.316229
+location	Saint Pierre Quiberon	47.5305	-3.13689
+location	Saint-Priest	45.704159	4.949456
+location	Saint Prix	44.9429187	4.5012905
+location	Saint Quentin	49.8465253	3.2876843
+location	Saint Sandoux	45.6403302	3.1060378
+location	Saint-Saulve	50.3710165	3.5547336
+location	Saint-Symphorien	50.4366253	4.012574
+location	Saint-Thibault-des-Vignes	48.862026	2.674513
+location	Saint-Ulrich	47.5952149	7.1182275
+location	Saint Valery en Caux	49.8597004	0.7106831
+location	Saint-Vallier-de-Thiey	43.6987023	6.8478583
+location	Saint-Verand	45.1738392	5.3329287
+location	Saint-Vincent-de-Tyrosse	43.6604837	-1.3029669
+location	Saint Yvoine	45.5849937	3.2313242
+location	Sainte-Clotilde	-20.89938965	55.476566852656774
+location	Sainte Marie Aux Mines	48.2476662	7.1851184
+location	Saintes	45.7460663	-0.6300671
+location	Saisinne	50.523754	4.035498
+location	Saive	50.652941	5.685550
+location	Sajdikove Humence	48.6571444	17.264489
+location	Sakhnin	32.8638052	35.3023184
+location	Sala	48.151379	17.8748587
+location	Salak	3.1020073999999997	101.70626782050327
+location	Salamá	15.1021016	-90.3145505
+location	Salamanca	40.9651572	-5.6640182
+location	Salas	43.4082096	-6.2568574
+location	Salatiga	-7.3302642	110.4995353
+location	Šalčininkų rajono savivaldybė	54.31741925	25.238008659317245
+location	Saldan	-31.274386314118022	-64.33771831738765
+location	Saldanha Bay	-32.97779805372684	18.022125380907177
+location	Saldanha Marinho	-28.394081	-53.097006
+location	Salem	44.9391565	-123.033121
+location	Salem County	39.5980987	-75.3488201
+location	Salem County NJ	39.5980987	-75.3488201
+location	Salerno	40.419441649999996	15.310756230322482
+location	Sales	-21.3418263	-49.4999228
+location	Sales Oliveira	-20.769612	-47.836873
+location	Salete	-26.9841891	-50.0076205
+location	Salfit	32.0847762	35.176638499999996
+location	Salgueiro	-8.073734	-39.12469
+location	Saline County	37.750075	-88.5302584
+location	Saline County IL	37.750075	-88.5302584
+location	Salitre	-1.8293674	-79.8174167
+location	Salka	47.8874242	18.7537209
+location	Sallent de Llobregat	41.8165676	1.8923865
+location	Salon-de-Provence	43.6405237	5.0980225
+location	Salt	41.9741672	2.7949886
+location	Salt Lake County	40.6632297	-111.9103124
+location	Salta	-24.7892946	-65.4103194
+location	Salto	-23.1989983	-47.2913682
+location	Salto Dupi	8.3557903	-81.89147551416832
+location	Saluda County	34.00497795	-81.74468468950093
+location	Salvador	-12.9822499	-38.4812772
+location	Salvador Mazza	-24.7357629	-65.3994104
+location	Saly Portudal	14.445536352156282	-16.98986300708038
+location	Salzburg	47.7981346	13.0464806
+location	Salzburg-Umgebung	47.8643961	13.0839322
+location	Samail	23.32	57.98
+location	Samano	43.3578453	-3.2297328
+location	Samarinda	-0.488935	117.142459
+location	Samawa	31.1972649	45.5374068
+location	Samba	-8.8387912	13.212125
+location	Sambhal	28.61875255	78.55087405404804
+location	Sambizanga	-8.8043556	13.2715131
+location	Samborondon	-2.0153600999999997	-79.73406493690683
+location	Sambreville	50.44606145	4.617878113126531
+location	Sambu	8.0273361	-78.2083096
+location	Samlino	53.8477497	14.9513205
+location	Samolez	52.6930942	16.4216948
+location	San Agustín Acasaguastlán	15.01663735	-89.99179796315836
+location	San Andres	12.537597850000001	-81.72041550499901
+location	San Andres del Rabanedo	42.6112327	-5.6168662
+location	San Antonio	9.89580112196045	-84.1399822884991
+location	San Antonio CL	-33.5808615	-71.6132377
+location	San Antonio CR	9.857465	-84.2985984
+location	San Antonio Este	-40.8035019	-64.8807966
+location	San Antonio PY	-25.415636887354747	-57.562387319246945
+location	San Benito County	36.6248089	-121.1177379
+location	San Bernardino County	34.8253019	-116.0833144
+location	San Bernardo	-33.5922859	-70.7045838
+location	San Carlos	10.6204181	-84.42581545828966
+location	San Carlos AR	-33.038893	-61.1619964
+location	San Carlos CL	-36.4248192	-71.9581208
+location	San Carlos CR	10.62017945	-84.42581794981697
+location	San Carlos de Bariloche	-41.1335	-71.3103
+location	San Clemente	39.4017	-2.4283
+location	San Clemente CL	-35.5375459	-71.4858841
+location	San Clemente ES	39.4086565	-2.4211637
+location	San Cristobal	-0.9151226	-89.5662955
+location	San Cristobal AR	-30.30898396739999	-61.235894632982145
+location	San Cristobal de la Polantera	42.3906726	-5.9076237
+location	San Cristobal EC	-0.9097240155540418	-89.55810090805137
+location	San Cristobal GT	15.00765485	-89.88626771820842
+location	San Cugat del Valles	41.4728432	2.0817809
+location	San Diego	32.733024	-117.143358
+location	San Diego County	32.981125	-116.681405
+location	San Diego CR	9.8998392	-84.0023103
+location	San Felices De Buelna	43.26630875	-4.030329207737704
+location	San Felipe	9.9034817	-84.1063339
+location	San Felipe CL	-32.7506976	-70.7252018
+location	San Felipe CR	9.9034817	-84.1063339
+location	San Fernando AR	-34.44835022215897	-58.56883100197011
+location	San Fernando CL	-34.588678974008204	-70.99230096155945
+location	San Fernando de Henares	40.4248548	-3.5350369
+location	San Fernando ES	36.46382893716933	-6.202051285817521
+location	San Francisco	37.757679	-122.440006
+location	San Francisco AR	-31.321674	-64.3026567
+location	San Francisco County	37.7749	-122.4194
+location	San Francisco CR	9.9950234	-84.1279718
+location	San Francisco de Dos Rios	9.9084178	-84.0594842
+location	San Francisco de Mostazal	-33.9799035	-70.7121737
+location	San Francisco El Alto	14.945113	-91.443109
+location	San Francisco PA	8.990150	-79.506474
+location	San German	18.0808972	-67.0408635
+location	San Germán County	18.0808972	-67.0408635
+location	San Guillermo	-33.350998	-61.4428099
+location	San Ignacio	-36.437888	-71.9154445
+location	San Isidro	9.8303018	-83.9536131
+location	San Isidro (Alajuela)	10.0780962	-84.1931678
+location	San Isidro (Cartago CR)	9.9206565	-83.8373508
+location	San Isidro (Heredia)	10.029724049999999	-84.03206860386899
+location	San Isidro AR	-34.47417457465127	-58.526015318917636
+location	San Isidro CR	9.8303018	-83.9536131
+location	San Isidro CR-C	9.8909395	-83.7920654
+location	San Isidro CR-H	10.029724049999999	-84.03206860386899
+location	San Isidro de El General	9.3714044	-83.7040469
+location	San Isidro de Nijar	36.909012	-2.1735077
+location	San Isidro ES	40.96522175	-5.651022261624924
+location	San Isidro PE	-12.0934341	-77.0258146
+location	San Jacinto County	30.5083577	-95.1902362
+location	San Jacinto de Yaguachi	-2.11784565	-79.73593868679905
+location	San Javier	-35.5923933	-71.735308
+location	San Jerónimo	10.0060332	-84.015112
+location	San Joaquin	-33.4936126	-70.62860451495828
+location	San Joaquin County	37.917472	-121.258503
+location	San Jose	9.935877	-84.094466
+location	San Jose CR	9.945683401643329	-84.11128831904148
+location	San Jose de la Esquina	-33.1197995	-61.7142859
+location	San Jose de Maipo	-33.6403975	-70.3527845
+location	San Jose del Golfo	14.79014705	-90.35930977045335
+location	San Jose Del Monte City	14.8110432	121.0491569
+location	San Jose Pinula	14.5464898	-90.34928674055958
+location	San Juan	9.9100082	-84.0111808
+location	San Juan Bautista	7.9668338	-80.4153532
+location	San Juan Chamelco	15.3832579	-90.23900142886828
+location	San Juan City	14.60474	121.0300488
+location	San Juan County	48.5443087	-122.9919497
+location	San Juan County NM	36.4755752	-108.3046555
+location	San Juan County WA	48.5443087	-122.9919497
+location	San Juan CR	9.9100082	-84.0111808
+location	San Juan de Dios	8.5537982	-80.2261377
+location	San Juan PA	9.246644700000001	-79.62199176532462
+location	San Juan PR	18.465299	-66.116666
+location	San Juan Sacatepequez	14.78429445	-90.6579108363871
+location	San Julian Chinautla	14.685830641450886	-90.49018171603218
+location	San Justo	-30.7890512	-60.5930565
+location	San Lorenzo	-32.7434258	-60.7496742
+location	San Lorenzo AR	-32.74528101079663	-60.742480547054136
+location	San Lorenzo County	18.1524948	-65.97563436136883
+location	San Lorenzo GT	15.01794045	-91.74565153007444
+location	San Lorenzo PR	18.1841319	-65.9682865
+location	San Lorenzo PY	-25.35467544347727	-57.5093107016072
+location	San Lucas	14.606752357258324	-90.65983698158207
+location	San Luis Obispo County	35.3102	-120.4358
+location	San Luis Rio Colorado	31.9939146	-114.29077314185326
+location	San Manuel Chaparron	14.5206343	-89.7683857
+location	San Martin	-34.5762765	-58.5388435
+location	San Martin AR	-34.5762765	-58.5388435
+location	San Martin BA	-38.736892350000005	-62.27364309899731
+location	San Martin de los Andes	-40.1568	-71.3525755
+location	San Martín de Porres	8.11680415	-80.95158404170274
+location	San Martin Jilotepeque	14.834153950000001	-90.77311995248066
+location	San Martin MZ	-32.8660224	-68.8655966
+location	San Martin PA	9.20218555	-79.24000267467781
+location	San Mateo County	37.438721	-122.348737
+location	San Miguel	-33.49755675	-70.65216109880235
+location	San Miguel AR	-34.540349	-58.7157491
+location	San Miguel CL	-33.49755675	-70.65216109880235
+location	San Miguel de Tucuman	-26.8303703	-65.2038133
+location	San Miguel GT	16.818333	-99.383056
+location	San Miguel Petapa	14.4976914	-90.5560333
+location	San-Nicolao	42.3706486	9.5000839
+location	San Nicolas	-36.5034103	-72.2123236
+location	San Pablo (Portoviejo)	-1.0454186	-80.4381871
+location	San Pablo AR	-26.87136925	-65.3144801964973
+location	San Pablo CR	9.99177875	-84.09947940231145
+location	San Pablo EC	0.2123268007310509	-78.17167632131718
+location	San Patricio County	27.9973226	-97.5130456
+location	San Pedro	9.931519	-84.0503028
+location	San Pedro AR	-33.6758554	-59.662845
+location	San Pedro Ayampuc	14.76393485	-90.43584020648493
+location	San Pedro Carchá	15.5782369	-90.20547238592238
+location	San Pedro CO	6.2668403	-75.5607892
+location	San Pedro CR	9.931519	-84.0503028
+location	San Pedro de Jujuy	-24.2311801	-64.8620656
+location	San Pedro de la Paz	-36.8414183	-73.1039909
+location	San Pedro de Pegas	42.4507713	-5.8742039
+location	San Pedro Pinula	14.6629921	-89.8476479
+location	San Pedro Sacatepequez	14.69497515	-90.64233914093663
+location	San Pedro Town	17.90265725	-87.98179870404411
+location	San Pol de Mar	41.6030132	2.6238092
+location	San Rafael	-34.6126025	-68.330514
+location	San Rafael AR	-34.6126025	-68.330514
+location	San Rafael Arriba	9.8760156	-84.0768575
+location	San Rafael Cartago	9.8698026	-83.9036025
+location	San Rafael CL	-35.3049609	-71.5162278
+location	San Rafael de Alajuela	9.964081	-84.223595
+location	San Rafael de Escazú	9.9299595	-84.1360509
+location	San Rafael Heredia	10.013197	-84.097456
+location	San Ramon	9.9406657	-83.9936985
+location	San Ramon CL	-33.53781595	-70.64249593576656
+location	San Ramon CR	9.9406657	-83.9936985
+location	San Ramon de la Nueva Oran	-23.136084	-64.3230702
+location	San Ramón District, La Unión	9.9393295	-83.9879075
+location	San Raymundo	14.7979606	-90.54133430479274
+location	San Roman	43.3047968	-3.9116562
+location	San Roman de la Vega	42.4717118	-6.0251891
+location	San Roman de los Caballeros	42.6484642	-5.8404551
+location	San Roque	36.210735	-5.386139
+location	San Roque CO	6.4307057499999996	-74.94080256175135
+location	San Roque CR	10.0970433	-84.3002741
+location	San Roque de Riomiera	43.2191046	-3.720078851403587
+location	San Roque EC	0.29969699290232965	-78.22359774728699
+location	San Roque ES	36.2096267	-5.3844546
+location	San Saba County	31.122268	-98.8397049
+location	San Salvador de Jujuy	-22.1082984	-65.6008495
+location	San Sebastian	43.3224219	-1.9838889
+location	San Sebastian EC	-3.1395613	-79.2533336
+location	San Sebastian ES	43.3224219	-1.9838889
+location	San Telmo	-34.6214013	-58.37375
+location	San Vicente	-34.4392675	-71.07679
+location	San Vicente de Castellet	41.6669999	1.8625559
+location	San Vicente de la Sonsierra	42.5626773	-2.7589811
+location	Sanarate	14.77720345	-90.19410851937073
+location	Sanary-sur-Mer	43.1177238	5.8008839
+location	Sancibrian	43.4611	-3.8866
+location	Sanclerlandia	-16.1993165	-50.309374
+location	Sancti Spiritu	-34.0076455	-62.2414297
+location	Sanders County	47.6801812	-115.1769538
+location	Sandhasal	22.6358572	73.3572471
+location	Sandolandia	-12.5389465	-49.9285958
+location	Sandomierz	50.6793066	21.7495055
+location	Sandoval County	35.5910806	-106.8472167
+location	Sandovalina	-22.4560782	-51.7634004
+location	Sanford	-33.1457648	-61.2771172
+location	Sangalkam	14.779304	-17.228261
+location	Sangamon County	39.7623668	-89.6454905
+location	Sangareddy	17.86859205	77.8228199507381
+location	Sangli	16.8502534	74.5948885
+location	Sankt Gallenkappel	47.245722	8.9652667
+location	Sankt Lorenz	47.8228118	13.3561241
+location	Sankt Pölten	48.138601449999996	15.817633511871579
+location	Sankt Pölten-Land	48.2852569	15.6955065
+location	Sankt Pölten-Stadt	48.138601449999996	15.817633511871579
+location	Sankt Veit An Der Glan	46.7672814	14.3576981
+location	Sanok	49.5567406	22.211701678304745
+location	Sansac de Marmiesse	44.8824607	2.3485484
+location	Sant Adria del Besos	41.4204568	2.2234134
+location	Sant Andreu de la Barca	41.4518183	1.972476
+location	Sant Andreu de Llavaneres	41.5739524	2.4828158
+location	Sant Antoni de Vilamajor	41.6735604	2.4012202
+location	Sant Boi de Llobregat	41.3459033	2.0413673
+location	Sant Boi de Llucanes	42.0578411	2.1511135
+location	Sant Celoni	41.6895041	2.4914526
+location	Sant Dalmai	41.9123811	2.7327969
+location	Sant'Elia a Pianisi	41.62043	14.875234
+location	Sant Esteve de Guialbes	42.1150143	2.8779527
+location	Sant Esteve de Palautordera	41.7040768	2.4343426
+location	Sant Esteve Sesrovires	41.4932429	1.8747348
+location	Sant Feliu de Codines	41.6885036	2.1646769
+location	Sant Feliu de Guixols	41.7838827	3.0283195
+location	Sant Feliu de Llobregat	41.3812851	2.0446381
+location	Sant Fost de Campsentelles	41.5122172	2.2379134
+location	Sant Fruitos	41.75177975	2.1211491910262454
+location	Sant Fruitos de Bages	41.7532735	1.8749418
+location	Sant Gregori	41.9910304	2.7564765
+location	Sant Hilari Sacalm	41.8780822	2.5131751
+location	Sant Hipolit de Voltrega	42.0152733	2.2376471
+location	Sant Jaume de Llierca	42.2119833	2.6074259
+location	Sant Joan de les Abadesses	42.233743	2.2854845
+location	Sant Joan de Moro	40.0609116	-0.1371097
+location	Sant Joan Despi	41.3667951	2.0570346
+location	Sant Joan Les Fonts	42.2132951	2.5134302
+location	Sant Joan Vilatorrada	41.7422073	1.803625
+location	Sant Julia de Ramis	42.0280167	2.8539991
+location	Sant Julia de Vilatorta	41.9219404	2.3240651
+location	Sant Llorenc Savall	41.6794647	2.0579669
+location	Sant Marti de Centelles	41.754090399999995	2.219576225875367
+location	Sant Miquel de Balenya	41.8417656	2.2509899
+location	Sant Miquel de Fluvia	42.1732143	2.9904591
+location	Sant Miquel de Gonteres	41.5666344	1.9730949
+location	Sant Pere De Ribes	41.2619218	1.7721357
+location	Sant Pere de Riudebitlles	41.4535893	1.7017388
+location	Sant Pere de Torello	42.0754755	2.2955862
+location	Sant Pere de Vilamajor	41.6843288	2.3900497
+location	Sant Quirze de Besora	42.101426	2.2170289
+location	Sant Quirze del Valles	41.530143	2.0820052
+location	Sant Vicenç de Montalt	41.5787122	2.5103642
+location	Sant Vicenc de Torello	42.0630229	2.272337
+location	Santa	-8.991713	-78.6188684404776
+location	Santa Adelia	-21.2432992	-48.8061481
+location	Santa Ana CR	9.930026	-84.180497
+location	Santa Ana PA	8.95708125	-79.53856710744475
+location	Santa Barbara County	34.7136533	-119.9858232
+location	Santa Barbara D'Oeste	-22.7542539	-47.4137884
+location	Santa Barbara de Goias	-16.5779125	-49.6982268
+location	Santa Barbara de Heredia	10.082351599999999	-84.14632695595529
+location	Santa Barbara do Para	-1.226144	-48.295101
+location	Santa Branca	-23.3974353	-45.8842294
+location	Santa Brigida	28.035684	-15.4974676
+location	Santa Catarina Pinula	14.56562755	-90.47611786893953
+location	Santa Clara	9.0336879	-79.7526466
+location	Santa Clara County	37.236094	-121.683399
+location	Santa Clara de Louredo	37.9701683	-7.8720098
+location	Santa Clara PA	9.0336879	-79.7526466
+location	Santa Coloma de Cervello	41.3687006	2.0174512
+location	Santa Coloma de Farners	41.8603109	2.6659047
+location	Santa Coloma de Gramenet	41.4515626	2.2083371
+location	Santa Comba	43.0336	-8.8047
+location	Santa Croce di Magliano	41.7124096	14.9933783
+location	Santa Cruz	10.23575875	-85.66996320389299
+location	Santa Cruz Balanya	14.6847218	-90.9176642
+location	Santa Cruz BR	-6.224752	-36.019297
+location	Santa Cruz County	37.050096	-121.9905908
+location	Santa Cruz County AZ	31.5094579	-110.8476281
+location	Santa Cruz County CA	37.050096	-121.9905908
+location	Santa Cruz CR	10.23575875	-85.66996320389299
+location	Santa Cruz Das Palmeiras	-21.823475	-47.248023
+location	Santa Cruz de Bezana	43.4429266	-3.9048376
+location	Santa Cruz de Lorica	9.238594101122898	-75.81619916716095
+location	Santa Cruz De Mudela	38.6419862	-3.4666934
+location	Santa Cruz De Tenerife	28.469648	-16.2540884
+location	Santa Cruz del Quiche	15.02328735	-91.12739451685866
+location	Santa Cruz do Capibaribe	-7.948019	-36.206092
+location	Santa Cruz do Rio Pardo	-22.9060715	-49.6277378
+location	Santa Cruz do Sul	-29.7141869	-52.4285914
+location	Santa Cruz EC	-0.62881505	-90.3638752022324
+location	Santa Eugenia de Berga	41.9000058	2.283319
+location	Santa Eulalia	15.74771805	-91.30883001507874
+location	Santa Eulàlia de Ronçana	41.6523952	2.229264
+location	Santa Fe AR	-31.61799171769444	-60.70471255354044
+location	Santa Fe County	35.4859674	-106.0135507
+location	Santa Fe County NM	35.4859674	-106.0135507
+location	Santa Fe de Antioquia	6.5392462	-75.91554177262941
+location	Santa Fe de Goias	-15.7705927	-51.1018204
+location	Santa Fe de Montseny	41.7736489	2.4649068
+location	Santa Fe ES	37.18715273934768	-3.720580462243735
+location	Santa Fe PA	8.6569607	-78.1560113
+location	Santa Helena	-24.8591735	-54.3328813
+location	Santa Ines	-3.6647821	-45.3826869
+location	Santa Isabel	-23.3194222	-46.2271903
+location	Santa Isabel AR	-33.8877576	-61.695947
+location	Santa Isabel do Pará	-1.2968557	-48.1605533
+location	Santa Isabel do Rio Negro	-0.4160389	-65.0153096
+location	Santa Juana	-37.1737794	-72.94259
+location	Santa Llogaia D'Alguema	42.2333519	2.9523456
+location	Santa Lucia	42.359725600000004	-6.618468536067086
+location	Santa Lucía Cotzumalguapa	14.300235350000001	-91.07772209655589
+location	Santa Luzia	-3.9633675	-45.6637956
+location	Santa Luzia do Norte	-9.6037	-35.823196
+location	Santa Luzia MA	-3.9633675	-45.6637956
+location	Santa Luzia MG	-19.7702097	-43.8505291
+location	Santa Margalida	39.7033676	3.1026602
+location	Santa Margarida de Montbui	41.5746303	1.6087408
+location	Santa Maria	-29.6860512	-53.8069214
+location	Santa María Cahabón	15.5980356	-89.73438102889162
+location	Santa María Chiquimula	15.0296151	-91.329326
+location	Santa Maria de Cayon	43.30976	-3.85548
+location	Santa Maria de Corcó	42.0340216	2.3697082
+location	Santa Maria de Guia de Gran Canaria	28.1390522	-15.6318282
+location	Santa Maria de Jetiba	-20.025296	-40.743931
+location	Santa Maria de Martorelle	41.5198085	2.2537044
+location	Santa Maria de Palautordera	41.693781	2.4442321
+location	Santa Maria del Aguila	36.780645	-2.7736816
+location	Santa Maria del Camino	39.6705	2.7680
+location	Santa Maria del Molise	41.552725	14.368224
+location	Santa Maria DF	-16.0171229	-48.0131328
+location	Santa Maria do Pará	-1.3455478	-47.5782981
+location	Santa Maria dos Olivais	39.60115745	-8.384718083003463
+location	Santa Maria Madalena	-21.9557957	-42.008283
+location	Santa Maria RS	-29.6860512	-53.8069214
+location	Santa Marta	11.234638	-74.192698
+location	Santa Pau	42.1442606	2.571379
+location	Santa Perpetua de Mogoda	41.5328106	2.1823309
+location	Santa Pola	38.1923641	-0.5555464
+location	Santa Ponca	39.5171235	2.4822483
+location	Santa Rita	-7.128465	-34.9846186
+location	Santa Rita PA	8.49659119774437	-80.18592621740063
+location	Santa Rita PB	-7.128465	-34.9846186
+location	Santa Rosa	-27.8643546	-54.4779287
+location	Santa Rosa AR	-36.6203503	-64.2905765
+location	Santa Rosa BR	-27.8643546	-54.4779287
+location	Santa Rosa CR	9.9254578	-83.6964964
+location	Santa Rosa de Calamuchita	-32.0644855	-64.5396135
+location	Santa Rosa de Lima	-28.0404239	-49.1280356
+location	Santa Rosa de Osos	6.69856175	-75.45987234539976
+location	Santa Salete	-20.2451795	-50.6889625
+location	Santa Sofia	5.714409	-73.602111
+location	Santa Susanna	41.6357256	2.7065933
+location	Santa Sylvina	-27.83264285	-61.1371948561827
+location	Santa Teresa	-19.936339	-40.597945
+location	Santa Vitoria do Palmar	-33.5195569	-53.3692659
+location	Santaella	37.561297	-4.8425505
+location	Santana	6.057578	-73.479309
+location	Santana BR	-0.0307068	-51.1789666
+location	Santana CO	6.055599150000001	-73.48209236741033
+location	Santana de Parnaiba	-23.4446715	-46.9167722
+location	Santana do Ipanema	-9.369989	-37.248018
+location	Santana do Livramento	-30.803658900000002	-55.52430857825763
+location	Santana do Matos	-5.9468972	-36.6502541
+location	Santana do Mundau	-9.171413	-36.217608
+location	Santander	43.4620412	-3.8099719
+location	Santander de Quilichao	3.0075752	-76.4856531
+location	Santany	39.3543115	3.1294799
+location	Santarem	39.2363637	-8.6867081
+location	Santarem BR	-2.438489	-54.699611
+location	Santarem PT	39.2363637	-8.6867081
+location	Santes	50.5977229	2.955471
+location	Santiago	-33.464455	-70.651851
+location	Santiago (Alajuela)	10.0652058	-84.4863993
+location	Santiago CR	10.0652058	-84.4863993
+location	Santiago de Cartes	43.3355848	-4.0651949
+location	Santiago de Compostela	42.8782	8.5448
+location	Santiago de Puriscal	9.8484405	-84.3132776
+location	Santiago PA	8.1097491	-80.9753886
+location	Santiago Sacatepequez	14.64120575	-90.67866924324778
+location	Santibanez	43.28626	-4.24253
+location	Santillana	43.3906511	-4.108048
+location	Santillana Del Mar	43.3906511	-4.108048
+location	Santo Amaro	-12.5519686	-38.7060448
+location	Santo Amaro Da Imperatriz	-27.6865324	-48.7769405
+location	Santo Anastacio	-21.974662	-51.652662
+location	Santo Andre	-23.6573395	-46.5322504
+location	Santo Angelo	-28.3000481	-54.2669971
+location	Santo Antonio Da Patrulha	-29.826768	-50.517489
+location	Santo Antonio Da Platina	-23.2957157	-50.0778957
+location	Santo Antonio Das Missoes	-28.5117897	-55.2290047
+location	Santo Antonio de Jesus	-12.9689361	-39.260914
+location	Santo Antonio de Padua	-21.5389992	-42.1799978
+location	Santo Antonio do Aventureiro	-21.7579052	-42.815566
+location	Santo Antônio do Içá	-3.095443	-67.946279
+location	Santo Antonio do Monte	-20.086944	-45.290555
+location	Santo Antônio do Tauá	-1.1522	-48.131446
+location	Santo Domingo	-0.34018899999999996	-79.17154939601922
+location	Santo Domingo AR	-31.11881059851453	-60.88711908675301
+location	Santo Domingo CR	9.987976	-84.06513476554412
+location	Santo Domingo de la Calzada	42.4406711	-2.9536395
+location	Santo Domingo de los Colorados	-0.25263278671144457	-79.17403474511357
+location	Santo Tome	-31.6630458	-60.7618282
+location	Santona	43.4449362	-3.4553628
+location	Santos	-23.960833	-46.333889
+location	Santpedor	41.7847594	1.8386882
+location	Santullan	43.3472893	-3.2106634
+location	Santurtzi	43.3287527	-3.0318766
+location	Sanyuyo	14.63933321729972	-90.15206882735566
+location	Sanz Peña	-25.9506177	-60.6172758
+location	Sao Benedito	-4.0479952	-40.8643488
+location	Sao Bento do Sul	-26.2483669	-49.3820672
+location	Sao Bento do Una	-8.5207092	-36.4445546
+location	Sao Bernardo do Campo	-23.735551	-46.563349
+location	Sao Borja	-28.6592237	-56.0044295
+location	Sao Caetano	-8.3304491	-36.135359
+location	Sao Caetano de Odivelas	-0.747293	-48.024622
+location	Sao Caetano do Sul	-23.6195923	-46.5688323
+location	Sao Carlos	-22.0180395	-47.891154
+location	Sao Cristovao	-11.0136465	-37.2071134
+location	São Domingos da Benfica	38.738026950000005	-9.195298604626885
+location	Sao Domingos do Capim	-1.6789331	-47.7717815
+location	São Domingos do Sul	-28.5297239	-51.8905306
+location	Sao Fidelis	-21.6482101	-41.7480548
+location	Sao Francisco	-0.0539603	-51.4016106
+location	Sao Francisco de Itabapoana	-21.4743369	-41.1118362
+location	Sao Francisco do Conde	-12.628108	-38.6811326
+location	Sao Francisco do Para	-1.1693995	-47.7972589
+location	Sao Francisco do Sul	-26.2495087	-48.6308087
+location	São Gabriel Da Cachoeira	-0.1249715	-67.0813855
+location	Sao Gabriel Da Palha	-19.0148349	-40.539464
+location	Sao Goncalo	-22.8219014	-43.0309252
+location	Sao Goncalo do Amarante	-3.6099755	-38.9687182
+location	São Gotardo	-19.3168844	-46.0476596
+location	Sao Joao Batista	-27.277547	-48.8496101
+location	Sao Joao Da Barra	-21.6348588	-41.0487079
+location	Sao Joao Da Boa Vista	-21.9778137	-46.7881722
+location	Sao Joao Da Boa Vista (Paraná)	-23.480774	-53.350981
+location	Sao Joao Da Boa Vista (São Paulo)	-21.9778137	-46.7881722
+location	São João Da Canabrava	-6.8175686	-41.3461715
+location	Sao Joao Da Ponta	-0.8526516	-47.9224095
+location	São João de Meriti	-22.8043744	-43.3724125
+location	Sao Joao de Pirabas	-0.7733201	-47.1770631
+location	Sao Joao do Ivai	-23.9914063	-51.8232148
+location	São João do Piauí	-8.3601426	-42.2487642
+location	São João do Sabugi	-6.718821	-37.1997947
+location	Sao Joaquim	-28.2924972	-49.9353255
+location	Sao Joaquim Da Barra	-20.5814993	-47.8608238
+location	Sao Joaquim do Monte	-8.4323653	-35.8076179
+location	Sao Jose	-27.5877184	-48.6493272
+location	Sao Jose Da Lapa	-19.6988548	-43.9583194
+location	São José de Mipibu	-6.0746867	-35.2370184
+location	Sao Jose de Ribamar	-2.5609115	-44.0559509
+location	Sao Jose de Uba	-21.3595365	-41.9389905
+location	Sao Jose do Brejo do Cruz	-6.212327	-37.3544536
+location	Sao Jose do Egito	-7.469447	-37.273974
+location	Sao Jose do Rio Pardo	-21.595288	-46.887303
+location	Sao Jose do Rio Preto	-20.8125851	-49.3804212
+location	São José do Seridó	-6.4488139	-36.878528
+location	Sao Jose do Vale do Rio Preto	-22.1509994	-42.9239986
+location	Sao Jose Dos Ausentes	-28.747731	-50.0645582
+location	Sao Jose Dos Campos	-23.1860383	-45.8866816
+location	Sao Jose Dos Pinhais	-25.533816	-49.2072163
+location	São Leopoldo	-29.793045	-51.1111978
+location	Sao Lourenco	-22.116389	-45.054167
+location	Sao Lourenco Da Mata	-7.9959607	-35.039335
+location	São Lourenco Da Serra	-23.8535923	-46.9440587
+location	Sao Lourenco do Sul	-31.3669286	-51.9814839
+location	Sao Ludgero	-28.3243832	-49.174819
+location	Sao Luis	-2.5634605	-44.2448718
+location	São Luis de Curu	-3.672399	-39.2364881
+location	Sao Luis de Montes Belos	-16.5210639	-50.3726281
+location	Sao Luiz Gonzaga	-28.4074546	-54.9609081
+location	Sao Mateus	-23.5982995	-46.4817046
+location	Sao Mateus do Sul	-25.866823	-50.382796
+location	Sao Miguel Arcanjo	-23.8807771	-47.9963492
+location	São Miguel do Guamá	-1.6116804	-47.4757551
+location	Sao Miguel do Guapore	-11.6951466	-62.7195739
+location	Sao Miguel do Iguacu	-25.349171	-54.240498
+location	Sao Miguel do Oeste	-26.7278977	-53.5176689
+location	Sao Miguel Dos Campos	-9.7831115	-36.0967804
+location	São Paulo	-23.551096	-46.634874
+location	São Paulo AN	-8.8135247	13.2559223
+location	São Paulo AO	-8.8135247	13.2559223
+location	Sao Pedro	-22.5512765	-47.9072359
+location	Sao Pedro Da Aldeia	-22.8384835	-42.1031604
+location	Sao Pedro do Sul	-29.6152729	-54.1790311
+location	Sao Pedro do Turvo	-22.745286	-49.742829
+location	São Rafael	-5.8022027	-36.8835945
+location	Sao Roque	-23.5304843	-47.1355473
+location	Sao Sebastiao	-23.8027866	-45.4070527
+location	Sao Sebastiao (Alagoas)	-9.9315057	-36.5439245
+location	Sao Sebastiao (São Paulo)	-23.8027866	-45.4070527
+location	Sao Sebastiao do Alto	-21.9568272	-42.134815
+location	Sao Sebastiao do Cai	-29.5911777	-51.3778772
+location	Sao Sebastiao do Passe	-12.5177926	-38.4921566
+location	Sao Simao	-21.4800208	-47.5531095
+location	Sao Simao (Goiás)	-18.9941302	-50.5468215
+location	Sao Simao (São Paulo)	-21.4800208	-47.5531095
+location	Sao Vicente	-23.9603686	-46.3847024
+location	Sape	-7.093591	-35.227975
+location	Sapiranga	-29.6392382	-51.0068586
+location	Sapolno	53.80678	17.33419
+location	Sappemeer	53.1642791	6.7960954
+location	Sapucaia	-21.9946569	-42.9137975
+location	Sapucaia do Sul	-29.8197019	-51.1608722
+location	Saquarema	-22.9257974	-42.507633
+location	Saraguro	-3.6224722	-79.2384881
+location	Sarah Baartman	-32.951175	24.655121593091742
+location	Sarail	24.1215351	91.1322954
+location	Sarandi	-27.942	-52.923085
+location	Sarandi PR	-23.444117	-51.876016
+location	Sarandi RS	-27.942	-52.923085
+location	Saransk	54.18671	45.18383
+location	Sarapiqui	10.5925359	-83.9687564
+location	Sarapiqui (Heredia)	10.48716355	-83.99568526979894
+location	Saratoga County	43.0324	-73.9360
+location	Saravena	6.9067931	-71.83629204271858
+location	Sarcelles	48.9960813	2.3796245
+location	Sarchi	10.1554079	-84.3244724
+location	Sardinal	10.5169085	-85.6467609
+location	Sardonedo	42.5355436	-5.8443872
+location	Sargans	47.0482641	9.4401995
+location	Sariego	43.418225199999995	-5.551820088082487
+location	Sarmiento	-32.0230049	-61.2203953
+location	Sarnen	46.8956729	8.2461492
+location	Sarolangun	-2.3051268	102.7175331
+location	Saron	43.3237089	-3.8536587
+location	Sarreguemines	49.1094836	7.0708865
+location	Sarria de Ter	42.0141923	2.8175976
+location	Sarriguren	42.8105858	-1.5926872
+location	Sarroca de Lleida	41.4594249	0.5610144
+location	Sarrola-Carcopino	41.99819295	8.831373535819166
+location	Sart-Dames-Avelines	50.554168950000005	4.489554025750576
+location	Sarthe	48.026928749999996	0.2538217482247317
+location	Sarzyna	50.3443285	22.3437901
+location	Sassari	40.777800400000004	8.921996955790174
+location	Šaštín-Stráže	48.6369924	17.148493
+location	Sastre	-34.0064335	-62.2445057
+location	Satiro Dias	-11.6033746	-38.581456
+location	Satkhira	22.7166509	89.0749857
+location	Saugues	44.959244	3.5446108
+location	Sauk County	43.4401728	-89.9653841
+location	Saukville	43.3817	-87.9406
+location	Saumur	47.2596224	-0.0785177
+location	Saurimo	-9.6503108	20.400352
+location	Sautour	50.1694005	4.5612425
+location	Sauwerd	53.2939692	6.5329756
+location	Sauzalito	-24.430807950000002	-61.70204474968414
+location	Savali	22.952682	73.110405
+location	Savar	23.8477	90.2587
+location	Savli	22.560712	73.223754
+location	Sawahlunto	-0.6818141	100.778552
+location	Sawyer County	45.8731634	-91.1468287
+location	Sax	47.2313591	9.4573009
+location	Sax CH	47.2313591	9.4573009
+location	Sax ES	38.5447558	-0.8141584
+location	Sayat	45.8273147	3.0510236
+location	Sayedabad	23.7143138	90.4272216
+location	Sběř	50.3201255	15.4243734
+location	Schänis	47.1591758	9.0466793
+location	Schaerbeek	50.8676041	4.3737121
+location	Schaffen	51.0017947	5.083998
+location	Schaffhausen	47.6960491	8.634513
+location	Scharnstein	47.904491	13.9609752
+location	Schelle	51.1245635	4.3361875
+location	Schenectady County	42.822882	-74.053939
+location	Schepdaal	50.8348548	4.1919739
+location	Scherpenheuvel	50.9802698	4.9774558
+location	Scherpenheuvel-Zichem	50.997795	4.967443
+location	Schierling	48.8350879	12.1378625
+location	Schilde	51.257095	4.595518213176632
+location	Schildwolde	53.2329904	6.8160591
+location	Schiphol	52.3080392	4.7621975
+location	Schladming	47.3940415	13.6867878
+location	Schlusselfeld	49.7569182	10.6186266
+location	Schmerikon	47.2256001	8.9415774
+location	Schoelcher	14.638297575038703	-61.100078399925614
+location	Schönau an der Triesting	47.9265367	16.257090237672276
+location	Schörfling Am Attersee	47.9463531	13.6035607
+location	Schötz	47.1698443	7.9884821
+location	Schoharie County	42.5757217	-74.4390277
+location	Schopfheim	47.6500525	7.8216997
+location	Schore	51.1110889	2.8402112
+location	Schoten	51.2498	4.4977
+location	Schriek	51.0248817	4.6908515
+location	Schroeder	-26.411571	-49.074041
+location	Schuyler County	40.1370869	-90.5697373
+location	Schuyler County IL	40.1370869	-90.5697373
+location	Schuyler County NY	42.3903231	-76.8691575
+location	Schwabach	49.3295535	11.0195132
+location	Schwaben	48.9105093	11.7606663
+location	Schwanenstadt	48.0545249	13.7749232
+location	Schwarzach	47.44718315	9.75849349364426
+location	Schwaz	47.3449529	11.7084253
+location	Schwechat	48.10499675	16.5848987032657
+location	Scioto County	38.823448	-83.017141
+location	Scotland County	34.8628902	-79.4903372
+location	Scott County	39.6333408	-90.4753685
+location	Scott County IA	41.6251843	-90.6164201
+location	Scott County IL	39.6333408	-90.4753685
+location	Scott County MS	32.3805744	-89.5092509
+location	Sde Moshe	31.600756	34.805793
+location	Sde Yitzhak	31.7359711	34.7485029
+location	Sdema	31.8317054	34.73857176018446
+location	Sderot	31.526474	34.5969696
+location	Seaford	38.6413452	-75.6114584
+location	Seattle	47.748301	-121.850150
+location	Sebastianopolis do Sul	-20.6581669	-49.9229043
+location	Seberi	-27.4828134	-53.4013251
+location	Secaucus	40.7899291	-74.0566735
+location	Secovska Polianka	48.7837273	21.680046
+location	Secunderabad	17.4337246	78.5006827
+location	Sedavi	39.4247119	-0.3834581
+location	Sedelnikovo	56.945618	75.306061
+location	Sedlec	50.132828	14.393011
+location	Sedliska	48.9053599	21.7278892
+location	Sedziszow	50.564781	20.0538047
+location	See	47.0833333	10.4666667
+location	Seefeld in Tirol	47.329203	11.188798
+location	Seekirchen am Wallersee	47.8942481	13.1260778
+location	Seewalchen Am Attersee	47.9539201	13.5866842
+location	Seewen	47.4354627	7.6582649
+location	Segorbe	39.8492	-0.4904
+location	Segovia	40.9502159	-4.1241494
+location	Seia	40.382903299999995	-7.691353727409561
+location	Seiersberg-Pirka	47.0047875	15.394198241769864
+location	Seine-Et-Marne	48.61902069999999	3.0418157506708345
+location	Seine-Port	48.551795	2.551916
+location	Seine-Saint-Denis	48.9098125	2.4528634784461856
+location	Seixal	38.6422246	-9.1072662
+location	Sejny	54.1101732	23.347142081833674
+location	Sélange	49.6081105	5.848409
+location	Selaya	43.216694	-3.806861
+location	Selbach	-28.6299869	-52.9530657
+location	Selec	48.7856867	17.9908464
+location	Selfkant	51.020689950000005	5.9217594796191495
+location	Seltisberg	47.4598282	7.7153815
+location	Selviria	-20.3638312	-51.4183823
+location	Semerovo	48.0083903	18.3448459
+location	Seminole County	28.7225829	-81.2353683
+location	Sena Madureira	-9.0659556	-68.6571058
+location	Senador Canedo	-16.7013233	-49.0914921
+location	Sene	47.6199584	-2.7373441
+location	Senec	48.2199473	17.3969901
+location	Seneca County	42.7831619	-76.8386051
+location	Seneffe	50.549618	4.268821
+location	Senica	48.6787557	17.3661529
+location	Senillosa	-39.0134511	-68.4267867
+location	Senlis	50.5331612	2.1523287
+location	Sennwald	47.2615026	9.5037691
+location	Senpara	23.8030582	90.3686342
+location	Sens	48.1978559	3.282606
+location	Sens de Bretagne	48.332872	-1.5359128
+location	Sentmenat	41.6110502	2.1374456
+location	Seoul	37.548278	126.990916
+location	Sepolno Krajenskie	53.4547434	17.5348373
+location	Serafina Correa	-28.7120266	-51.9343269
+location	Seraing	50.591687	5.516066
+location	Serbannes	46.0990614	3.3623424
+location	Serchhip	23.385892300000002	92.930598908176
+location	Sereď	48.2889032	17.7308808
+location	Sergiyev Posad	56.3153529	38.1358208
+location	Sermentizon	45.7617278	3.5002847
+location	Seropédica	-22.7438887	-43.6991998
+location	Seros	41.4636665	0.4118677
+location	Serov	59.6051905	60.574043
+location	Serowe	-22.39776	26.703289
+location	Serra	-20.1252961	-40.3064477
+location	Serra do Salitre	-19.1101839	-46.6809858
+location	Serra Talhada	-7.9867805	-38.2920294
+location	Serrana	-21.2066883	-47.6053774
+location	Serrinha	-11.66199	-39.0034021
+location	Serrinha Dos Pintos	-6.112315	-37.9566189
+location	Serrita	-7.9476953	-39.2957383
+location	Serskamp	50.9888236	3.9295057
+location	Sertanopolis	-23.0600434	-51.0373544
+location	Sertao	-27.9853815	-52.257587
+location	Sertolovo	60.143707	30.207806
+location	Sesimbra	38.4454915	-9.099472824318077
+location	Sestroretsk	60.0981084	29.9597606
+location	Sete Barras	-24.3878438	-47.9265798
+location	Sete Lagoas	-19.466111	-44.246944
+location	Sete Quedas	-23.978822	-55.0428349
+location	Seuzach	47.534596	8.7338342
+location	Seva	41.8361292	2.2835441
+location	Sevagram	20.7391912	78.6185535
+location	Sevelen	47.1206364	9.4871231
+location	Severinia	-20.810753	-48.80538
+location	Severomorsk	69.069168	33.416656
+location	Sevilla	37.379170	-5.983557
+location	Seymour	41.396164	-73.072024
+location	Sha'Ab	32.8905934	35.2383757
+location	Shadrinsk	56.7413072	62.8656617
+location	Shahjahanpur	27.912633149999998	79.74656294869826
+location	Shailokupa	23.685593	89.242822
+location	Shajapur	23.37074105	76.62051527475785
+location	Shalya	57.2461908	58.7292306
+location	Shanghai	31.171447	121.429896
+location	Shangla	34.956944	72.848056
+location	Shangrao	28.4549	117.9434
+location	Shangyu	30.0331	120.8681
+location	Shantou	23.379291	116.700154
+location	Shanwei	22.776721	115.366044
+location	Shaoguan	24.803789	113.598404
+location	Shaoyang	26.958944	111.283087
+location	Shape	50.771320	3.943706
+location	Shariatpur	23.2132841	90.3481247
+location	Shariatpur Sadar Upazila	23.21955261848975	90.31721072972182
+location	Sharkey County	32.8742585	-90.8478339
+location	Shasta County	40.7965121	-121.9979194
+location	Shawano County	44.7817214	-88.7118868
+location	Shawnee County	39.0273676	-95.7627535
+location	Shaymoli	23.7763809	90.3638875
+location	Sheboygan County	43.7128967	-87.9370433
+location	Shelby County	33.2503347	-86.6639746
+location	Shelby County AL	33.2503347	-86.6639746
+location	Shelby County IL	39.3665064	-88.7886278
+location	Shelby County TN	35.1782557	-89.8739775
+location	Shelby County TX	31.7716364	-94.1301652
+location	Shelton	41.3165	73.0932
+location	Shenzhen	22.639468	114.044046
+location	Sheridan	45.0992814	-123.3948291
+location	Sherman County	45.3944268	-120.6963746
+location	Sherpur	25.0227686	90.0060793
+location	Shibganj	24.6813931	88.1582985
+location	Shijiazhuang	38.0429742	114.5088385
+location	Shimla	31.1041526	77.1709729
+location	Shlomi	33.0760504	35.1485842
+location	Shoham	31.9977784	34.95421212451707
+location	Sholokbahar	22.3655282	91.8371121
+location	Shoshone County	47.305486	-115.9583164
+location	Shtip	41.7374724	22.1935856
+location	Shulan	44.4084581	126.9410597
+location	Shuya	61.900646	34.242317
+location	Shuya (Ivanovo)	56.8558465	41.3838496
+location	Shuya (Karelia)	61.900646	34.242317
+location	Sialkot	32.4935378	74.5411575
+location	Siavonga	-16.511069	28.7586151
+location	Sibin	53.9059007	14.6752944
+location	Siddhpur	23.918279	72.3681846
+location	Sidi Bouzid	35.0382386	9.4865301
+location	Sidoarjo	-7.4559622	112.66022171549456
+location	Sidrolandia	-20.9361042	-54.9640262
+location	Siedlce	52.161593800000006	22.281253302988254
+location	Siedlecin	50.9387107	15.6905264
+location	Siedliska-Bogusz	49.9150235	21.4158949
+location	Siedlisko	54.20178	22.23588
+location	Siekierczyna	49.6522995	20.4346735
+location	Sielsko	53.58293	15.46851
+location	Siemianowice Slaskie	50.31285075	19.017785857354603
+location	Siemiatki	53.3244444	20.4616667
+location	Siemiatycze	52.4209252	22.875437270492178
+location	Siena	43.16711185	11.467331746909997
+location	Sienno	51.08489	21.4737425
+location	Siepraw	49.9087175	19.9686151
+location	Sieradz	51.6017529	18.739901469268844
+location	Sierakow	49.9064378	20.0833997
+location	Siero	43.3952982	-5.635702393762417
+location	Sierosław	52.4039794	16.6752851
+location	Sieroszow	50.6154604	16.9027402
+location	Sierra County	33.1165937	-107.2569421
+location	Sierra County CA	39.5849065	-120.5305731
+location	Sierra County NM	33.1165937	-107.2569421
+location	Sierra de Fuentes	39.4372411	-6.2739777
+location	Sierrapando	43.3439274	-4.03291
+location	Siggerwiesen	47.8597857	13.0107741
+location	Sigmaringen	48.0855844	9.2178879
+location	Sihelne	49.5	19.4333333
+location	Sihla	48.657583	19.6468201
+location	Sijunjung	-0.6664603	100.9448719
+location	Sikar	27.662826000000003	75.02792628691331
+location	Sikenicka	47.934344	18.6834497
+location	Silica	48.5555727	20.5219149
+location	Silla	39.3632045	-0.4112618
+location	Silleda	42.6900518	-8.28359
+location	Silly	50.638827	3.943396
+location	Sils	41.8089441	2.7414651
+location	Silute	55.3413747	21.4605697
+location	Silva Jardim	-22.6504534	-42.3919146
+location	Silver Bow County	45.9009106	-112.6788845
+location	Simalungun	2.9505160999999998	98.78353062383172
+location	Simao	-18.9941302	-50.5468215
+location	Simao Dias	-10.7388301	-37.809016
+location	Simat de la Valldigna	39.0427	-0.3107
+location	Simoca	-27.262655	-65.356616949214
+location	Simpelveld	50.83081145	5.984685303060697
+location	Simpheropol	44.94604762073824	34.106807829288186
+location	Sincelejo	9.315429349999999	-75.43297645405696
+location	Sindhudurg	16.135719299999998	73.65220860183584
+location	Singapore	1.344189	103.867546
+location	Sinnamary	5.3771446	-52.9573533
+location	Sint-Agatha-Rode	50.7868179	4.6338484
+location	Sint-Amands	51.046340900000004	4.210734819659272
+location	Sint-Amandsberg	51.061875	3.7488657
+location	Sint-Andries	51.192022	3.178018989157882
+location	Sint-Denijs	50.7517122	3.3683921
+location	Sint-Eloois-Vijve	50.9059283	3.4038085
+location	Sint-Genesius-Rode	50.743667	4.371971
+location	Sint-Gillis-Waas	51.226622	4.118297
+location	Sint-Huibrechts-Hern	50.8281262	5.4514094
+location	Sint-Joris (Veurne)	51.1303504	2.7781352
+location	Sint-Joris-Weert	50.8032485	4.6524453
+location	Sint-Joris-Winge	50.9078611	4.8765529
+location	Sint-Katelijne-Waver	51.06232435	4.511427814014689
+location	Sint-Katherina-Lombeek	50.8726659	4.1535568
+location	Sint-Kruis	51.2185508	3.273037047606274
+location	Sint-Lenaarts	51.3453831	4.6782162
+location	Sint-Martens-Latem	51.020971	3.6397549
+location	Sint-Michiels	51.18087935	3.207862106248589
+location	Sint-Niklaas	51.1646685	4.1395124
+location	Sint-Pieters-Leeuw	50.781183549999994	4.245218617306429
+location	Sint-Pieters-Rode	50.9321326	4.8214061
+location	Sint-Stevens-Woluwe	50.8662434	4.436057976358823
+location	Sint-Truiden	50.810338	5.192644
+location	Sintra	38.8355605	-9.352225245746453
+location	Sioma	-16.6018637	23.5028306
+location	Siquirres	10.1513812	-83.48051634442399
+location	Sirajganj	24.4566253	89.7081281
+location	Siran	44.9543549	2.1270458
+location	Sirault	50.5054072	3.7882895
+location	Širvintų rajono savivaldybė	55.008606400000005	24.88623218512127
+location	Siskiyou County	41.5007223	-122.54435414752092
+location	Sissach	47.4634767	7.8125639
+location	Sisseln	47.5534624	7.989416
+location	Sisteron	44.1963467	5.9443791
+location	Sistrans	47.231579	11.466706
+location	Sitges	41.2366707	1.8228136
+location	Sittard-Geleen	51.0094043	5.8376057867167965
+location	Sittersdorf	46.53971575	14.616718237467305
+location	Sivagangai	9.9650599	78.7204283237222
+location	Sivakasi	9.4669895	77.77597856822051
+location	Siyathemba	-29.59172	22.52017633268437
+location	Skagit County	48.485784	-121.815524
+location	Skalica	48.8452079	17.2279127
+location	Skamania County	45.966211	-121.9278867
+location	Skarbki	52.1360215	18.5129048
+location	Skarzysko-Kamienna	51.122965699999995	20.87700914767867
+location	Skierniewice	51.95805445	20.144870111023707
+location	Skierniewice County	51.94468755	20.009552327706285
+location	Skirino	58.1562118	30.4590291
+location	Skoki	52.6725926	17.1531343
+location	Skórzewo	52.3920508	16.7908473
+location	Skoszewo	53.78327	14.63044
+location	Skrbensko	49.9065584121232	18.528714034271523
+location	Skwierzyna	52.582556	15.8251716
+location	Slanicka Osada	49.4003441	19.5103588
+location	Slaný	50.2306933	14.0868501
+location	Slatina	50.2241583	14.2207359
+location	Slavec	48.5869516	20.4677768
+location	Slavkov U Brna	49.1535759	16.8763606
+location	Slavkovce	48.6028664	21.9213887
+location	Slawecin	53.602287181842165	17.61473608698098
+location	Sławka Mała	53.34068	20.30042
+location	Slawkowice	49.9360145	20.1458549
+location	Slawno	54.361141950000004	16.6754076140828
+location	Sleman	-7.6952864000000005	110.34462923977276
+location	Slemien	49.7189661	19.3711294
+location	Slinger	43.3336	-88.2862
+location	Slobozia	44.5635999	27.3618477
+location	Slochteren	53.2188327	6.8061724
+location	Slodkow-Kolonia	52.0266551	18.4372602
+location	Slomniki	50.2403739	20.0811369
+location	Slovenska Volova	48.9821888	21.8468527
+location	Slovensky Grob	48.2550032	17.2843332
+location	Slubice	52.3557481	14.5662367
+location	Sluis	51.32566285	3.5166294409278827
+location	Słupca	52.29070125	17.871644736662404
+location	Slupia	51.0136924	20.1486924
+location	Słupsk	54.460570849999996	17.027730037017736
+location	Smalyavichy	54.0299337	28.089752
+location	Smicz	50.41111	17.61525
+location	Smith County	32.3402898	-95.2563971
+location	Smith County TN	36.2549331	-85.9741567918973
+location	Smith County TX	32.3402898	-95.2563971
+location	Smogorzewo	51.9133741	17.0878088
+location	Smolenice	48.5063832	17.4319834
+location	Smolensk	54.77897005	32.04718121915615
+location	Smrdáky	48.7235678	17.306860820989435
+location	Smyrna	39.2998339	-75.6046494
+location	Sneek	53.033548	5.6611029
+location	Snina	48.9900623	22.1556248
+location	Snohomish County	48.006	-122.0731
+location	Soacha	4.581264	-74.216815
+location	Sobkow	50.6981874	20.4559353
+location	Sobotiste	48.7323967	17.4048253
+location	Sobrance	48.7446501	22.1806628
+location	Sochaczew	52.2367219	20.25712361363545
+location	Sochi	43.5854823	39.723109
+location	Socorro	-22.5902619	-46.5249112
+location	Socorro County	33.9904719	-106.9220832
+location	Socuellamos	39.2847	-2.7904
+location	Sölden	46.9673961	11.0070193
+location	Söll	47.5104298	12.206404904058626
+location	Sogamoso	5.7148307	-72.9279328
+location	Sohar	24.3445577	56.7424766
+location	Sokolce	47.8526679	17.8292407
+location	Sokoliniec	53.2920871	15.4987314
+location	Sokółka	53.4049183	23.4995562
+location	Sokolova	56.5465841	61.5065237
+location	Sokolow	51.5148113	18.7356098
+location	Sokolow Podlaski	52.41425845	22.239936475982624
+location	Sol	48.9272527	21.5993108
+location	Solano County	38.295909	-121.928845
+location	Solapur	17.84990665	75.27632027348457
+location	Solares	43.3840287	-3.7385842
+location	Solcany	48.5374754	18.1987362
+location	Soldini	-33.0184214	-60.753138
+location	Solec nad Wisla	51.1349963	21.765376
+location	Soledad	10.905451549999999	-74.77405314080215
+location	Sollana	39.2784514	-0.3818215
+location	Sollenau	47.8994729	16.2463342
+location	Soller	39.7663047	2.7150538
+location	Solms	50.5333914	8.4073302
+location	Solnechnogorsk	56.1853501	36.9781536
+location	Solok City	-0.7922164	100.6573316
+location	Solok Regency	-0.9288959666458962	100.78702153168835
+location	Solothurn	47.2081355	7.5384045
+location	Solsona	41.9945762	1.5184038
+location	Somain	50.3589237	3.2810972
+location	Sombreffe	50.529666132703525	4.602426167675574
+location	Sombrio	-29.107985	-49.632776
+location	Someren	51.38632235	5.688884477579495
+location	Somerset County	40.5675084	-74.6189556
+location	Somerset County MD	38.0630795	-75.8745873
+location	Somerset County NJ	40.5675084	-74.6189556
+location	Somervell County	32.2275813	-97.7724138
+location	Somiedo	43.102801150000005	-6.251455743067364
+location	Somo	43.2964299	-3.6030979
+location	Son Servera	39.6201	3.3603
+location	Sona	7.877591150000001	-81.34948861871585
+location	Sonebhadra	24.6897879	83.0653136
+location	Soneja	39.8172	-0.4302
+location	Sonoma County	38.506902	-122.863769
+location	Sonora	-17.5852028	-54.7548288
+location	Sooretama	-19.1918129	-40.1037067
+location	Sopelana	43.3802735	-2.9838326
+location	Sopetran	6.5174974	-75.7246270734982
+location	Sopkovce	49.01540835	21.871533044661398
+location	Soporna	48.2537227	17.8157589574625
+location	Sopot	54.44190905	18.54309444570447
+location	Sorbas	37.098183	-2.1239548
+location	Soria	41.60125045	-2.721938035449954
+location	Sorinnes	50.2597292	4.98106
+location	Sorkwity	53.8446645	21.1434709
+location	Sorocaba	-23.501667	-47.458056
+location	Sort	42.4113985	1.1297727
+location	Sortavala	61.70274	30.691231
+location	Soses	41.5332267	0.487517
+location	Soshanguve	-25.5263889	28.0994444
+location	Sosnica	49.288988700000004	19.953841407907717
+location	Sosnicowice	50.2722844	18.5298588
+location	Sosnogorsk	63.58523435	53.90040175016682
+location	Sosnovka	62.829796	34.76281
+location	Sosnovyi Bor	59.89695	29.076492
+location	Sosnowa	50.4964449	16.8726968
+location	Sossego	-6.767694	-36.2455081
+location	Sotes	42.39922534634833	-2.602423602356782
+location	Soto de la Marina	43.4661028	-3.8948053
+location	Soto De La Vega	42.3315921	-5.8817976
+location	Soto del Real	40.7534432	-3.7866573
+location	Soultz Haut Rhin	47.8870216	7.2288038
+location	Soultzeren	48.0628907	7.1033848
+location	Soumagne	50.636363	5.733485
+location	Sousa	-6.7662029	-38.2319607
+location	South 24 Parganas	22.145444	88.474411
+location	South Andaman	10.7056905	92.48746789633373
+location	South Coast District	29.873836	34.934417
+location	South Jakarta	-6.2639932	106.7924085
+location	South Milwaukee	42.908266	-87.860903
+location	South Pesisir	-1.6847379939406404	100.90015197379961
+location	South Sikkim	27.74891905	88.5214387098307
+location	South Solok	-1.4221157258055603	101.24606608841445
+location	South Tangerang	-6.2955404	106.7085494
+location	South Tyrol	46.65594215	11.229637264169462
+location	South West Khasi Hills	25.330722100000003	91.32645013786319
+location	South Yorkshire	53.476171	-1.327867
+location	Southeast Alaska	57.3115	-133.8687
+location	Southeast Queensland	-27.478427	152.687047
+location	Southwest Alaska	59.2614	-162.7666
+location	Sowno	54.18391	16.51554
+location	Spanbroek	52.6978541	4.9612207
+location	Spartanburg County	34.937029	-81.9955954
+location	Speicher	47.4201895	9.4203163
+location	Spicheren	49.192118	6.967399
+location	Spiegel B. Bern	46.9260194	7.4362121
+location	Spiere-Helkijn	50.7279919	3.3667739
+location	Spijkenisse	51.8464881	4.3287681
+location	Spisska Nova Ves	48.9435344	20.562964
+location	Spisska Teplica	49.0472297	20.2521678
+location	Spisske Bystre	48.991455	20.2427442
+location	Spisske Podhradie	49.000035	20.7510716
+location	Spittal an der Drau	46.7982211	13.4963308
+location	Spittel An Der Drau	46.7982211	13.4963308
+location	Spokane County	47.605929	-117.398931
+location	Spreitenbach	47.4182444	8.3640342
+location	Spring Green	43.177689	-90.069216
+location	Springbok	-29.6659872	17.8825119
+location	Spy	50.48321905	4.695355517403303
+location	Spychowo	53.6022737	21.3461575
+location	Srbac	45.0954444	17.5198587
+location	Srbobran	45.5484758	19.7911219
+location	Srebrna Gora	50.5755664	16.6589225
+location	Sredneuralsk	56.991631	60.46888
+location	Srem	52.0893322	17.0156809
+location	Sremska Mitrovica	44.9701654	19.6124132
+location	Srikakulam	18.32002205	83.91607719937166
+location	Sroda Slaska	51.1638949	16.5942505
+location	Sroda Wielkopolska	52.2284266	17.277827
+location	St Alyre D Arlanc	45.3681792	3.6386363
+location	St Amant Tallende	45.6689972	3.1091394
+location	St Bernard Parish	29.805323	-89.660779
+location	St Bonnet Les Alliers	45.74186013804722	3.253496255529513
+location	St Cernin	45.0591427	2.4213159
+location	St Charles Parish	29.8883177	-90.3794968
+location	St Clément	48.2184446	3.2936175
+location	St Denis Combarnazat	45.966417	3.3358182
+location	St Eloy Les Mines	46.1611691	2.8345577
+location	St Eustatius	17.4865252	-62.9653116
+location	St Gallen	47.4250593	9.3765878
+location	St Georges	3.8908813	-51.8018208
+location	St Georges de Mons	45.9387966	2.8406572
+location	St Georges sur Allier	45.7107569	3.2441974
+location	St Germain Lembron	45.4578213	3.2389896
+location	St Gervais D Auvergne	45.2022356	5.4820229
+location	St Gervazy	45.4146342	3.2164953
+location	St Hilaire la Croix	46.0464674	3.0463657
+location	St Hippolyte	45.2234102	2.7044242
+location	St Ignat	45.9230736	3.2741618
+location	St James Parish	30.0096684	-90.7989525
+location	St Jeanvrin	46.5961356	2.2341299
+location	St John The Baptist Parish	30.1141748	-90.5276838
+location	St Julien Puy Laveze	45.665626	2.6724466
+location	St Landry Parish	30.6174002	-92.0035057
+location	St Laure	45.901565	3.2903151
+location	St Laurent Du Maroni	5.4989648	-54.0306793
+location	St-Louis	48.7160783	7.1884164
+location	St Maigner	46.0873614	2.6849306
+location	St Mamet la Salvetat	44.8578799	2.3065265
+location	St Maurice Pres Pionsat	46.0651674	2.6020552
+location	St Ours Les Roches	45.8504781	2.8931458
+location	St Plaisir	46.6225895	2.9684788
+location	St Priest des Champs	45.9920042	2.7641296
+location	St Remy sur Durolle	45.8882695	3.5930474
+location	St Saturnin	45.6599836	3.0922454
+location	St Simon	44.9642272	2.4898166
+location	St Sylvestre Pragoulin	46.0547125	3.3944292
+location	St Tammany Parish	30.438441	-89.935519
+location	St Yorre	46.0658287	3.4614685
+location	St. Anton	47.121254	10.265750
+location	St. Anton am Arlberg	47.1288996	10.2663669
+location	St. Charles County	38.7877791	-90.6747372
+location	St. Clair County	38.4616972	-89.9324347
+location	St. Clair County AL	33.7086407	-86.3364
+location	St. Clair County IL	38.4616972	-89.9324347
+location	St. Croix	17.7289564	-64.75901597858353
+location	St. Georgen Im Attergau	47.9336035	13.4908056
+location	St. Jakob	46.6785854	14.6904763
+location	St. Johann im Pongau	47.3475782	13.2026049
+location	St. Joseph County	41.5941578	-86.2787334
+location	St. Konrad	47.9135494	13.8892579
+location	St. Lawrence County	44.4973591	-75.0657043
+location	St. Lorenz	47.8228118	13.3561241
+location	St. Louis MO	38.6270	-90.1994
+location	St. Lucie County	27.3900897	-80.457904
+location	St. Margrethen	47.4510277	9.6410249
+location	St. Moritz	46.4960592	9.8386578
+location	St. Pantaleon	47.4601498	7.6910021
+location	St. Thomas	18.34290815	-64.91889970060265
+location	St. Valentin	48.16847735	14.549624526556675
+location	St.Valentin	48.16847735	14.549624526556675
+location	Stabroek	51.3352018	4.370408277101575
+location	Staden	50.9705286	3.0013884999155254
+location	Stadl-Predlitz	47.0837184	13.966493771538275
+location	Stadskanaal	52.996240099999994	7.001434882926471
+location	Staffelbach	47.2834729	8.0419242
+location	Stalowa Wola	50.5653105	22.0644075
+location	Stambruges	50.5086579	3.7192008
+location	Stanislaus County	37.5500871	-121.0501425
+location	Stanislaw Dolny	49.9036506	19.6561963
+location	Staňkovice	50.5893992	14.16702
+location	Stanly County	35.3235477	-80.2391366
+location	Stans	46.9570611	8.3661026
+location	Stansstad	46.979741	8.3373667
+location	Stara Blotnica	51.5462702	20.9749741
+location	Stara Lubovna	49.3001533	20.6889231
+location	Starachowice	51.03844825	21.0820435436384
+location	Stare Brynki	53.2940252	14.5570387
+location	Stare Chrapowo	53.1748318	14.788669
+location	Staré Hrady	50.3860114	15.2129566
+location	Stare Jablonki	53.69379	20.10404
+location	Stare Kotkowice	50.3421194	17.9061813
+location	Stare Pole	54.0546851	19.2035336
+location	Stare Siedlisko	54.2191146	19.8108636
+location	Stargard	53.30897745	15.031645934671849
+location	Stark County	41.0712135	-89.8066831
+location	Starnberg	48.0000	11.3390
+location	Starogard Gdański	53.96553375	18.526892978957534
+location	Starogardzki	53.8990805	18.371607124248555
+location	Staropole	52.3468698	15.4452446
+location	Starr County	26.5630409	-98.7479897
+location	Starrkirch-Wil	47.3465368	7.925075
+location	Stary Dwor	52.4925	17.8205556
+location	Stary Kamien	53.7340016	19.2092212
+location	Stary Kamień	52.8704883	22.4401701
+location	Stary las	50.3792618	17.408282
+location	Stary Oskol	51.301733771509085	37.8503792523148
+location	Staszow	50.5612276	21.1677849
+location	Staten Island	40.592429	-74.149614
+location	Stavropol	45.0433245	41.9690934
+location	Stearns County	45.535326	-94.6139422
+location	Stebark	53.4953662	20.1335477
+location	Steckborn	47.6653429	8.9815246
+location	Steenkerque	50.6428237	4.0689795
+location	Steenokkerzeel	50.922396	4.499669
+location	Steffisburg	46.7774738	7.6354195
+location	Stegna	54.3286519	19.1130637
+location	Stegny	54.1092953	19.680037
+location	Stein	50.9732145	5.760681940061414
+location	Steinach am Brenner	47.090272	11.472902
+location	Steinen	47.6435624	7.7395193
+location	Steinerkirchen an der Traun	48.0790001	13.9578147
+location	Steinkopf	-29.2625	17.7333333
+location	Stekene	51.214088	4.030857
+location	Stellenbosch	-33.934444	18.869167
+location	Stephenson County	42.3503474	-89.6735637
+location	Stephenson County IL	42.3503474	-89.6735637
+location	Stepien	54.36447	19.76913
+location	Sterrebeek	50.866403	4.474336
+location	Steuben County	42.2359045	-77.3750862
+location	Stevens County	48.4249969	-117.8489411
+location	Stevoort	50.9159568	5.2470802
+location	Steyr-Land	47.8760625	14.2268389
+location	Stillwater County	45.6540259	-109.3579352
+location	Štítnik	48.6589529	20.3641195
+location	Stodůlky	50.0483074	14.3124035
+location	Stojowice	49.8885373	20.0453437
+location	Stokkem	51.0207811	5.7442709
+location	Storey County	39.4572167	-119.5157991
+location	Stoughton	42.922770	-89.225062
+location	Stradzewo	53.2215482	15.4368102
+location	Stránska	48.7571928	19.1592572
+location	Strasbourg	48.5734	7.7521
+location	Strass Im Attergau	47.9092541	13.4540582
+location	Strass im Zillertal	47.397430	11.820402
+location	Strasshof an der Nordbahn	48.3189487	16.6429437
+location	Straszyn	54.2722494	18.5823095
+location	Stratford	41.1845	-73.1332
+location	Strážske	48.8746597	21.8337692
+location	Strba	49.0542052	20.0792023
+location	Strépy-Bracquegnies	50.480107	4.120343
+location	Strocin	49.2664878	21.5980323
+location	Strombeek-Bever	50.9083929	4.3516713
+location	Stromiec	51.6464554	21.0910141
+location	Stromiecka Wola	51.6405133	21.053217
+location	Stronie	49.7573536	20.2472633
+location	Stropkov	49.2020091	21.6521343
+location	Strozki	52.7060593	16.414129
+location	Strpce	42.2395276	21.0266727
+location	Struga	41.1770278	20.6790586
+location	Strumiany	50.0127089	20.1039212
+location	Strumica	41.4392045	22.6397203
+location	Strykowo	52.24836	16.6152934
+location	Strzalki	51.4584317	18.7881634
+location	Strzegom	50.9601066	16.3462134
+location	Strzelce Krajenskie	52.8785255	15.5325925
+location	Strzelce Opolskie	50.5109033	18.3004547
+location	Strzelin	50.78092	17.0683947
+location	Strzezewo	54.012395	14.8671225
+location	Strzyzow	49.8702087	21.7856291
+location	Stuchowo	53.94913	15.01204
+location	Studienka	48.52836	17.1347157
+location	Stupava	48.2731324	17.0327458
+location	Sturovo	47.7978002	18.7158785
+location	Suances	43.4260091	-4.041568
+location	Subid Bazar	24.9039371	91.8603594
+location	Sublimity	44.8295663	-122.7945335
+location	Subotica	46.1000129	19.6640974
+location	Sucany	49.0990866	18.9937678
+location	Sucha	50.55818	18.22186
+location	Suchá Hora	49.3663146	19.7901141
+location	Suchabeskidzka	49.73498962856042	19.5801494294513
+location	Suchy Bor	50.65391	18.04051
+location	Suchy las	52.4775865	16.8772192
+location	Sucre	-0.7264261	-80.41619512637334
+location	Sucre BO	-19.0581322	-65.2463385
+location	Sucre EC	-0.7326786000000001	-80.41990564699557
+location	Sueca	39.2025604	-0.3111645
+location	Südoststeiermark	46.85967165	15.850364747446001
+location	Suesca	5.103373	-73.799748
+location	Suffolk	42.3544455	-70.9788771
+location	Suffolk County	40.9849	-72.6151
+location	Suffolk County MA	42.3544455	-70.9788771
+location	Suffolk County NY	40.8832318	-72.8578027
+location	Suhr	47.373166	8.079534
+location	Sukow	50.8141172	20.6875924
+location	Sulecin	52.4413768	15.1161501
+location	Sulecin (Lubuskie)	52.4413768	15.1161501
+location	Sulecin (Wielkopolskie)	51.9275	17.8352778
+location	Sulejovice	50.4987867	14.0374081
+location	Sulejowek	52.244349	21.278243596186364
+location	Sulice	49.924356244026505	14.557208390113757
+location	Sulina	-25.7001327	-52.7207833
+location	Sulislawice	50.6558379	16.8097541
+location	Suliszewice	51.6854609	18.4031492
+location	Sułków	49.9927065	20.1052994
+location	Sulkowice	49.8408265	19.8012137
+location	Sullivan County	41.7156311	-74.7804323
+location	Sumare	-22.8217964	-47.267105
+location	Šumavské Hoštice	49.0396769	13.871864
+location	Sumbe	-8.9401783	13.365328522308467
+location	Sume	-7.671521	-36.8788755
+location	Sumidouro	-22.0498059	-42.6742601
+location	Summit County	41.1457902	-81.5333603
+location	Summit County OH	41.1457902	-81.5333603
+location	Sumner County TN	36.4496718	-86.4685413
+location	Sumperk	49.9655521	16.9705651
+location	Sumter County	32.5234698	-88.1837986
+location	Sumter County AL	32.5234698	-88.1837986
+location	Sumter County SC	33.8998826	-80.3237032
+location	Sun Prarie	43.185544	-89.230804
+location	Sunamganj	25.0653149	91.406908
+location	Sunchales	-30.9450891	-61.5608072
+location	Sunshine Coast	-26.6500	153.0667
+location	Surabaya	-7.2459717	112.7378266
+location	Surany	48.0861055	18.1868344
+location	Surat	21.166995	72.824307
+location	Suresnes	48.8710994	2.2283997
+location	Surgut	61.254032	73.3964
+location	Suria	41.8328065	1.7526606
+location	Suryapet	17.08001385	79.7925329742427
+location	Sussex County	38.6908097	-75.3691421
+location	Sussex County DE	38.6908097	-75.3691421
+location	Sussex County NJ	41.133372	-74.6930393
+location	Susz	53.7166619	19.3385289
+location	Suszec	50.0380334	18.7883358
+location	Sutrapada	20.8428692	70.4799081
+location	Sutter County	38.9509675	-121.697088
+location	Suubotica	46.1000129	19.6640974
+location	Suwałki	54.102712499999996	22.931878217494493
+location	Suzano	-23.5427842	-46.3108391
+location	Suzhou	31.289911	120.538521
+location	Svaty Peter	47.8464683	18.2628926
+location	Švenčionių rajono savivaldybė	55.06973645	25.998084037467127
+location	Svidnik	49.3085082	21.5733508
+location	Svit	49.0582357	20.1965291
+location	Svobodny (Amur)	51.377354	128.13475
+location	Svobodny (Sverdlovsk)	58.037659	60.394432
+location	Svrcinovec	49.480914	18.796231
+location	Swarzedz	52.4103728	17.0771038
+location	Sweet Grass County	45.8729386	-109.9503947
+location	Swellendam	-34.021111	20.441944
+location	Swiatki	53.9260127	20.2444128
+location	Swidnica	51.8907321	15.3961278
+location	Swidnica DS	50.8424835	16.4870549
+location	Swidnica LB	51.8907321	15.3961278
+location	Swidnik	50.886056	15.9970341
+location	Swidwin	53.7743624	15.782515872730308
+location	Swiebodzice	50.872464550000004	16.32287834675313
+location	Swiebodzin	52.2498357	15.5324973
+location	Swiecie	53.4072518	18.4455253
+location	Swierze Gorne	51.6562298	21.4833304
+location	Swierzno	53.96536	14.96746
+location	Swinna	49.6664501	19.2558902
+location	Swinoujscie	53.9097477	14.2510703
+location	Swisher County	34.47235	-101.7119955
+location	Sycow	51.30998	17.72354
+location	Sydney	-33.870747	151.208359
+location	Sylhet	24.89922	91.8685271
+location	Sypanica	53.7881519	19.1480036
+location	Sysert	56.5030175	60.8093215
+location	Szabruk	53.7260683	20.3375782
+location	Szalkowo	53.6455932	19.5830769
+location	Szamotuly	52.6120328	16.5831241
+location	Szczecin	53.4301818	14.5509623
+location	Szczecinek	53.70234205	16.70713424642978
+location	Szczycienski	53.541742049999996	21.018362051755837
+location	Szczytniki	49.97432	20.23122
+location	Szczytniki Czerniejewskie	52.4181554	17.5534045
+location	Szczytno	53.56373295	20.996863617882177
+location	Szczyty	51.6430067	21.0100017
+location	Szewna	50.9164139	21.3606697
+location	Szkotowo	53.4023108	20.280849
+location	Szowsko	50.05155	22.71307
+location	Szprotawa	51.5650714	15.5367584
+location	Sztum	53.9198663	19.0305384
+location	Sztumskie Pole	53.92897	19.0098701
+location	Sztutowo	54.330086	19.177209
+location	Szudziałowo	53.2994967	23.6548709
+location	Szydlowiec	51.2079964	20.9234453
+location	Szyldak	53.6202301	20.0644299
+location	Szyleny	54.33893	19.87045
+location	Szymaniszki	51.8262987	19.7821329
+location	Szymanow	52.1616414	20.3810754
+location	Szymany	53.29914	20.38505
+location	Tabanan	-8.5392306	115.1265683
+location	Tabapua	-20.9648397	-49.0332398
+location	Tabatinga	-4.2327349	-69.9263372
+location	Tabernas	37.0498879	-2.3913774
+location	Tabira	-7.583661	-37.537735
+location	Taboao Da Serra	-23.6121912	-46.7790539
+location	Tabuleiro do Norte	-5.2440865	-38.1284605
+location	Tachov	49.7955449	12.6329861
+location	Taciba	-22.3893943	-51.2888486
+location	Tacoma	47.2495798	-122.4398746
+location	Tafalla	42.522804	-1.675960
+location	Tafi Viejo	-26.7342344	-65.259341
+location	Taguig City	14.5288867	121.0699173
+location	Taiacu	-21.143144	-48.511203
+location	Taibe	32.2628299	35.00857640690519
+location	Taio	-27.1167574	-50.0002159
+location	Taiobeiras	-15.8080842	-42.2270207
+location	Taipei	25.043279	121.565717
+location	Takoradi	4.887401	-1.7519316
+location	Talagante	-33.6643506	-70.9298675
+location	Talala	21.0560298	70.5303798
+location	Talamanca	9.418596950000001	-83.2041410920307
+location	Talange	49.2368955	6.1736941
+location	Talatona	-8.9352517	13.233246497023764
+location	Talca	-35.4266305	-71.6661153
+location	Talcahuano	-36.7144863	-73.1141463
+location	Taldykorgan	45.0164138	78.3791841
+location	Talladega County	33.3967079	-86.1597137
+location	Tallahatchie County	33.9414425	-90.1577411
+location	Tallapoosa County	32.8595687	-85.8023774
+location	Tallende	45.6693722	3.1243787
+location	Talmei Yehi'El	31.7520156	34.7631967
+location	Talod	23.3512	72.9505
+location	Tamale	9.4051992	-0.8423986
+location	Tamandaré	-8.7500009	-35.1045787
+location	Tamarin	-20.3362432	57.3726018
+location	Tamarite de Litera	41.8683507	0.4213037
+location	Tambau	-21.70292	-47.270344
+location	Tambov	52.72879	41.45536
+location	Tambovka	50.098019	128.069885
+location	Tamenglong	24.935401300000002	93.56791112289724
+location	Tamra	32.8534876	35.1978748
+location	Tanabi	-20.6251635	-49.6519879
+location	Tanah Datar	-0.4742493	100.6235057
+location	Tanay	14.4985359	121.2856331
+location	Tangail	24.2507265	89.9149441
+location	Tangerang	-6.1760311	106.6384468
+location	Tangerang Selatan	-6.2955404	106.7085494
+location	Tangipahoa Parish	30.6323024	-90.4315754
+location	Tangua	-22.7353777	-42.7202272
+location	Tanhacu	-14.019662	-41.247271
+location	Tanos	43.3324632	-4.0438031
+location	Tanowo	53.5408392	14.4670656
+location	Taoyuan	24.951706	121.219785
+location	Tapaua	-5.6232283	-63.1879157
+location	Tapejara	-28.069233	-52.0117161
+location	Tapera	-28.6262957	-52.8680873
+location	Tapes	-30.6747721	-51.3986199
+location	Tapesovo	49.3740873	19.4467954
+location	Tapi	21.1060413	72.7008247
+location	Tapia de Casariego	43.5692581	-6.9436488
+location	Tapin	-2.969304	115.2661034
+location	Taquara	-29.6465318	-50.7805672
+location	Taquari	-29.79433	-51.865346
+location	Taquaritinga	-21.407486	-48.5054848
+location	Taquarituba	-23.5337307	-49.2452541
+location	Tara	56.902587	74.3698652
+location	Tarabai	-22.3038726	-51.5628675
+location	Taradell	41.8762624	2.2859511
+location	Tarakan	3.3416343	117.59862807440442
+location	Taranto	40.524671	17.215202
+location	Tarapacá	-2.8911456702010083	-69.74219953074318
+location	Tarare	45.8942555	4.4371374
+location	Taraz	42.9015945	71.3769302
+location	Tarbena	38.6936688	-0.1020792
+location	Tarbes	43.232858	0.0781021
+location	Targowka	51.9525882	18.4418426
+location	Targu Mures	46.5446244	24.5611947
+location	Tarifa	36.0143	-5.6044
+location	Tarkwa	5.310935	-1.992426
+location	Tarkwa Gold Fields	5.3132484	-2.021593977152805
+location	Tarlow	51.0010956	21.715178
+location	Tarn	43.7921741	2.133964772269535
+location	Tarn-Et-Garonne	44.080656000000005	1.2050632958700225
+location	Tarnawa	51.0094759	16.0848735
+location	Tarnica	50.6711515	17.5069603
+location	Tarnobrzeg	50.58372	21.711638132824728
+location	Tarnow	50.025988299999995	20.96405842696229
+location	Tarnowo Podgorne	52.4657445	16.6664446
+location	Tarragona	41.1172364	1.2546057
+location	Tarrant County	32.7513658	-97.335696
+location	Tarrazu	9.609000	-84.069307
+location	Tarrega	41.6472761	1.1409115
+location	Tartagal	-22.5194493	-63.7986328
+location	Tartareu	41.9210208	0.7177581
+location	Taruma	-22.7474736	-50.5783374
+location	Tashkent City	40.3840363	69.2573571
+location	Tasikmalaya	-7.3262484	108.2201154
+location	Tate County	34.6391136	-89.9335244
+location	Tatranská Štrba	49.0853881	20.0691919
+location	Tatui	-23.3518451	-47.848026
+location	Taubate	-23.031448	-45.5612792
+location	Tauste	41.9203185	-1.2547248
+location	Tauves	45.5605295	2.6245746
+location	Tavernes Blanques	39.5064294	-0.3625992
+location	Tavernes de la Valldigna	39.0734	-0.2644
+location	Taylor	32.2793121	-99.8812612
+location	Taylor County TX	32.2793121	-99.8812612
+location	Taylor County WI	45.2057106	-90.4915874
+location	Tazewell County	40.5126429	-89.5442084
+location	Tazewell County IL	40.5126429	-89.5442084
+location	Tazona	38.3057	-1.9093
+location	Tchaoudjo	8.9826228	1.1338481090323635
+location	Tczew	54.09087615	18.77794352885673
+location	Teba	36.9834861	-4.9202568
+location	Tecate	32.5653831	-116.6298787
+location	Tecpán	14.8077626	-91.01476940672575
+location	Tefe	-3.3485276	-64.7102278
+location	Tehama County	40.1251334	-122.2015529
+location	Tehatta	23.730511	88.527338
+location	Tehovec	49.9814941	14.7302926
+location	Tehri Garhwal	30.5	78.666667
+location	Teia	41.4970697	2.3214331
+location	Teilhede	45.9567	3.0725
+location	Teixeira de Freitas	-17.5376644	-39.7458096
+location	Tejgaon	23.758670	90.391633
+location	Tejkunipara	23.7625751	90.3914718
+location	Tel-Aviv	32.0804808	34.7805274
+location	Telemaco Borba	-24.3282939	-50.6318021
+location	Tellin	50.081019	5.216837
+location	Telnice	50.7329577	13.9577771
+location	Temirtau	50.0506837	72.966066
+location	Temple	31.098207	-97.3427847
+location	Templeuve	50.6449107	3.2831228
+location	Temploux	50.484053	4.753481
+location	Temse	51.135398	4.208311
+location	Temuco	-38.7362611	-72.590546
+location	Tena	-0.94387175	-78.10839815239592
+location	Tende	44.0889416	7.5933916
+location	Tenente Laurentino Cruz	-6.1498142	-36.7174889
+location	Tenkasi	9.031895800000001	77.36536124793122
+location	Teno	-34.8667952	-71.1612202
+location	Tensas Parish	31.996977	-91.321633
+location	Teo	42.8061	-8.5611
+location	Teodelina	-34.3695677	-62.1327106
+location	Teodoro Sampaio	-22.5300202	-52.1686847
+location	Teodorow	51.815941	19.6752026
+location	Tepic	21.5043446	-104.894676
+location	Teplice	50.6406644	13.8244461
+location	Teplicka nad Vahom	49.2251922	18.7943585
+location	Teramo	42.661036	13.710926
+location	Teresina	-5.0896403	-42.809588
+location	Teresopolis	-22.4170	-42.9756
+location	Terezina	-5.0896403	-42.809588
+location	Termoli	41.9983273	14.9939366
+location	Ternat	50.8713392	4.1756966
+location	Teror	28.0590002	-15.5475653
+location	Terra Alta	-1.0397924	-47.9091595
+location	Terra Boa	-23.768329	-52.447002
+location	Terrassa	41.5629885	2.0102442
+location	Terrebonne Parish	29.4616211	-90.8705871
+location	Terry County	33.1514254	-102.3328121
+location	Tertre	50.466483	3.811510
+location	Teruel	40.3457	-1.1064
+location	Tervuren	50.820725	4.52387
+location	Tesedikovo	48.101436	17.8512447
+location	Tessenderlo	51.053036	5.060074
+location	Testelt	51.0091661	4.951587
+location	Teton County	47.8455676	-112.2566035
+location	Teutonia	-29.4816568	-51.813752
+location	Thakurgaon	26.0200532	88.4694397
+location	Thalwil	47.2944325	8.5635762
+location	Thane	19.1943294	72.9701779
+location	Thanh Hoa	19.805359	105.784515
+location	Thanjavur	10.7860267	79.1381497
+location	Thann	47.8101008	7.1020957
+location	Thaur	47.308893	11.462294
+location	Thaya	48.8558271	15.2873599
+location	The Nilgiris	11.4	76.7
+location	Thedes	45.7371099	3.0245569
+location	Theewaterskloof	-34.15103331620523	19.413194160761417
+location	Thembisile Hani	-25.410567098683515	28.95592482297885
+location	Theni	9.969664300000002	77.47420048524822
+location	Therwil	47.4992969	7.5574673
+location	Thesprotia	39.54401235	20.308355368968883
+location	Theux	50.518906	5.814748
+location	Thiadiaye	14.4204818	-16.7056134
+location	Thiais	48.7643664	2.391024
+location	Thiant	50.2976	3.44044
+location	Thiensville	43.236206	-87.979679
+location	Thiers	45.855795	3.5489707
+location	Thieulain	50.6179826	3.6085857
+location	Thieusies	50.5151015	4.0489552
+location	Thiezac	45.013702	2.6652774
+location	Thines	50.586787349999994	4.382595409373116
+location	Thionville	49.3579272	6.1675872
+location	Thirimont	50.2608137	4.2364418
+location	Thiruvallur	13.13014755	79.92435386254968
+location	Thiruvarur	10.73618605	79.63318659437627
+location	Thise	47.284553	6.079822
+location	Thomas County	30.8686157	-83.9472421
+location	Thonon-Les-Bains	46.3731303	6.4779448
+location	Thoothukudi	8.8052602	78.1452745
+location	Thoricourt	50.6101161	3.9509699
+location	Thoubal	24.624587	94.04247928402684
+location	Thrissur	10.5256264	76.2132542
+location	Thulin	50.428445	3.739358
+location	Thurston County	46.935508	-122.867349
+location	Tiana	41.4819226	2.2689473
+location	Tiangua	-3.7307332	-41.0004019
+location	Tianmen	30.6510	113.1556
+location	Tibas	9.9576	-84.0816
+location	Tielen	51.2422595	4.8965455
+location	Tielt-Winge	50.922676	4.892596
+location	Tienen	50.80466	4.937784
+location	Tierra Amarilla	-27.4680505	-70.2649307
+location	Tierra Nueva	14.6768727	-90.5307777
+location	Tierralta	8.171825	-76.060340
+location	Tiete	-23.1030302	-47.7147937
+location	Tigre	-34.4226513	-58.5808967
+location	Tijuana	32.5010188	-116.9646629
+location	Tijucas	-27.239404	-48.6353696
+location	Tilaran	10.483747300000001	-84.90095220462871
+location	Tilburg	51.571419	5.052759
+location	Tildonk	50.9451742	4.6436427
+location	Tillamook County	45.460293	-123.7266793
+location	Timelkam	48.0015216	13.6125109
+location	Timika	-4.5481052	136.889884
+location	Timon	-5.1023325	-42.8449518
+location	Timoradza	48.8110952	18.2362612
+location	Tineo	43.309275299999996	-6.491952249131376
+location	Tinteniac	48.32761014747541	-1.8361087310980118
+location	Tioga County	42.1333395	-76.3309339
+location	Tippah County	34.7296814	-88.9119403
+location	Tippecanoe County	40.3916066	-86.8879689
+location	Tira	32.2346856	34.9544553
+location	Tiradentes	-27.8310956	-53.7776845
+location	Tirat Carmel	32.7613834	34.9715506
+location	Tirat Zvi	32.4218582	35.5279708
+location	Tiros	-19.003889	-45.963611
+location	Tirrases	9.9073136	-84.0396595
+location	Tiruchirapalli	10.76208595	78.71277098691044
+location	Tirunelveli	8.7012203	77.5792694
+location	Tirupati	13.6316368	79.4231711
+location	Tirupattur	12.490898	78.564709
+location	Tiruppur	11.1017815	77.345192
+location	Tiruvannamalai	12.22721295	79.07015554906167
+location	Tisá	50.7844989	14.0313007
+location	Tišnov	49.348838	16.4244906
+location	Tisovec	48.6812756	19.9420632
+location	Tištín	49.3068883	17.1653976
+location	Titel	45.204631	20.311359
+location	Titiribi	6.0655797	-75.80294800576844
+location	Titus County	33.2040399	-94.9651725
+location	Tivaoune	14.947976337828274	-16.815980822916263
+location	Tkoa	31.65328	35.2293265
+location	Toa Alta County	18.3887052	-66.247968
+location	Toa Baja	18.432654	-66.21260602081739
+location	Toabre	8.6551956	-80.3209618
+location	Tobarra	38.5910	-1.6931
+location	Tobias Barreto	-11.1878721	-38.0030397
+location	Tobl	46.7939166	11.9337667
+location	Tocopilla	-22.0887189	-70.1960657
+location	Tocumen	9.0894831	-79.3833857
+location	Tösens	46.99241735	10.630621294687085
+location	Togui	5.937829	-73.513494
+location	Tokyo	35.683441	139.766131
+location	Toledo	-24.7222438	-53.7402476
+location	Toledo PR	-24.7222438	-53.7402476
+location	Tolemaida	4.2511484	-74.6449836
+location	Tolhuin	-54.5113492	-67.1954004
+location	Toliara	-23.354173	43.66966
+location	Tolkmicko	54.3202314	19.5269874
+location	Tolkowiec	54.2898899	19.98048
+location	Tolland County	41.818446	-72.3562252
+location	Tolosa	43.1386336	-2.0719964
+location	Tom Green County	31.3782559	-100.4133839
+location	Tomah	43.988774	-90.502952
+location	Tomar do Geru	-11.3752475	-37.8413399
+location	Tomasikovo	48.0811834	17.6941428
+location	Tomasov	48.1420549	17.3348601
+location	Tomaszkowice	49.9761631	20.0973407
+location	Tomaszów Lubelski	50.447922950000006	23.42919536202701
+location	Tomaszow Mazowiecki	51.5194865	20.033759067449843
+location	Tomaszowo	51.6215692	15.3970476
+location	Tomazina	-23.7777942	-49.9546482
+location	Tomelloso	39.1585715	-3.0214959
+location	Tompkins County	42.4422105	-76.49962462430045
+location	Ton	47.8047007	17.8380937
+location	Tona	41.8538039	2.2280115
+location	Tongi	23.897429	90.4078742
+location	Tonneins	44.3905556	0.3091667
+location	Toole County	48.6768334	-111.7313702
+location	Topolcany	48.5594345	18.1754394
+location	Topolovka	48.9238403	21.8093623
+location	Toral De Los Guzmanes	42.2428548	-5.5671476
+location	Tordera	41.6977173	2.7172987
+location	Tordoia	43.0860275	-8.5407983
+location	Torelló	42.0478304	2.2643391
+location	Torhout	51.062493	3.100652
+location	Torija	40.7433322	-3.0316885
+location	Toritama	-8.0083743	-36.058776
+location	Tornala	48.4221599	20.3232507
+location	Toronto	43.720877	-79.365740
+location	Torralba de Calatrava	39.0170808	-3.7502053
+location	Torrance County	34.6356278	-105.9059678
+location	Torre del Mar	36.7413845	-4.0946126
+location	Torre-Romeu	41.5491256	2.1256174
+location	Torreblanca	40.2202661	0.1953363
+location	Torrecilla en Cameros	42.2560793	-2.6305716
+location	Torrefarrera	41.6735377	0.6066894
+location	Torrejon Del Rey	40.6449395	-3.336053
+location	Torrelavega	43.3487303	-4.0515082
+location	Torremolinos	36.620077	-4.500794
+location	Torrent	39.436668	-0.4656213
+location	Torrenueva	36.496538799999996	-4.692711912648409
+location	Torres	-29.3373663	-49.7299648
+location	Torres AR	-35.1502798	-59.7056508
+location	Torres BR	-29.3373663	-49.7299648
+location	Torres De Elorz	42.733599	-1.596477
+location	Torres Novas	39.5147503	-8.562223320605705
+location	Torres Vedras	39.11014835	-9.276731117530929
+location	Torrevieja	37.9775416	-0.6828446
+location	Torroella de Montgri	42.040982	3.1262041
+location	Torruella de Baix	41.7659984	1.8910854
+location	Tortellà	42.233331	2.630869
+location	Torti	8.9215295	-78.3980199
+location	Torun	53.0145361	18.596583144651557
+location	Torzhok	57.04589547324559	34.97769130515222
+location	Tosno	59.5412777	30.8773645
+location	Totonicapán	14.911838	-91.3599703
+location	Totoras	-32.5842697	-61.1667933
+location	Touba	14.864559	-15.876047
+location	Toulon	43.1257311	5.9304919
+location	Toulouse	43.6044622	1.4442469
+location	Tourcoing	50.7235038	3.1605714
+location	Tourinnes-la-Grosse	50.7777654	4.7472104
+location	Tournai	50.615852	3.400822
+location	Tourpes	50.572688	3.6493593
+location	Tours	47.404471	0.693908
+location	Tovarkovo	54.6774326	35.9381406
+location	Trabiju	-22.0410733	-48.3350302
+location	Tracuateua	-1.0765338	-46.9030822
+location	Trairao	-4.700551	-55.9972165
+location	Traisen	48.2278208	15.6575291
+location	Trajano de Moraes	-22.0637911	-42.0644414
+location	Trakų rajono savivaldybė	54.56351875	24.727863632334092
+location	Tramandai	-29.9855339	-50.1316076
+location	Tramin	46.3415121	11.2422716
+location	Trapaga	43.3029245	-3.0169955
+location	Traunkirchen	47.8448255	13.7902844
+location	Traunstein	47.8701474	12.6423403
+location	Travis County	30.2878569	-97.7561392
+location	Travnica	48.1344307	18.3332336
+location	Trazegnies	50.466074	4.334811
+location	Trazo	43.0266669	-8.5174783
+location	Trebejov	48.840644749999996	21.231796705169064
+location	Třebenice	50.4763245	13.9900472
+location	Trebisov	48.6286222	21.7201711
+location	Treguaco	-36.432410950000005	-72.61481252396095
+location	Trelew	-43.2531242	-65.3094407
+location	Tremelo	50.9919047	4.7040582
+location	Tremouille Saint Loup	45.4897	2.5596
+location	Tremp	42.1663681	0.8946181
+location	Trempealeau County	44.2398	-91.3662
+location	Trencianska Tepla	48.9344602	18.1200726
+location	Trenton	40.2170575	-74.7429463
+location	Tres Arroyos	-38.3770869	-60.2753897
+location	Três Cachoeiras	-29.4521243	-49.9190608
+location	Três Coroas	-29.5155023	-50.7770635
+location	Tres de Febrero	-38.7339587	-62.2254137
+location	Tres de Maio	-27.7799415	-54.2356626
+location	Tres Isletas	-26.3419469	-60.427926594151
+location	Tres Lagoas	-20.7866799	-51.7061247
+location	Tres Marias	-18.204795	-45.247289
+location	Tres Passos	-27.4556106	-53.9294399
+location	Tres Rios	9.9080401	-83.9872
+location	Tres Rios BR	-22.1167884	-43.2087226
+location	Tres Rios CR	9.9080401	-83.9872
+location	Treto	43.3935609	-3.4737167
+location	Trevenans	47.5712429	6.8623067
+location	Treviso	45.806691349999994	12.206315763116372
+location	Treze de Maio	-28.5574415	-49.1447586
+location	Trichardt	-26.4913889	29.2288889
+location	Tricio	42.4019281	-2.7183425
+location	Trieste	45.6504806	13.7931263
+location	Trimmis	46.8970804	9.5634251
+location	Trindade	-16.6549924	-49.4876203
+location	Trindade (Goiás)	-16.6549924	-49.4876203
+location	Trindade (Pernambuco)	-7.759	-40.26472
+location	Trinity County	31.0834452	-95.1219348
+location	Trinity County CA	40.6053256	-123.171268
+location	Trinity County TX	31.0834452	-95.1219348
+location	Triunfo	-29.9407972	-51.7191859
+location	Trivento	41.781407	14.5511246
+location	Trivières	50.4517378	4.1475857
+location	Trobajo del Camino	42.5951876	-5.6073495
+location	Troia	41.363128	15.312347
+location	Troitsk	55.4728168	37.3017465
+location	Trombudo Central	-27.3040981	-49.79316
+location	Troncal	-2.433689	-79.37516322526545
+location	Trondheim	63.4305658	10.3951929
+location	Troup County	33.0237625	-85.0254022
+location	Troyes	48.2971626	4.0746257
+location	Trstena	49.3593197	19.6078094
+location	Trujillo	4.212089	-76.319157
+location	Trujillo Alto	18.33707575	-66.00174210279962
+location	Trujillo CO	4.2336249	-76.33654405213005
+location	Trujillo ES	39.3370725	-5.4872328
+location	Trumbull	41.247238	-73.194570
+location	Trumbull County	41.3068487	-80.7661017
+location	Trutnov	50.5608851	15.9130498
+location	Trzciel	52.3683007	15.9118514
+location	Trzcinsko-Zdroj	52.9660381	14.6075982
+location	Trzebiez	53.6548324	14.5093186
+location	Trzebnica	51.3096424	17.062596
+location	Trzemeszno	52.5600669	17.8208936
+location	Trzuskołon	52.4762372	17.733357
+location	Tubarao	-28.471488	-49.014132
+location	Tubas	32.3397411	35.3601893
+location	Tubize	50.687041	4.193545
+location	Tucapel	-37.2915574	-71.9508741
+location	Tuchkovo	55.6014428	36.4662973
+location	Tuchola	53.5880901	17.8590414
+location	Tucquegnieux	49.3082902	5.8979199
+location	Tucunduva	-27.6581837	-54.4416605
+location	Tucurui	-3.7738509	-49.6708204
+location	Tucuti	7.9601581	-77.933112
+location	Tudanca	43.15226	-4.3728
+location	Tudela	42.063972	-1.6053391
+location	Tudelilla	42.2995149	-2.1164086
+location	Tuebingen	48.5236164	9.0535531
+location	Tuensang	26.168505500000002	94.85819821659115
+location	Tughlakabad	28.5023598	77.2992401
+location	Tuklaty	50.0847775	14.7694956
+location	Tulare County	36.2516475	-118.852583
+location	Tulcan	0.8114572	-77.7172256
+location	Tulce	52.3434434	17.0758308
+location	Tuliszkow	52.0770973	18.294932
+location	Tulkarem	32.3194023921685	35.023729717985056
+location	Tulle	45.2678347	1.7706797
+location	Tulsa	36.1556805	-95.9929113
+location	Tulua	4.092520	-76.197483
+location	Tulungagung	-8.07290355	111.89964078880708
+location	Tumaco	1.792753	-78.793766
+location	Tumakuru	13.3400771	77.1006208
+location	Tunas	-29.1053032	-52.9569329
+location	Tunis	36.8002068	10.1857757
+location	Tunja	5.5323632	-73.361362
+location	Tunuyan	-32.5913874	-69.3477469
+location	Tuolumne County	38.056944	-119.9919351
+location	Tupa	-21.9349129	-50.5141255
+location	Tupandi	-29.4779269	-51.4209232
+location	Turany nad Ondavou	49.09010605	21.661494682930424
+location	Turbo	8.0950848	-76.728545
+location	Turčianska Štiavnička	49.0863462	19.023593
+location	Turcianske Teplice	48.8614083	18.8608115
+location	Turek	52.0162022	18.511440948960132
+location	Turie	49.1491194	18.7526706
+location	Turin	45.0677551	7.6824892
+location	Turkestan	43.298692	68.26296
+location	Turkowice	50.6570817	23.74354834584146
+location	Turrialba	9.78380435	-83.49914625487494
+location	Tururu	-3.5985489	-39.4358101
+location	Turvania	-16.6120126	-50.1352075
+location	Turzovka	49.4051578	18.6259805
+location	Tuscaloosa County	33.2668398	-87.4862182
+location	Tusice	48.7249577	21.7483557
+location	Tuttlingen	47.9844315	8.8186606
+location	Tver	56.858675	35.9208284
+location	Tveria	32.7938522	35.5328566
+location	Tvrdosin	49.3365743	19.5541875
+location	Tvrdosovce	48.0952012	18.0619537
+location	Twarogi-Mazury	52.5738345	22.6301901
+location	Tweed Heads	-28.201312	153.543425
+location	Twin Falls County	42.2728777	-114.6971949
+location	Tworzymirki	51.9492688	17.0228353
+location	Tychowo	53.92866	16.25668
+location	Tychy	50.114397	18.9965933
+location	Tygerberg	-33.8474485	18.6410685
+location	Tymowa	49.8542421	20.6334268
+location	Tyumen	57.153534	65.542274
+location	Tzfat	32.9646301	35.502451
+location	Ubarana	-21.1637674	-49.7167796
+location	Ubatuba	-23.433162	-45.083415
+location	Ubeda	38.0114	-3.3712
+location	Uberaba	-19.750833	-47.936666
+location	Ubiarco	43.41145	-4.10275
+location	Ubirata	-24.542725	-52.9899678
+location	Ubla	48.8991109	22.3899976
+location	Úbrež	48.7868818	22.1318717
+location	Uccle	50.793431	4.355608
+location	Uchoa	-20.951106	-49.171295
+location	Uciechow	50.7547791	16.6815546
+location	Udine	46.0634632	13.2358377
+location	Udupi	13.3419169	74.7473232
+location	Ufa	54.7261409	55.947499
+location	Ugijar	36.9610885	-3.0546834
+location	Ugory	53.98013	14.89773
+location	Ugu	-30.54723	30.29119696183432
+location	Uhersky Brod	49.0253139	17.6464437
+location	Uijeongbu	37.7381078	127.033929
+location	Uikhoven	50.9264738	5.719919850734141
+location	Uitgeest	52.523293949999996	4.737466990272131
+location	Uithoorn	52.24400285	4.828160506359512
+location	Uithuizen	53.4096293	6.6746834
+location	Uithuizermeeden	53.4159396	6.7255446
+location	Ujazd	50.3892513	18.3504502
+location	Ujjain	23.161092	75.803740
+location	Ukhta	63.5624585	53.684243
+location	Ukmerge	55.2477293	24.7599714
+location	Ulan-Ude	51.827029	107.655954
+location	Ulany nad Zitavou	48.1071585	18.2389788
+location	Ullastrell	41.5265763	1.9560471
+location	Ulldecona	40.5967567	0.4475376
+location	Ulm	48.3974003	9.9934336
+location	Ulow	51.5683197	20.68213
+location	Ulster County	41.8586	-74.3118
+location	Umatilla County	45.648981	-118.720688
+location	Umbilo	-29.8905556	30.9777778
+location	Umbuzeiro	-7.696494	-35.6666231
+location	uMgungundlovu	-29.52982	30.057047991912206
+location	uMkhanyakude	-46.77757335	37.79103213020967
+location	Umuarama	-23.7621152	-53.3116192
+location	uMzinyathi	-28.0585234	30.3725385
+location	Una	31.4685	76.2708
+location	Unai	-16.3628767	-46.892413
+location	Unecha	52.8451	32.6867
+location	Únětice	50.15163592179371	14.355066580244468
+location	União	-4.5892553	-42.8593348
+location	Uniao Da Vitoria	-26.228596	-51.0869796
+location	Uniao Dos Palmares	-9.1576807	-36.0342251
+location	Uniao Paulista	-20.8878168	-49.8986804
+location	Uniemysl	53.6264707	14.5041675
+location	Union County	40.6652251	-74.3045277
+location	Union County IL	37.4616454	-89.2504793
+location	Union County MS	34.4834555	-88.9789198
+location	Union County NC	34.9795158	-80.5128209
+location	Union County NJ	40.6652251	-74.3045277
+location	Union County OR	45.2680014	-118.0257466
+location	Union County SC	34.6941696	-81.642794
+location	Union Panamericana	5.305963045957773	-76.64747542725281
+location	Union Parish	32.8385899	-92.3910295
+location	Unquillo	-31.2339887	-64.3164639
+location	Unterach Am Attersee	47.816465550000004	13.473181062166006
+location	Unterägeri	47.1374124	8.584483
+location	Untersiggenthal	47.4992019	8.2574722
+location	Unterterzen	47.1139539	9.2522904
+location	Untertullnerbach	48.1884656	16.1248453
+location	Unterwart	47.2596082	16.2331055
+location	Upala	10.868428250000001	-85.14532738694118
+location	Upshur County	32.7263725	-94.9286251
+location	Urbes	47.8838689	6.9567035
+location	Urcuqui	0.4172921	-78.1941499
+location	Urk	52.6654515	5.5987894
+location	Uru	-21.7846064	-49.2819702
+location	Urucará	-2.537073	-57.7590254
+location	Urucurituba	-3.1304332	-58.1549157
+location	Uruguaiana	-29.7560726	-57.0867546
+location	Urumqi	43.419754	87.319461
+location	Urupes	-21.2027026	-49.2921996
+location	Uscikowo	52.6426104	16.7606695
+location	Uscikowo Folwark	52.63395	16.79282
+location	Ushuaia	-54.8069332	-68.3073246
+location	Uspantan	15.475278849999999	-90.8306012720069
+location	Ussel	45.0803547	2.9352058
+location	Usson	45.527366	3.3377043
+location	Ussuriysk	43.7972447	131.9520752
+location	Ust-Ishim	57.693462	71.169968
+location	Usti nad Labem	50.6603327	14.0381357
+location	Ustka	54.573764600000004	16.858728693053727
+location	Ustrzyki Dolne	49.4301874	22.5877003
+location	Utah County	40.0841662	-111.6259473
+location	uThukela	-28.7446904	30.2224445
+location	Utiel	39.5680838	-1.2051778
+location	Utinga	-12.0781018	-41.090787
+location	Utrecht	52.0907	5.1214
+location	Uttar Dinajpur	25.8707958	87.96259728449391
+location	Uttara	23.8759	90.3795
+location	Uttarkashi	30.9654214	78.63368731187963
+location	Uvalde County	29.300357	-99.7733181
+location	Uvarovka	55.5301214	35.6068561
+location	Uzda	53.4644547	27.2134845
+location	Uzès	44.0121279	4.4196718
+location	Uzice	43.8564957	19.840273
+location	Uznach	47.2250636	8.9856079
+location	Vaals	50.7781016	5.981067967268041
+location	Vaasa	63.081820949999994	21.479812522296804
+location	Vacaria	-28.5102901	-50.9356044
+location	Vacarisses	41.592496	1.8936269
+location	Vacoas	-20.3774092	57.484975
+location	Vadiya	21.7104964	70.8117886
+location	Vadodara	22.306797	73.173072
+location	Val D'Oise	49.07507045	2.209811443668384
+location	Val de Loire	47.4490466	-0.5135894
+location	Val de San Lorenzo	42.4163053	-6.1190189
+location	Val Verde County	29.9153286	-101.1284631
+location	Valaliky	48.641526	21.2931296
+location	Valansart	49.6847401	5.41452
+location	Valdaracete	40.2106	-3.1946
+location	Valdecilla	43.3789198	-3.7352439
+location	Valdepenas	38.7594573	-3.3847392
+location	Valderredible	42.8564085	-3.970889841832725
+location	Valderrubio	37.2346	-3.8183
+location	Valdeviejas	42.4620462	-6.0788959
+location	Valdevimbre	42.4195695	-5.6202669
+location	Valdivia	-39.8141262	-73.2459859
+location	Vale do Sol	-29.6036459	-52.6867334
+location	Valenca	-22.2461028	-43.6996917
+location	Valence	44.926123	4.900583
+location	Valencia	39.337	-0.354
+location	Valencia County	34.7325886	-106.8503919
+location	Valencia de Alcantara	39.4131173	-7.242137
+location	Valencia de Don Juan	42.2936047	-5.5188832
+location	Valencia EC	-0.7696521000000001	-79.32113550340011
+location	Valencia ES	39.4697065	-0.3763353
+location	Valencia Horta	39.465736	-0.424354
+location	Valenciennes	50.3579317	3.5234846
+location	Valga	42.6830	-8.6491
+location	Valigny	46.7126221	2.8174155
+location	Valinhos	-22.97056	-46.99583
+location	Valkenburg	52.1809225	4.4285918
+location	Valkenburg Aan de Geul	50.86094405	5.813709999149556
+location	Valkenswaard	51.3202409	5.458181897733282
+location	Valkovce	49.16663685	21.523461060765122
+location	Vall d'Alba	40.17587	-0.0350962
+location	Vall d'Uixo	39.8235837	-0.2316995
+location	Valladolid	41.6521328	-4.728562
+location	Vallarta	20.5384729	-103.4668414
+location	Valle De Villaverde	43.232393900000005	-3.2824230157742376
+location	Valle del Zalabi	37.275224550000004	-3.067211732803494
+location	Valledupar	10.466023	-73.253272
+location	Vallenar	-28.5750438	-70.7616398
+location	Vallendar	50.4001381	7.6142479
+location	Valleseco	28.0501609	-15.5744925
+location	Valley County	48.3564433	-106.615665
+location	Valley County ID	44.7475094	-115.5978843
+location	Valley County MT	48.3564433	-106.615665
+location	Vallfogona de Balaguer	41.7518459	0.8165116
+location	Vallgorguina	41.6473229	2.5100384
+location	Vallirana	41.3877623	1.9320806
+location	Vallon en Sully	46.5375	2.60656
+location	Vallromanes	41.5323208	2.2989347
+location	Valparaiso	-33.0458456	-71.6196749
+location	Valparaiso BR	-21.2230369	-50.8666375
+location	Valparaiso CL	-33.0458456	-71.6196749
+location	Valparaiso de Goias	-16.0686394	-47.9764907
+location	Vals	46.6166848	9.1804954
+location	Valthermond	52.8870134	6.9751387
+location	Valuyki	50.19417240489066	38.11999415685251
+location	Van Buren County	42.2710763	-86.013973
+location	Van Zandt County	32.5375642	-95.8292165
+location	Vanasthalipuram	17.3303179	78.568278
+location	Vancouver	45.6306954	-122.6744557
+location	Vandoeuvre-Les-Nancy	48.6599676	6.1724618
+location	Vandoeuvres	46.2214083	6.2024623
+location	Vannes	47.6586772	-2.7599079
+location	Vanves	48.821722	2.288675
+location	Var	43.38009902407034	6.203904389455158
+location	Varanasi	25.3356491	83.0076292
+location	Varendonk	51.0801317	4.9552253
+location	Varennes-sur-Usson	45.53218	3.3068333
+location	Varese	45.83971285	8.754157594917665
+location	Vargas	43.3216572	-3.961383
+location	Vargem Alta	-20.6742303	-41.010615
+location	Vargem Grande	-3.5443611	-43.9149128
+location	Vargem Grande do Sul	-21.832194	-46.891286
+location	Vargem Grande Paulista	-23.599338	-47.022038
+location	Varginha	-21.5565914	-45.4340674
+location	Varjão de Minas	-18.3791473	-46.030627
+location	Varre Sai	-20.9308869	-41.8685772
+location	Varsenare	51.1900214	3.1433949
+location	Varzea Paulista	-23.2113889	-46.8283333
+location	Varėnos rajono savivaldybė	54.1724093	24.418009775621538
+location	Vasai	19.439884550000002	72.8803834000775
+location	Vasilov	49.3492449	19.38514
+location	Vassouras	-22.4040394	-43.6633853
+location	Vatara	23.8034313	90.42432
+location	Vavrecka	49.3855959	19.4674903
+location	Važec	49.0592773	19.9816464
+location	Vazquez de Coronado	10.0301109	-83.9519851
+location	Vechmaal	50.7608875	5.373733
+location	Vedra	42.7765527	-8.4821723
+location	Veendam	53.0807517	6.877303483300453
+location	Veerle	51.068963	4.986866
+location	Vega Alta County	18.4121187	-66.3312486
+location	Vega Baja	18.41776575	-66.39944742043909
+location	Vega de Pas	43.1585436	-3.7821043
+location	Vegaquemada	42.79869845	-5.339723737661707
+location	Vegas del Genil	37.1701	-3.6978
+location	Veguellina de Orbigo	42.4367662	-5.8851414
+location	Vehari	30.050262150000002	72.35714007018092
+location	Veldegem	51.10402849441712	3.159341112179109
+location	Velden Am Wörther See	46.6151882	14.0450583
+location	Veldhoven	51.40770635	5.392731058176404
+location	Veles	41.718869	21.7705695
+location	Velez Malaga	36.779282	-4.100078
+location	Velikiye Luki	56.342361	30.527922
+location	Veliky Novgorod	58.5209862	31.2757862
+location	Velingara	13.1441	-14.1059
+location	Velka Frankova	49.3380439	20.2934499
+location	Veľké Leváre	48.5046369	17.0017297
+location	Velke Lovce	48.0666614	18.3333351
+location	Velke Ludince	47.9630579	18.5065438
+location	Velké Popovice	49.9224718	14.6390582
+location	Veľké Revištia	48.7450877	22.0934606
+location	Velke Ulany	48.1628869	17.5762098
+location	Velke Zaluzie	48.3070684	17.9387181
+location	Velky Cepcin	48.8950108	18.8088667
+location	Velký Harcáš	47.7469355	18.1783256
+location	Velky Kliz	48.5507981	18.3671328
+location	Velky Krtis	48.2093428	19.3490365
+location	Velky Kyr	48.1843418	18.1556874
+location	Velky Lapas	48.28687805	18.185203076258013
+location	Velky Meder	47.8557806	17.7693671
+location	Velky Slavkov	49.1002831	20.263592479136165
+location	Vellore	12.7948109	79.0006410968549
+location	Velm	50.7790412	5.1324556
+location	Velserbroek	52.4317169	4.6601847
+location	Veltem-Beisem	50.905721	4.620653
+location	Veltrusy	50.27387660272186	14.33171393830055
+location	Vémyslice	49.0220403	16.2567936
+location	Venado Tuerto	-33.7455871	-61.9686068
+location	Venafro	41.483425	14.045112
+location	Venancio Aires	-29.614306	-52.193159
+location	Vendee	46.67577325	-1.29144634801388
+location	Venezia	45.4371908	12.3345898
+location	Venissieux	45.704031	4.882246
+location	Venlo	51.39244885	6.1511724144122955
+location	Venray	51.5270258	5.9753635
+location	Ventanas	-1.3335519	-79.33690086959444
+location	Ventas del Bano	42.05702995	-1.9086504628788425
+location	Ventura County	34.440591	-119.058305
+location	Venturosa	-8.5765199	-36.876569
+location	Vera Cruz (Rio Grande do Sul)	-29.711722690697588	-52.508481599940495
+location	Vera Cruz (São Paulo)	-22.2212638	-49.8243021
+location	Veracruz	8.8933671	-79.6208588
+location	Veranopolis	-28.9351293	-51.5516741
+location	Veraval	20.9057	70.3781
+location	Vere	-25.8812309	-52.9081757
+location	Verkhny Tagil	57.3748048	59.9320354
+location	Verkhnyaya Pyshma	56.9724682	60.5738926
+location	Vermilion County	40.1749809	-87.7323857
+location	Vermilion Parish	29.8411106	-92.3501175
+location	Vermillion County	39.8763626	-87.4635672
+location	Vern sur Seiche	48.0452053	-1.6045972
+location	Verneix	46.3974	2.67254
+location	Vernon County	43.5577	-90.8294
+location	Verona IT	45.4384	10.9916
+location	Verona WI	42.987161	-89.535380
+location	Verrières-le-Buisson	48.7467819	2.2653844
+location	Vertaizon	45.7703602	3.2881194
+location	Vertolaye	45.649908	3.7088801
+location	Veyre Monton	45.6732958	3.1648468
+location	Vezeronce-Curtin	45.65338115	5.469001042499197
+location	Viamao	-30.0819338	-51.0261927
+location	Viana	42.5154725	-2.3713437
+location	Viana AN	-8.9053515	13.371089
+location	Viana AO	-8.9053515	13.371089
+location	Viana BR	-20.3914471	-40.4966587
+location	Viana ES	42.5141614	-2.3715912
+location	Vianen	51.9890128	5.0937164
+location	Viator	36.8887282	-2.4251246
+location	Vic	41.9302021	2.2545943
+location	Vic le Comte	45.6433495	3.2433311
+location	Vicência	-7.6574422	-35.3218464
+location	Vicente Lopez	-34.52955795	-58.506973968642164
+location	Vicentina	-22.4093447	-54.4370921
+location	Vicenza	45.63485905	11.40635425660249
+location	Vichuga	57.220222	41.9245606
+location	Vichy	46.1239268	3.4203712
+location	Vicosa	-9.3728032	-36.2432636
+location	Vicosa do Ceara	-3.5667684	-41.091504
+location	Victoria County	28.8026443	-96.9766308
+location	Victoriano Lorenzo	9.032232950000001	-79.50808452571513
+location	Vicuna	-30.0340383	-70.7126682
+location	Videira	-27.00544	-51.1533733
+location	Vidreres	41.7888681	2.7792768
+location	Viedma	-40.8084274	-62.994722
+location	Viella Mitg Aran	42.7017572	0.7954744
+location	Vielsalm	50.2883685	5.9170187
+location	Vienna	48.2083537	16.3725042
+location	Vienne	48.190041	16.382686
+location	Vierhuizen	53.360658	6.2918351
+location	Vieux Ferette	47.6238204	7.2401542
+location	Vieux-Genappe	50.6083965	4.4412263
+location	Vigia	-0.8546027	-48.1432873
+location	Vígľašská Huta-Kalinka	48.4936815	19.2767309
+location	Vigo	42.2376602	-8.7247205
+location	Vijayawada	16.5087586	80.6185102
+location	Vikarabad	17.2702855	77.74529700637382
+location	Vikartovce	48.9928346	20.1544026
+location	Vila Alice	-8.8267641	13.2476469
+location	Vila Franca de Xira	38.912368400000005	-8.988824041991643
+location	Vila Pavao	-18.6191731	-40.6043622
+location	Vila Valerio	-18.9984033	-40.3894342
+location	Vila Velha	-20.3472	-40.2823
+location	Vilabertran	42.2826972	2.9814591
+location	Vilablareix	41.9569396	2.7728439
+location	Viladecans	41.3163083	2.0156034
+location	Viladecavalls	41.5563969	1.9553173
+location	Viladrau	41.8478521	2.3920004
+location	Vilafames	40.1126075	-0.0541178
+location	Vilafant	42.2515266	2.9418008
+location	Vilafranca de Bonany	39.5703083	3.0889977
+location	Vilalba Sasserra	41.6530012	2.4405379
+location	Vilamalla	42.2165982	2.9708293
+location	Vilanova de la Barca	41.6895577	0.7288787
+location	Vilanova de Segria	41.7121134	0.6169172
+location	Vilanova del Vallés	41.5536734	2.2862297
+location	Vilanova i la Geltru	41.2241992	1.7256327
+location	Vilareal	39.9294806	-0.1965348
+location	Vilas County	46.0382686	-89.4734462
+location	Vilasar de Mar	41.5064041	2.3913883
+location	Vilassar de Dalt	41.5163595	2.3592879
+location	Vilassar de Mar	41.5064041	2.3913883
+location	Vilatenim	42.2677156	2.995153
+location	Vilcun	-38.6701003	-72.2240739
+location	Villa Alegre	-35.6752031	-71.7446702
+location	Villa Alemana	-33.0441903	-71.3725464
+location	Villa Amelia	-33.1759838	-60.6641381
+location	Villa Angela	-27.5768225	-60.7112067
+location	Villa Cañas	-34.0042781	-61.6054955
+location	Villa Carlos Paz	-31.4183774	-64.4936985
+location	Villa Constitucion	-32.93558	-60.8766268
+location	Villa de Cruces	42.7937228	-8.1699391
+location	Villa del Rosario	-31.5546127	-63.5343042
+location	Villa Dolores	-31.948647288218332	-65.18894014975473
+location	Villa Gob. Galvez	-30.9393827	-61.5500875
+location	Villa Gobernador Galvez	-33.0250796	-60.633744
+location	Villa la Angostura	-40.7620649	-71.6473205
+location	Villa Maria	-32.41964350402729	-63.240765153914566
+location	Villa Nueva	14.5308826	-90.5963325
+location	Villa Ocampo	-28.4839542	-59.3469032
+location	Villa Regina	-39.09977725	-67.08639520694014
+location	Villablino	42.9388713	-6.3183421
+location	Villacarriedo	43.2306206	-3.8049489
+location	Villach	46.6167284	13.8500268
+location	Villach-Land	46.553864250000004	13.828515867881872
+location	Villada	-33.3500129	-61.4444512
+location	Villademor De La Vega	42.2697632	-5.5687703
+location	Village-Neuf	47.6054816	7.5696755
+location	Villahermosa	38.7507812	-2.871768
+location	Villajoyosa	38.5064035	-0.2309882
+location	Villamanan	42.3221133	-5.5833776
+location	Villamediana de Iregua	42.4259906	-2.4187939
+location	Villamesias	39.2447173	-5.8729243
+location	Villamol	42.4275108	-5.048693
+location	Villamor de Orbigo	42.4835233	-5.87595
+location	Villamunio	42.4752015	-5.1948701
+location	Villanueva de Alcoron	40.6789978	-2.2531854
+location	Villanueva de Cameros	42.1671295	-2.6509038
+location	Villanueva De Jamuz	42.2338273	-5.8567541
+location	Villanueva de la Jara	39.4403	-1.9551
+location	Villanueva de la Torre	40.5830897	-3.2993647
+location	Villanueva de la Vera	40.1290938	-5.4620958
+location	Villaobispo de las Regueras	42.6132607	-5.5486764
+location	Villapresente	43.36426	-4.10544
+location	Villaquilambre	42.6469775	-5.5596277
+location	Villarejo de Orbigo	42.445501	-5.9040383
+location	Villarrica	-39.2780911	-72.2274364
+location	Villarrobledo	39.2683	-2.6016
+location	Villarrodrigo De Las Regueras	42.6349132	-5.5349678
+location	Villarrubia de los Ojos	39.2181465	-3.6070212
+location	Villaturiel	42.5185496	-5.4871978
+location	Villava	42.8318984	-1.6071287
+location	Villavicencio	4.134000	-73.623483
+location	Villefranche-d'Allier	46.3970933	2.8566399
+location	Villefranche-sur-Saône	45.9864749	4.726611
+location	Villejuif	48.7921098	2.3633048
+location	Villel de Mesa	41.1257257	-1.989641
+location	Villena	38.6360967	-0.8659745
+location	Villeneuve-Loubet	43.6579947	7.1217592
+location	Villeneuve-Saint-Georges	48.7305272	2.44782
+location	Villeneuve St Georges	48.7305272	2.44782
+location	Villerot	50.485709	3.791108
+location	Villers-la-Ville	50.5727351	4.5342675
+location	Villers-le-Bouillet	50.5745343	5.2628392
+location	Villers-Saint-Amand	50.6323587	3.7322941259661855
+location	Villeta	-25.5047339	-57.569182
+location	Villeurbanne	45.7733124	4.886899
+location	Villingen-Schwenningen	48.0632739	8.494588
+location	Villosanges	45.9133856	2.645576
+location	Villupuram	11.9398285	79.4945645
+location	Vilobi Donyar	41.8882291	2.7423246
+location	Vilvoorde	50.932484	4.429885
+location	Vimianzo	43.1102989	-9.0327488
+location	Vina del Mar	-33.0244535	-71.5517636
+location	Vinalesa	39.537576	-0.3706682
+location	Vinchiaturo	41.492925	14.590729
+location	Vinkeveen	52.214764	4.9321634
+location	Vinne	48.8105598	21.9677235
+location	Vinodol	48.1880897	18.2077766
+location	Vinosady	48.3105517	17.2926404
+location	Vinzelles	45.9258481	3.3969277
+location	Vinzol-Ahmedabad	22.952078	72.6490796
+location	Viradouro	-20.8726051	-48.2968122
+location	Virar	19.4553059	72.811816
+location	Virginia Beach	36.8529841	-75.9774183
+location	Virudhunagar	9.5208936	77.8784563961865
+location	Visaginas	55.5995933	26.4371224
+location	Visakhapatnam	17.7231276	83.3012842
+location	Visegrad	43.7864291	19.294097
+location	Viseu	-1.204892	-46.1392244
+location	Visoko	43.9894986	18.1816434
+location	Visp	46.11758005	7.866476544533072
+location	Vista Alegre	8.931677	-79.700195
+location	Vista Alegre do Alto	-21.171293	-48.6299172
+location	Vista Gaucha	-27.2897171	-53.7024746
+location	Vistalegre	43.2279605007686	-5.774377261654533
+location	Vitacura	-33.3802063	-70.56579553780725
+location	Vitanova	49.3583033	19.7224433
+location	Viterbo IT	42.294225	12.4124237
+location	Vitoria	-20.3200917	-40.3376682
+location	Vitoria de Santo Antao	-8.1209019	-35.2944858
+location	Vitoria do Jari	-0.9310733	-52.4241059
+location	Vitoria-Gasteiz	42.848478	-2.672011
+location	Vitre	48.1244503	-1.214331
+location	Vitry le Francois	48.7262225	4.5851622
+location	Viveda	43.37923	-4.05616
+location	Vizag	17.673210592148827	83.2090211526305
+location	Vizianagaram	18.1120819	83.4052196224888
+location	Vladikavkaz	43.024593	44.68211
+location	Vladimir	56.1288899	40.4075203
+location	Vladivostok	43.1150678	131.8855768
+location	Vlamertinge	50.853066	2.824175
+location	Vlcany	48.0377641	17.9526505
+location	Vleteren	50.930143	2.7289867
+location	Vleuten	52.101323449999995	5.000957567354371
+location	Vlezenbeek	50.8075574	4.2319001
+location	Vliermaal	50.8406437	5.428823
+location	Vliermaalroot	50.8637432	5.42394
+location	Voderady	48.2766783	17.558552
+location	Vöcklabruck	48.0078587	13.6460378
+location	Vöcklamarkt	48.0022211	13.4850818
+location	Völkermarkt	46.6604246	14.6340505
+location	Voeren	50.7465564	5.8390140411473
+location	Voerendaal	50.8722592	5.913755707785212
+location	Voiotia	38.35744775	23.11012390870053
+location	Voiron	45.3631386	5.5910751
+location	Vojnatina	48.73665025	22.237437240876737
+location	Volcan	8.7734239	-82.6375763
+location	Volendam	52.4963695	5.0683538
+location	Volgograd	48.7081906	44.5153353
+location	Volketswil	47.3898617	8.690503
+location	Volkhov	59.9275868	32.3276803
+location	Volodarskiy	46.400037514281095	48.534566990378416
+location	Volokolamsk	56.0360129	35.9583358
+location	Volta Redonda	-22.5225497	-44.1040128
+location	Volvic	45.872542	3.0375701
+location	Voorschoten	52.12572195	4.441016864583206
+location	Vorchdorf	48.0035141	13.922837
+location	Voronezh	51.6605982	39.2005858
+location	Voroux-lez-Liers	50.686830	5.554916
+location	Vorselaar	51.216049	4.773289
+location	Vosloorus	-26.3563889	28.2083333
+location	Vosselaar	51.3129153	4.8878026
+location	Vossem	50.8354014	4.5607522
+location	Votorantim	-23.5386249	-47.440842
+location	Votuporanga	-20.4252908	-49.972028
+location	Vranov nad Toplou	48.8891513	21.6822318
+location	Vranov nad Toplov	48.87575755612325	21.68378992433617
+location	Vrasene	51.2191283	4.194377
+location	Vratislavice nad Nisou	50.7434889	15.0964436
+location	Vrbas	45.568028	19.6470089
+location	Vrbnica	48.6786841	21.883228
+location	Vrbovce	48.7998174	17.468989
+location	Vrbove	48.6195312	17.7238763
+location	Vremde	51.1753099	4.5226229
+location	Vries	53.0767216	6.5779261
+location	Vrsac	45.1211263	21.2960485
+location	Vrutky	49.1088603	18.9250702
+location	Všebořice	50.6837604	13.991913
+location	Vsevolozhsk	60.024006	30.646042
+location	Vught	51.6511806	5.236800132062463
+location	Vyborg	60.709217	28.744051
+location	Vydrnik	49.000699499999996	20.410109482487883
+location	Vysne Hagy	49.1216199	20.127237662838123
+location	Vysne Nemecke	48.6593683	22.2632096
+location	Waaksens	53.10994	5.5383029
+location	Waalwijk	51.687337150000005	5.017307939950269
+location	Waanrode	50.9169762	5.0022179
+location	Waarloos	51.1052659	4.453
+location	Waasmont	50.726586	5.062739
+location	Waasmunster	51.1182	4.080492
+location	Wabash County	38.4615994	-87.8460903
+location	Wabasha County	 44.274798	-92.226763
+location	Wabrzezno	53.27835005	18.94049477910491
+location	Wachock	51.073812	21.0116897
+location	Wachsenberg	46.761034	14.0955792
+location	Wachtebeke	51.1701927	3.8574284
+location	Waco	31.549333	-97.1466695
+location	Wadelincourt	50.537149	3.653475
+location	Wadowice	49.8834484	19.4925345
+location	Waghodia	22.3043328	73.4016768
+location	Wagnelée	50.5231724	4.5334768
+location	Wagrowiec	52.81220655	17.201913487483125
+location	Wahkiakum County	46.2794223	-123.3452562
+location	Wahlen B. Laufen	47.4021415	7.5148865
+location	Waidhofen An Der Thaya	48.8146165	15.284518
+location	Waidhofen An Der Ybbs	47.951264949999995	14.744525855941326
+location	Waitemata	-36.8212269	174.66980747974335
+location	Wake County NC	35.7979355	-78.6118311
+location	Wakiso	0.2124412	32.5386152
+location	Wakken	50.930782	3.3978669
+location	Walbrzych	50.785221	16.284640336127822
+location	Walcourt	50.2513997	4.4314089
+location	Walcz	53.27285375	16.476817657727903
+location	Waldo County	44.4870161	-69.1365185
+location	Waldshut-Tiengen	47.6281754	8.2408579
+location	Waldstatt	47.3563362	9.2838414
+location	Walem	51.0657941	4.4568748
+location	Walendow	52.0786111	20.8472222
+location	Walenstadt	47.1236457	9.3149919
+location	Walhain	50.6180106	4.6953383
+location	Walker County	33.7804491	-87.2767248
+location	Walker County AL	33.7804491	-87.2767248
+location	Walker County TX	30.6795741	-95.5522823
+location	Walla Walla County	46.2055155	-118.5174284
+location	Wallbach	47.5599243	7.902809
+location	Waller County	29.9443902	-95.9955885
+location	Wallingford	41.460399	-72.804432
+location	Wallis	-13.2846405	-176.20665679493294
+location	Wallisellen	47.4166195	8.5919985
+location	Wallowa County	45.5582608	-117.1990173
+location	Walshoutem	50.7208713	5.0883752
+location	Walthall County	31.1241919	-90.1197687
+location	Walton	32.360678225278846	-95.84836813156247
+location	Walton County	30.6204939	-86.1912678
+location	Walton County FL	30.6204939	-86.1912678
+location	Waltwilder	50.8638819	5.5464648
+location	Walworth County	42.66774995	-88.54129289935219
+location	Wambrechies	50.6861944	3.0521806
+location	Wanakena	44.1339512	-74.9210219
+location	Wanaparthy	16.285294399999998	77.98644727021286
+location	Wandre	50.667253	5.661576
+location	Wanfercée-Baulet	50.4723768	4.5891745
+location	Wangen	47.4107645	8.6458518
+location	Wangen-Brüttisellen	47.4107645	8.6458518
+location	Wangenies	50.4776689	4.519112
+location	Wangi	47.496703	8.9533301
+location	Wanze	50.549453	5.196784
+location	Wapnica	53.2761457	15.4633778
+location	Warangal	17.9806094	79.5982115
+location	Ward County TX	31.5007583	-103.0781186
+location	Wardha	20.82562315	78.61314549522919
+location	Waregem	50.8868222	3.4323622
+location	Warneton	50.7529932	2.9502023
+location	Warren County	43.5018687	-73.8164637
+location	Warren County IL	40.8442828	-90.6168408
+location	Warren County NJ	40.8602222	-74.9720493
+location	Warren County NY	43.5018687	-73.8164637
+location	Warren County OH	39.4203978	-84.180897
+location	Warszawa	52.241015	20.985625
+location	Wartkowice	51.9755724	19.0022484
+location	Warwickshire	52.2671	1.4675
+location	Warzymice	53.387654	14.4720474
+location	Wasco County	45.145543	-121.204409
+location	Wasen Im Emmental	47.0429032	7.7944281
+location	Washburn County	45.8926321	-91.7971652
+location	Washim	20.28792095	77.23606281061035
+location	Washington County ID	44.3986887	-116.7400859
+location	Washington County IL	38.3662806	-89.4201902
+location	Washington County MS	33.2626706	-90.9183546
+location	Washington County NY	43.303560	-73.428260
+location	Washington County OR	45.544427	-123.010435
+location	Washington County RI	41.46361564311959	-71.64806019561742
+location	Washington County TN	36.2636501	-82.4911791
+location	Washington County TX	30.2226352	-96.3936114
+location	Washington County WI	43.362309	-88.235107
+location	Washington Parish	30.8337523	-90.0721467
+location	Washoe	38.305749	-122.7358219
+location	Washoe County	40.5849048	-119.6131606
+location	Wasilla	61.579538	-149.468390
+location	Wasosz	53.30815	17.06443
+location	Wasquehal	50.6691577	3.1312447
+location	Waterbury	41.5582	-73.0515
+location	Waterloo	50.710994	4.406944
+location	Watermael-Boitsfort	50.793201	4.423990
+location	Waterschei-Zwartberg	51.003230599999995	5.522580315918505
+location	Watou	50.8585545	2.6202796
+location	Wattala	6.9898705	79.8927094
+location	Wattwil	47.291534299999995	9.087813825936845
+location	Waukesha County	43.000286	-88.237059
+location	Waunakee	43.185210	-89.446208
+location	Waupaca County	44.4927889	-88.9650419
+location	Waupun	43.633216	-88.7296352
+location	Waushara County	44.1103406	-89.2347222
+location	Wauwatosa	43.054646	-88.039969
+location	Wavre	50.7162425	4.60845
+location	Wayne County	43.1500557	-77.0377603
+location	Wayne County IL	38.4251958	-88.4197678
+location	Wayne County NC	35.3546293	-78.0149444
+location	Wayne County NY	43.1500557	-77.0377603
+location	Wayne County OH	40.8615819	-81.9034617
+location	Weakley County	36.2902404	-88.7263475
+location	Webb County	27.6983621	-99.2523577
+location	Webster County MS	33.6197203	-89.2646598
+location	Webster Parish	32.726688	-93.341411
+location	Weelde	51.4071394	4.9905925
+location	Weert	51.1021651	4.1920146
+location	Weert BE	51.1021651	4.1920146
+location	Weert NL	51.235582949999994	5.705079711646853
+location	Weesp	52.30444305	5.0585343520066335
+location	Wegenstetten	47.4995108	7.9337595
+location	Weggis	47.0322545	8.4346408
+location	Wegorzewski	54.2069539	21.79181619253709
+location	Wegry	50.9286329	17.0386872
+location	Wehr	47.6286078	7.9046417
+location	Weil Am Rhein	47.6048182	7.6094052
+location	Weitersfeld	48.7817161	15.8115924
+location	Weiz	47.2174206	15.6221694
+location	Weißkirchen An Der Traun	48.1642098	14.1271488
+location	Wejherowo	54.606068199999996	18.23178605516042
+location	Weld County	40.5632344	-104.4835287
+location	Welkom	-27.982298	26.737969
+location	Welle	50.9005405	4.0448599
+location	Wellen	50.8414946	5.337092
+location	Welnica	52.560795	17.6455947
+location	Wels	48.1565472	14.0243752
+location	Wels-Land	48.1261105	13.9519318
+location	Wels-Stadt	48.1563978	14.0246656
+location	Welsberg	46.756898	12.1043528
+location	Wemmel	50.908020300000004	4.305641557650904
+location	Wenceslau Braz	-23.8748841	-49.8035872
+location	Werchter	50.9701533	4.6933645
+location	Werdenberg	47.168525	9.4636231
+location	Wernberg	46.624741	13.9321561
+location	Wervershoof	52.7375095	5.139338864050055
+location	Wervik	50.807707	3.052349
+location	Wesola	52.2517942	21.2292763
+location	Wespelaar	50.960557	4.640385
+location	West Baton Rouge Parish	30.4514623	-91.3261882
+location	West Coast	-32.9218992	17.985654577646827
+location	West Delhi	28.6479519	77.08556541088615
+location	West Dhanmondi	23.745763	90.36968610363476
+location	West Feliciana Parish	30.8842729	-91.4016657
+location	West Garo Hills	25.60780175	90.20380106122235
+location	West Godavari	17.0	81.166667
+location	West Haven	41.279571	-72.962057
+location	West Jaintia Hills	25.4425965	92.29882747091773
+location	West Khasi Hills	25.58173695	91.28910306371017
+location	West Pasaman	0.1875976	99.68987375527963
+location	West Rand	-26.209282503849348	27.556660564979346
+location	West Tripura	23.916667	91.5
+location	West Yellowstone	44.664290199999996	-111.10513722509046
+location	Westbroek	52.1506143	5.1259863
+location	Westchester County	41.1220	-73.7949
+location	Westende	51.1587721	2.7683368
+location	Westerlo	51.086694	4.9168675
+location	Westmalle	51.2857251	4.6845138
+location	Westouter	50.7982882	2.7462978
+location	Westrem	50.9697855	3.8614248
+location	Westrozebeke	50.931354188772325	3.011939550343966
+location	Weststellingwerf	52.87191835	6.008674359652279
+location	Wetter	51.3879463	7.3951553
+location	Wetteren	50.9983603	3.8731040535437895
+location	Wettstetten	48.8236836	11.414012
+location	Wetzikon	47.3226925	8.7980939
+location	Wevelgem	50.832135	3.174228
+location	Weyregg Am Attersee	47.9020955	13.5722764
+location	Wezemaal	50.9482598	4.7544622
+location	Wezembeek-Oppem	50.842122	4.490653
+location	Wharton County	29.2454534	-96.2291474
+location	Whatcom County	48.830959	-121.791189
+location	Wheatland County	46.4335302	-109.8498047
+location	Wheeler County	35.3921902	-100.2632764
+location	Wheelwright	-33.7922704	-61.2107401
+location	White County	38.0632329	-88.1577725
+location	White Pine County	39.5298185	-114.8899563
+location	Whitefish Bay	43.111041	-87.901408
+location	Whitehall County	44.366840	-91.324050
+location	Whiteside County	41.7612332	-89.9214744
+location	Whitman County	46.9428831	-117.5286172
+location	Wiaczyn Dolny	51.7687685	19.6232774
+location	Wiatowice	49.9494489	20.2131332
+location	Wichelen	51.0020843	3.980643809897363
+location	Wichita County	33.9516534	-98.7088886
+location	Widnau	47.4053426	9.6356294
+location	Wieckowo	53.3760062	20.5863021
+location	Wiekevorst	51.1099023	4.7941786
+location	Wielen	52.8943347	16.1712847
+location	Wielgie	51.2414849	21.4956227
+location	Wielichowo	52.1182673	16.3521384
+location	Wieliczka	49.9823773	20.0602114
+location	Wielsbeke	50.91140755	3.3604037488966805
+location	Wielun	51.2205345	18.5701081
+location	Wien	48.21294605004242	16.38470323201002
+location	Wiener Neustadt	47.80708635	16.23325959462936
+location	Wiener Neustadt-Land	47.80708635	16.23325959462936
+location	Wieruszow	51.2951647	18.1510623
+location	Wierzchowo	53.8588964	16.6092787
+location	Wierzchowo-Dworzec	53.6175254	17.4508837
+location	Wierzyce	52.4547296	17.3870102
+location	Wiesbaden	50.0820384	8.2416556
+location	Wijchen	51.82025285	5.696090348571646
+location	Wijgmaal	50.9322675	4.695096913535268
+location	Wijnegem	51.228317	4.515561
+location	Wijtschate	50.7856902	2.8826178
+location	Wil	47.4654409	9.0423202
+location	Wilamowice	49.9167395	19.1524707
+location	Wilbarger County	34.0265157	-99.2085961
+location	Wilcox County	31.9523021	-87.3005169
+location	Wilczyce	49.6666388	20.1887297
+location	Wildervank	53.0852546	6.8664148
+location	Wilen bei Wil	47.45056450278256	9.034978068142982
+location	Wilkow Wielki	50.7528606	16.8485275
+location	Wilkowice	49.7626335	19.0928616
+location	Wilkowo	52.3993137	16.5018214
+location	Wilkowo Polskie	52.0622254	16.4324581
+location	Will County	41.4194058	-87.9994754
+location	Will County IL	41.4194058	-87.9994754
+location	Willacy County	26.4553947	-97.5947484
+location	Willaupuis	50.5670756	3.6014894
+location	Willebroek	51.0626964	4.357232464403333
+location	Williams County OH	41.5018224	-84.5923785
+location	Williamsburg	33.6442699	-79.7442135
+location	Williamsburg County	33.6442699	-79.7442135
+location	Williamson County	30.6580927	-97.6041649
+location	Williamson County IL	37.737632500000004	-88.92944520134037
+location	Williamson County TN	35.8772991	-86.8978708
+location	Williamson County TX	30.6580927	-97.6041649
+location	Wilmington	39.7459468	-75.546589
+location	Wilrijk	51.169169	4.396261
+location	Wilsele	50.889602	4.693823
+location	Wilskerke	51.1809498	2.8401373
+location	Wilson County	29.1589961	-98.1251465
+location	Wilson County TN	36.1466658	-86.3119998
+location	Wilson County TX	29.1589961	-98.1251465
+location	Wilsonville	45.3099218	-122.7681602
+location	Wimmertingen	50.8829843	5.3517691
+location	Windham County	41.8208345	-72.0051201
+location	Windigsteig	48.7663181	15.2854332
+location	Windisch	47.4793472	8.2179918
+location	Wingene	51.058896	3.252863
+location	Winifreda	-36.22695965	-64.2321442569862
+location	Winkler County	31.8005913	-103.0762299
+location	Winksele	50.897244	4.644376
+location	Winn Parish	31.947293	-92.6401816
+location	Winnebago County IL	42.3255276	-89.1496574
+location	Winnebago County WI	44.0697014	-88.6516527
+location	Winneshiek County	43.288933	-91.839928
+location	Winona County	43.993965	-91.799960
+location	Winston County	34.1328863	-87.361354
+location	Winsum	53.3283335	6.5162773
+location	Winterthur	47.4991723	8.7291498
+location	Wiorek	52.3035605	16.9073194
+location	Wiry	52.3197406	16.8542748
+location	Wisconsin	44.535145	-89.527762
+location	Wise County	33.2139213	-97.6563925
+location	Wisla	49.6523647	18.8709256
+location	Wisla Glebce	49.6216894	18.8760729
+location	Wisniowa Gora	51.7130624	19.6274166
+location	Wisniowka	53.6308333	17.8586111
+location	Wissembourg	49.0365935	7.9445109
+location	Witkow	51.29117	15.86061
+location	Witkowo	52.4395881	17.7725138
+location	Witkowo Drugie	53.29965	15.04217
+location	Witnica	52.1101817	18.0508604
+location	Witolubie	54.1861094	16.0497151
+location	Witoszow Gorny	50.81831855	16.391711409257873
+location	Wittenbach	47.4624072	9.3820343
+location	Witterswil	47.4858554	7.5248795
+location	Wladyslawowo	54.1609064	19.355476
+location	Wloclawek	52.6655636	19.096129748054388
+location	Wloclawski	52.55667875	19.04185408101088
+location	Wlodawa	51.54154425	23.528801875901806
+location	Wlosan	49.9203088	19.8891522
+location	Wloszczowa	50.8520727	19.9667772
+location	Wlynkowko	54.5063464	16.9962948
+location	Wodnica	54.5584017	16.8663104
+location	Wodzislaw	50.5211403	20.1909163
+location	Woerden	52.08701595	4.876687198673499
+location	Wörth Am Rhein	49.0543232	8.2667399
+location	Woippy	49.154613	6.148404
+location	Wojciechowice	50.8447202	21.5865167
+location	Wojcieszyce	50.8819011	15.6347975
+location	Wojkow	51.58846	18.42986
+location	Wojnowce	53.3919523	23.7027735
+location	Wojnowice	51.0640207	17.2560587
+location	Wojnowice (Dolnośląskie)	51.0640207	17.2560587
+location	Wojnowice (Slaskie)	50.0555733	18.1531508
+location	Wojska	50.4856534	18.6642594
+location	Wola Batorska	50.0524215	20.2656679
+location	Wola Cyrusowa	51.8771148	19.7737681
+location	Wola Lagiewnicka	52.62992	17.36548
+location	Wola Morawicka	50.7354786	20.6346479
+location	Wola Rzedzinska	50.0372232	21.064394
+location	Wola Skrzydlanska	49.7396269	20.1573642
+location	Wola Zarczycka	50.286457	22.2510349
+location	Woldendorp	53.2735639	7.0297936
+location	Wolfhausen	47.2570817	8.800881
+location	Wolfratshausen	47.9104632	11.4266377
+location	Wolfsberg	46.8390583	14.8452061
+location	Wolfurt	47.4646422	9.74596429463968
+location	Wolhusen	47.0580138	8.0725617
+location	Wolin	53.9131743	14.52001388837596
+location	Wólka	54.3056993	20.700425
+location	Wólka (Mazowieckie)	51.1988938	21.6868806
+location	Wólka (Warminsko-Mazurskie)	54.3056993	20.700425
+location	Wolka Baltowska	51.0351172	21.5260097
+location	Wolka Bodzechowska	50.9271339	21.4495248
+location	Wollerau	47.1957261	8.7194595
+location	Wolomin	52.3468689	21.2420179
+location	Wolsztynski	52.0879324	16.100285128712613
+location	Woluwe-Saint-Lambert	50.8430448	4.4256732
+location	Woluwe-Saint-Pierre	50.829410	4.433356
+location	Wolvertem	50.9510266	4.3085198
+location	Wommelgem	51.2031044	4.5238022
+location	Wommersom	50.8130597	5.0173851
+location	Wondelgem	51.0885639	3.7132822
+location	Wonfurt	50.0115757	10.4662369
+location	Wood County	44.4517617	-90.0199618
+location	Wood County OH	41.2776661	-83.6643025
+location	Wood County TX	32.7577475	-95.3812941
+location	Wood County WI	44.4517617	-90.0199618
+location	Wood Village	45.5351189	-122.4212226
+location	Woodbridge	41.357409	-73.009510
+location	Woodbury County	42.3775361	-96.0607187
+location	Woodford County IL	40.8145359	-89.2074215
+location	Worcester County	42.3705781	-71.8677242
+location	Worcester County MA	42.3705781	-71.8677242
+location	Wormer	52.4983303	4.8122972
+location	Wortegem-Petegem	50.8485315	3.5375547
+location	Wortel	51.397672	4.7951262
+location	Wągry	51.7889488	19.854845
+location	Wrociszow	51.046507	15.0583328
+location	Wroclaw	51.1089776	17.0326689
+location	Wronki	52.7101225	16.3742272
+location	Września	52.3250694	17.5652282
+location	Wrzosowa	49.9002137	19.9627611
+location	Wuhan	30.554807	114.271501
+location	Wulvergem	50.7596951	2.8538814
+location	Wuustwezel	51.38525	4.565174345040151
+location	Wyczechy	53.68911	17.04057
+location	Wymyslow	50.5165656	20.6833405
+location	Wymyslowo	52.6231941	16.7525601
+location	Wyoming County	42.7039813	-78.2415228
+location	Wysławice	52.32239	17.31377
+location	Wysogotowo	52.41152	16.7820305
+location	Wysokie Mazowieckie	52.925635400000004	22.51040144868788
+location	Wyszkowo	54.34074	20.1074271
+location	Węgrow	52.4007333	22.04646417697228
+location	Węgrzce Wielkie	50.0148566	20.1099342
+location	Xai Xai	-25.044479	33.64073
+location	Xangri-la	-29.8039422	-50.0413748
+location	Xativa	38.9957288	-0.5138534074471998
+location	Xeraco	39.0331	-0.2163
+location	Xexeu	-8.8036743	-35.6244442
+location	Xingtai	37.0616519	114.499746
+location	Xinyu	27.8178	114.9173
+location	Xirivella	39.4639546	-0.4293866
+location	Xishuangbanna	21.995	100.837
+location	Yadadri Bhuvanagiri	17.42819665	79.09049097612106
+location	Yafa An-Naseriyye	32.685946	35.274821
+location	Yakima County	46.430431	-120.711765
+location	Yalobusha County	34.0213455	-89.6991703
+location	Yamhill County	45.2298399	-123.2180414
+location	Yangjiang	21.888814	111.972598
+location	Yanino-1	59.947418	30.561453
+location	Yantzaza	-3.7146811499999997	-78.73763444639725
+location	Yaroslavl	57.6263877	39.8933705
+location	Yates County	42.6444444	-77.112177
+location	Yauco	18.0352547	-66.8487055
+location	Yavapai County	34.5668857	-112.5515965
+location	Yavatmal	20.15	78.35
+location	Yaviza	8.1762134	-77.709096
+location	Yavne	31.8768863	34.7382974
+location	Yazoo County	32.770896	-90.4120889
+location	Yebes	40.5331907	-3.1107441
+location	Yehud	32.0340	34.8859
+location	Yekaterinburg	56.839104	60.60825
+location	Yekaterinoslavka	50.380718641765085	129.10012300677616
+location	Yellowstone County	45.9645464	-108.276076
+location	Yerba Buena	-26.8121581	-65.2981714
+location	Yernée-Fraineux	50.528091	5.383570
+location	Yeruham	31.8151308	34.7847003
+location	Yessentuki	44.0468389	42.8565018
+location	Yeumbeul	14.7722	-17.3581
+location	Yevpatoriya	45.1907635	33.3679049
+location	Yffiniac	48.4846721	-2.6768534
+location	Yichun	27.804179	114.414177
+location	Yigo	13.535204499999999	144.89715694673106
+location	Yingtan	28.258501	117.043863
+location	Yiwu	29.3063535	120.0702682
+location	Yolo County	38.7184542	-121.9059001
+location	Yongchuan	29.374774	105.925391
+location	Yopal	5.3356662	-72.3936931
+location	York County	34.9603293	-81.1655408
+location	York County ME	43.4229305	-70.6546639
+location	York County PA	39.9067499	-76.7008946
+location	York County SC	34.9603293	-81.1655408
+location	Yorkshire	53.3833	-1.4599
+location	Yorktown Heights	41.2709	-73.7776
+location	Young County	33.1508315	-98.6962766
+location	Ypane	-25.4601626	-57.51149165377325
+location	Yquelon	48.8469864	-1.5574109
+location	Yssac la Tourette	45.9355555	3.0936111
+location	Yssingeaux	45.1435556	4.1244363
+location	Ytrac	44.9111838	2.3633014
+location	Yuba County	39.2839755	-121.3556818
+location	Yuecheng	29.9882	120.5826
+location	Yuma	32.665135	-114.47603157249804
+location	Yuma County	32.7915374	-113.8975031
+location	Yuma County AZ	32.7915374	-113.8975031
+location	Yumbo	3.525117	-76.502240
+location	Yungay	-37.1193665	-72.0188531
+location	Yunquera de Henares	40.7546981	-3.1662667
+location	Yuryevets	57.3178792	43.1110178
+location	Yuvalim	32.8775051	35.2705626
+location	Yvelines	48.76203735	1.8871375621264361
+location	Yzeure	46.5676568	3.3539775
+location	Zaandam	52.4424926	4.8298607
+location	Zaandijk	52.4744145	4.8080282
+location	Zabawa	49.9939736	20.089716
+location	Zabiedovo	49.320123	19.6069033
+location	Zabor	51.21215	16.726291
+location	Zaborze	53.80344	16.13922
+location	Zacapa	14.9685142	-89.5314792
+location	Zachowice	50.9849098	16.7878411
+location	Zafarraya	36.9735191	-4.1416876
+location	Zagan	51.615323149999995	15.3007805981478
+location	Zagnansk	50.9800365	20.6632227
+location	Zagozd	53.57783	15.76079
+location	Zagreb	45.8131847	15.9771774
+location	Zagrody	50.5926561	21.1162534
+location	Zahedan	29.4928874	60.8503017
+location	Zajezierze	53.89738	19.7142401
+location	Zakliczyn	49.8564352	20.8086652
+location	Žakovce	49.0817207	20.3972802
+location	Zakret	52.2200265	21.2699906
+location	Zakrzewiec	54.34919	19.94589
+location	Zakrzewo	53.2809	20.29286
+location	Zakrzów	50.0108335	20.1455486
+location	Zakrzowiec	50.0022376	20.1609677
+location	Zalasewo	52.386163	17.074423
+location	Zalesie	53.6808965	22.1500205
+location	Zalesie (Łódzkie)	51.7602304	18.9181259
+location	Zalesie (Pomorskie)	53.1706343	18.6902263
+location	Zalesie (Warminsko-Mazurskie)	53.6808965	22.1500205
+location	Zalewo	53.8458768	19.606118
+location	Zaleze	54.182195750000005	15.54760868771456
+location	Zalobin	48.9698054	21.7280436
+location	Zaluskow	52.3176394	19.9832242
+location	Zambrow	52.975833300000005	22.23729346971591
+location	Zambrowski	53.022658899999996	22.24796561974756
+location	Zamora	-4.0042008	-78.95777541910938
+location	Zamora ES	41.6857693	-5.942315018340977
+location	Zamość	50.721273	23.259588703837892
+location	Zams	47.159925	10.587413
+location	Zandhoven	51.2147918	4.6595103
+location	Zandvoorde	51.2008761	2.975876
+location	Zango 4	-9.0712238	13.4112097
+location	Zapala	-38.9029381	-70.0642572
+location	Zapata County	26.9879626	-99.1673556
+location	Zapopan	20.7211203	-103.3913671
+location	Zapote	9.9212527	-84.0595812
+location	Zápy	50.1657204	14.6791468
+location	Zaragoza	41.6488	-0.8891
+location	Zaragoza CO	7.4949425000000005	-74.93071761130234
+location	Zaragoza ES	41.768433	-0.331362
+location	Zaragoza GT	14.6497267	-90.8909403
+location	Zarasų rajono savivaldybė	55.73037705	26.038793538617405
+location	Zarauz	43.2834873	-2.1723467
+location	Zarechny	56.8149706	61.3205936
+location	Zarnovica	48.4833983	18.7215497
+location	Zarow	50.9438416	16.4923538
+location	Zarraton	42.5152122	-2.8820043
+location	Zarren	51.0185167	2.9585072
+location	Zarza la Mayor	39.8755169	-6.8644412
+location	Zatonie	50.9461862	14.9405703
+location	Závadka (Gelnica)	48.8648005	20.6171867
+location	Zavalla	-33.0185383	-60.8788584
+location	Zaventem	50.8806207	4.4730008
+location	Zavitinsk	50.1076138552731	129.44126185489958
+location	Zavodie	49.2151366	18.7198421
+location	Zavolzhsk	57.4909934	42.13964
+location	Zawada	49.9848431	21.0142325
+location	Zawady	52.7265385	23.0848978
+location	Zawiercie	50.4844179	19.4333887
+location	Zborov	49.3679102	21.3080014
+location	Zdiby	50.1679384	14.4515432
+location	Zdunska Wola	51.594911550000006	18.950108677704648
+location	Zebrzydowice	49.8699168	18.6247092
+location	Zedelgem	51.1389736	3.1395587
+location	Zedowice	50.5832744	18.5119393
+location	Zeebrugge	51.3312211	3.207561
+location	Zeewolde	52.3311	5.5405
+location	Zefat	32.9646301	35.502451
+location	Zegartowice	49.8267658	20.1912842
+location	Zehra	48.9804224	20.7920261
+location	Zeist	52.086531750000006	5.249007957671885
+location	Zele	51.0730461	4.0424143
+location	Zelechow	51.8096724	21.895505
+location	Zelenchukskaya	43.8549752	41.5853611
+location	Zeleneč	50.133619	14.660698
+location	Zelenec CZ	50.133619	14.660698
+location	Zelenec SK	48.3322277	17.5943147
+location	Zelenograd	55.982578390036124	37.18906459762615
+location	Zelenokumsk	44.403175	43.884163
+location	Želiezovce	48.0492258	18.6583548
+location	Zelkow	50.1593052	19.7961829
+location	Zell	48.34397126348534	8.081118640537058
+location	Zell Am Moos	47.9024754	13.3187889
+location	Zell am See	47.3239636	12.7963165
+location	Zellik	50.8842475	4.2744185
+location	Zelovce	48.1245541	19.3527584
+location	Zeltweg	47.1912045	14.7549244
+location	Zelzate	51.2000036	3.8105002
+location	Zemianska Olca	47.8058453	17.8726467
+location	Zemst	50.9842166	4.4650814
+location	Zepperen	50.8225873	5.2476844
+location	Zernez	46.6979839	10.0943311
+location	Zernograd	46.844845	40.304813
+location	Zeroslawice	49.8305118	20.2339027
+location	Zevekote	51.1368151	2.920019
+location	Zevenhuizen	52.0116234	4.5802253
+location	Zeya	53.7403584	127.2716246
+location	Zgierz	51.8555209	19.390634827153598
+location	Zgorzelec	51.15178695	15.014432971933283
+location	Zhanjiang	21.229510	110.393313
+location	Zheleznogorsk	56.250938	93.53286
+location	Zhengzhou	34.714074	113.621939
+location	Zhongshan	22.542629	113.390864
+location	Zhongxian	30.323947	108.012855
+location	Zhuhai	22.271346	113.562879
+location	Ziar nad Hronom	48.5910183	18.8500892
+location	Zichem	51.0014178	4.9856978
+location	Ziebice	50.6007752	17.0405633
+location	Zielatkowo	52.5610235	16.7978085
+location	Zielona Gora	51.9383777	15.5050408
+location	Zillebeke	50.83401376391528	2.9221106193967072
+location	Zimotki	51.9901558	18.6327667
+location	Ziniare	12.582722	-1.2331183259644114
+location	Žíp	48.359836200000004	20.2115685503136
+location	Zipaquira	5.023869	-73.999449
+location	Zizur Mayor	42.7887152	-1.692616
+location	Zlaté Moravce	48.3833333	18.4
+location	Zlocieniec	53.5310697	16.0120665
+location	Zlotniki	52.4937835	16.8450812
+location	Zlotoryja	51.122408899999996	15.919447631385701
+location	Złotów	53.3591987	17.043815994517477
+location	Zloty Stok	50.445143	16.8765836
+location	Znin	52.848462	17.7218791
+location	Znojmo	48.86108	16.034083
+location	Zoerle-Parwijs	51.0880889	4.8729402
+location	Zoersel	51.259362	4.666641
+location	Zoetermeer	52.06228915	4.487754536970652
+location	Zofingen	47.288491	7.9458259
+location	Zolder	50.9905	5.258
+location	Zollikon	47.3395679	8.5761264
+location	Zonhoven	50.9871	5.3672
+location	Zonnebeke	50.8731885	2.9874678
+location	Zopowy-Osiedle	50.1680963	17.7537749
+location	Zottegem	50.869252	3.8103878
+location	Zoutleeuw	50.836614	5.107761
+location	Ząbkowice Śląskie	50.5892698	16.8111518
+location	Zrenjanin	45.3802683	20.3907614
+location	Zuberec	49.2601209	19.6142571
+location	Zubne	49.0477998	22.0625757
+location	Zubrohlava	49.4445716	19.5115439
+location	Zubrow	52.4806339	15.1437475
+location	Zürich	47.3744489	8.5410422
+location	Zug	47.1679898	8.5173652
+location	Zuidbroek	53.1593423	6.8667625
+location	Zuidhorn	53.2480055	6.4048657
+location	Zuidlaren	53.0940808	6.6871992
+location	Zuidwolde	52.6749542	6.4317343
+location	Zuienkerke	51.2685834	3.1567406094326182
+location	Zujar	37.5394	-2.8415
+location	Zukczyn	54.2141629	18.6056317
+location	Zulte	50.9401085	3.4753307227884633
+location	Zulueta	42.745008	-1.579320
+location	Zululand	-27.897909900000002	31.293846335885597
+location	Zumarraga	43.0859968	-2.3140925
+location	Zunzgen	47.4504005	7.80462
+location	Zurita	43.3476194	-3.9883478
+location	Zutendaal	50.9318992	5.5725548
+location	Zvánovice	49.9319472	14.7802303
+location	Zvenigorod	55.7293613	36.8585382
+location	Zvolen	48.5782517	19.1247135
+location	Zwaag	52.6687248	5.0755907
+location	Zwettl	48.6196156	15.0601913
+location	Zwettl-Niederösterreich	48.6050427	15.1681644
+location	Zwevegem	50.8128396	3.3331679
+location	Zwijnaarde	51.0003917	3.7167702
+location	Zwijndrecht	51.2306636	4.3183779247034195
+location	Zwingen	47.437887	7.527901
+location	Zydowo	52.0027234	16.6107307
+location	Zyrardow	52.05553205	20.44464353021984
+location	Żywiec	49.706496099999995	19.21914906371902
+
+division	Aalst	50.939656	4.064173
+division	Aargau	47.420629	8.172097
+division	Aatalunya	41.670376	1.657348
+division	Abadan	30.3636097	48.2591475
+division	Abruzzo	42.192	13.7289
+division	Abu Dhabi	24.4747961	54.3705762
+division	Abuja	9.0643305	7.4892974
+division	Aceh	4.3685491	97.0253024
+division	Acre	-8.862769	-70.079844
+division	Ad-Dawhah	25.2856329	51.5264162
+division	Adamaoua	7.084796	12.0872226
+division	Adamawa	9.5129772	12.3881887
+division	Adan	29.231698918007556	48.068968448266425
+division	Adana	36.9863599	35.3252861
+division	Addis Ababa	9.0107934	38.7612525
+division	Addu	-0.64149345	73.16299780292195
+division	Adıyaman	37.900714	38.309879
+division	Adrar	26.4888155	-1.3582442169365363
+division	Adygea	44.6939006	40.1520421
+division	Aegean Islands	38.2504094	20.6304217
+division	Afghanistan	33.7680065	66.2385139
+division	Africa	4.070194	21.824559
+division	Afyon	38.752653	30.553661
+division	Agadez	16.972556	7.990739
+division	Agadir	30.4198163	-9.6128498
+division	Agder	58.71944225	8.034963534558171
+division	Agri	39.7191	43.0506
+division	Aguascalientes	22.0000001	-102.5000001
+division	Agusan del Norte	8.92	125.46
+division	Ahvaz	31.3240443	48.6637087
+division	Aichi	35.067543	137.334061
+division	Akita	39.6898802	140.342608
+division	Aksaray	38.44611	33.878216
+division	Aktobe Region	48.2396582	57.7213289
+division	Akwa-Ibom	4.9408638	7.8412267
+division	Al Asimah	29.09261275	48.51334671327169
+division	Al-Muthanna Province	30.5015763	45.0188363
+division	Al-Najaf-Al-Ashraf	32.02193996396834	44.337727476253775
+division	Al Wusta	19.679297	56.59113398322508
+division	Alabama	32.3182	-86.9023
+division	Alagoas	-9.74863	-36.417626
+division	Alajuela	10.020137	-84.210339
+division	Alaska	65.797699	-152.214189
+division	Alba	46.015921250000005	23.54685524706489
+division	Albania	41.000028	19.9999619
+division	Alberta	55.001251	-115.002136
+division	Alborz Province	35.9413239	50.7884216
+division	Alexandria	31.199004	29.894378
+division	Alger	36.7753606	3.0601882
+division	Algeria	28.0000272	2.9999825
+division	Algiers	36.70649229138003	3.0544471144244483
+division	Alif Alif Atoll	4.0518934	72.7276959
+division	Alifu Dhaalu Atoll	3.5993756505411025	72.82595552226857
+division	Almaty	43.2363924	76.9457275
+division	Aloatra-Mangoro	-17.93579010617825	48.30432131939425
+division	Alta Verapaz	15.5	-90.333333
+division	Altai Krai	52.6932243	82.6931424
+division	Alto Paraguay	-20.5	-59.166667
+division	Alto Paraná	-25.5	-54.833333
+division	Alytaus Apskritis	54.22953895	24.07911990913408
+division	Alytus	54.3961344	24.0459268
+division	Amapa	1.582936	-51.809488
+division	Amazonas BR	-4.479925	-63.5185396
+division	Amazonas PE	-5.070085	-78.145666
+division	Amazonas VE	3.5	-66.0
+division	Amhara	11.5	38.5
+division	Amman	31.9539	35.9106
+division	Amoron'i Mania	-20.4591292	46.72639219499414
+division	Amur Region	52.9596609	141.21179224371429
+division	Amyntaio	40.691024	21.6854184
+division	Analamanga	-18.6000004	47.51310021616148
+division	Analanjirofo	-16.5075	49.5280
+division	Ancash	-9.5	-77.75
+division	Ancona	43.480120400000004	13.218790609151764
+division	Andalusia	37.5443	-4.7278
+division	Andaman and Nicobar Islands	12.61123865	92.83165406414926
+division	Andel	51.7851	5.0549
+division	Andhra Pradesh	15.9129	79.7400
+division	Andorra	42.5407167	1.5732033
+division	Ang Thong	14.6495224	100.3170382
+division	Angola	-11.1691767	13.2845209
+division	Anguilla	18.21445329034252	-63.05253050784242
+division	Anhui	31.754331	117.211441
+division	Ankara	39.949377	32.854736
+division	Antigua	17.086	-61.78629453333333
+division	Antigua and Barbuda	17.2234721	-61.9554608
+division	Antioquia	6.709191	-75.484721
+division	Antofagasta	-23.6509	-70.3975
+division	Antsiranana	-12.2779134	49.2913394
+division	Antwerpen	51.225698	4.420885
+division	Aomori	40.886943	140.590121
+division	Appenzell Ausserrhoden	47.3960076	9.3705839
+division	Appenzell Innerrhoden	47.3007262	9.3991527
+division	Apulia	40.7928	17.1012
+division	Apure	7.166667	-68.833333
+division	Apurimac	-14.0	-73.0
+division	Aqaba	29.526702	35.007822
+division	Arad	46.1753793	21.3196342
+division	Aragon	41.5976	-0.9057
+division	Aragua	10.0	-67.166667
+division	Arak	34.0865203	49.6888415
+division	Arauca	6.6666755	-71.0000086
+division	Araucanía	-38.6710116	-72.2564576
+division	Ardabil	38.4583983	47.9313001
+division	Arequipa	-16.3988667	-71.5369607
+division	Argentina	-34	-64
+division	Arges	45.060683	24.903263
+division	Ariana	36.968573500000005	10.121985506329507
+division	Arica and Parinacota	-18.5713496	-69.7884774
+division	Aridaia	40.9755407	22.0610874
+division	Arizona	34.220707	-111.657462
+division	Arkansas	35.2010	-91.8318
+division	Arkhangelsk Region	64.543022	40.537121
+division	Arlon	49.6834601	5.8167711
+division	Armenia	40.7696272	44.6736646
+division	Arnissa	40.7948906	21.8360883
+division	Artigas	-30.6170756	-56.9373451
+division	Aruba	12.4902998	-69.9609842
+division	Arunachal Pradesh	28.0937702	94.5921326
+division	Arusha	-3.427534	36.70858481848994
+division	Ashanti Region	6.8003319	-1.5188142
+division	Ashdod	31.8044	34.6553
+division	Asia	30.451098	86.654576
+division	Assam	26.2006	92.9376
+division	Astrakhan Region	46.3498308	48.0326203
+division	Asturias	43.317041	-6.006428
+division	Asuncion	-25.2800459	-57.6343814
+division	Atacama	-27.5571783	-70.0156882
+division	Ath	50.646122	3.770363
+division	Athens	37.987832	23.726319
+division	Atlantico	10.681025	-74.955752
+division	Atlántida	15.8172492	-87.11469350954292
+division	Atsimo-Andrefana	-23.0907053	44.40133257710572
+division	Atsinanana	-18.87255782473823	48.9338102093968
+division	Attica	37.9946543	23.79940251269328
+division	Attock	33.7695323	72.3610911
+division	Atyrau Region	47.6605827	50.806203
+division	Auckland	-36.837842	174.800853
+division	Auderghem	50.812905	4.435779
+division	Australia	-24.7761085	134.755
+division	Australian Capital Territory	-35.4883502	149.0026942
+division	Austria	47.5162	14.5501
+division	Auvergne-Rhône-Alpes	45.4471	4.3853
+division	Awdal	10.5000045	43.4999956
+division	Ayacucho	-14.0	-74.0
+division	Aysén	-46.1434629	-74.36488694169807
+division	Azad Kashmir	33.62045585868291	75.12498213019724
+division	Azerbaijan	40.3936294	47.7872508
+division	Azuay	-3.0524451	-79.2395135
+division	Bac Giang	21.3092863	106.6165128
+division	Bac Ninh	21.1212051	106.0880245
+division	Bacau	46.42613415	26.71205400126924
+division	Bács-Kiskun County	46.551745	19.374218
+division	Baden-Wuerttemberg	48.712618	9.13403
+division	Bafoussam	5.4758083	10.4215565
+division	Baghdad	33.3024309	44.3787992
+division	Bagherhat	22.655249	89.774093
+division	Baglung	28.356335299999998	83.14253600515775
+division	Bagmati	27.08050365	85.47681103355023
+division	Bahamas	24.7736546	-78.0000547
+division	Bahia	-12.5797	-41.7007
+division	Bahrain	26.0667	50.5577
+division	Baie-Mahault	16.2679458	-61.5870766
+division	Baja California	30.0338923	-115.1425107
+division	Baja California Sur	25.5818014	-111.5706164
+division	Baja Verapaz	15.1009234	-90.3139743
+division	Baker Island	0.1955757	-176.4778235675172
+division	Bakhar	26.0475573	68.3990527
+division	Balassagyarmat	48.0712	19.2937
+division	Balatonfured	46.9599	17.8851
+division	Balear Islands	39.30	3.0
+division	Bali	-8.3304977	115.0906401
+division	Balikesir	39.650196	27.88958
+division	Balochistan	28.0	66.0
+division	Balti	47.7664144	27.9032992
+division	Balzers	47.0671067	9.5002584
+division	Bamako	12.60503275	-7.986513673439357
+division	Bandung	-6.917318	107.607954
+division	Bangkok	13.798471	100.590834
+division	Bangladesh	24.506442	90.041454
+division	Bangsamoro Autonomous Region In Muslim Mindanao	5.8506231	120.0284034624274
+division	Bangui	4.3907153	18.5509126
+division	Banovce nad Bebravou	48.7216671	18.2598263
+division	Banska Bystrica	48.7384028	19.1573494
+division	Banten	-6.47800285	105.54102849016589
+division	Bar	42.0979745	19.0954528
+division	Baranya County	45.9714436	18.1669246
+division	Barbados	13.1500331	-59.5250305
+division	Barcelona	41.394769	2.173828
+division	Barinas	8.166667	-69.833333
+division	Baringo	0.72514575	36.01949550152824
+division	Barishal	22.7562851	90.41098391553726
+division	Bartosova Lehotka	48.650737899999996	18.91107723135121
+division	Basel-Land	47.493316	7.714938
+division	Basel-Stadt	47.557238	7.595666
+division	Bashkortostan	54.8573563	57.1439682
+division	Basilicata	40.447062	16.081705
+division	Basque Country	42.9896	-2.
+division	Basse	13.40499765	-14.149557582246608
+division	Basse-Terre	16.0000778	-61.7333373
+division	Bastogne	50.006852823238276	5.760870385343908
+division	Bat Yam	32.0132	34.7480
+division	Batizovce	49.0734666	20.1843029
+division	Batna	35.5772247	6.1411111
+division	Bauchi	10.6228284	10.0287754
+division	Bavaria	48.1382614	11.5845093
+division	Bay of Plenty	-38.216044	176.783577
+division	Bayanga	2.912403	16.2611354
+division	Bayelsa State	4.7629786	6.028898
+division	Beijing	40.07132	116.406908
+division	Beirut	33.8938	35.5018
+division	Beit Shemesh	31.7470	34.9881
+division	Beja	38.0153	-7.8627
+division	Bekaa	33.6746204	35.83265535410547
+division	Békés County	46.741797	21.031653
+division	Bekesszentandras	46.8716	20.4834
+division	Bela nad Cirochou	48.974421	22.1072708
+division	Belarus	53	28
+division	Belgium	50.707735	4.677726
+division	Belgorod Region	50.79667820890024	37.501333128673124
+division	Belgrade	44.8178131	20.4568974
+division	Belize	16.8259793	-88.7600927
+division	Belmopan	17.250199	-88.770018
+division	Ben Arous	36.747441	10.234475
+division	Benadir	2.0812612	45.4607164
+division	Bengkulu	-3.5186763	102.5359834
+division	Bengo	-8.30833915	13.88301594422697
+division	Beni	-14.0	-65.0
+division	Beni Mellal	32.334193	-6.353335
+division	Benin	9.2231105	2.31006719638123
+division	Benue State	7.3505747	8.7772877
+division	Beoumi	7.6745381	-5.5827323
+division	Berane	42.846826	19.8740451
+division	Berea	-29.278351	27.5602768
+division	Berlin	52.507192	13.408126
+division	Bermuda	32.3018217	-64.7603583
+division	Bern	46.855135	7.570549
+division	Berrechid	33.2676746	-7.5811465
+division	Bethlehem	31.7043556	35.2061876
+division	Beyla	8.909431999999999	-8.367475476673686
+division	Bhaktapur	27.6720657	85.428171
+division	Bicol	13.100588	123.52313310936306
+division	Bie	-12.2630485	17.4967812
+division	Bielsk Podlaski	52.764915	23.188210662123517
+division	Bihac	44.8120	15.8686
+division	Bihar	25.0961	85.3131
+division	Bihor	46.992055	22.190274243393223
+division	Bijelo Polje	43.0341595	19.7473559
+division	Biobío	-37.3391407	-72.4106825
+division	Bioko Norte	3.6484594	8.7851155
+division	Bioko Sur	3.4245254	8.6646092
+division	Biskra	34.8468008	5.6884562
+division	Bizerte	37.280658	9.863049
+division	Bjelovar-Bilogora County	45.7462142	16.9212335
+division	Black River	-20.32645475	57.415467680680635
+division	Blagoevgrad	42.0209	23.0943
+division	Blekinge	56.12401225	15.40220875187768
+division	Blida	36.48329	2.808751
+division	Bobonong	-22.092649	28.4756626
+division	Bobrov	49.4291733	19.5421527
+division	Bocas del Toro	9.3040914	-82.12843877974339
+division	Boeny	-16.23492785	46.12926718059281
+division	Boffa	10.1812281	-14.0377043
+division	Bogota	4.629337	-74.095588
+division	Bohol	9.833333	124.1615579
+division	Boipelego	-22.6104265	25.5976516
+division	Boke	11.3406898	-13.9440724
+division	Bolivar	8.753508	-74.367735
+division	Bolivar CO	10.4190661	-75.5267671
+division	Bolivar EC	-1.574489	-79.103194
+division	Bolivar VE	8.1080955	-63.551078
+division	Bolivia	-17.0568696	-64.9912286
+division	Bomet	-0.7196054000000001	35.23963801252495
+division	Bonaire	12.1558998	-68.242427
+division	Bong	6.927103677721825	-9.631899105957558
+division	Bongolava	-18.567679963367897	46.229277259149626
+division	Bono East Region	7.8035236	-1.0876492
+division	Bono Region	7.6761791	-2.4735401
+division	Bonthe	7.5292766	-12.5131866
+division	Bordj-Bou-Arreridj	36.095506	4.661100173631754
+division	Borno State	12.1875392	13.3080034
+division	Boromo	11.7447567	-2.9300274
+division	Borsod-Abaúj-Zemplén County	48.2939	20.6934
+division	Bosnia and Herzegovina	43.9159	17.6791
+division	Botha Bothe	-28.762610199999997	28.256564410276525
+division	Botosani	47.85234105	26.759511926593397
+division	Botswana	-23.1681782	24.5928742
+division	Bouafle	6.9926792	-5.7444227
+division	Bouaké	7.6906058	-5.0298408
+division	Boucle du Mouhoun Region	12.4635117	-3.4593427
+division	Boufarik	36.57709	2.914137
+division	Bouira	36.2316481	3.9082579191011253
+division	Bourgogne	47.0525	4.3837
+division	Bourgogne-France-Comté	47.2805	4.9994
+division	Boyaca	5.454426	-73.362218
+division	Brabant Wallon	50.652853	4.555627
+division	Brahmanbaria	23.96059985	91.11908934668182
+division	Braila	45.2716092	27.9742932
+division	Braine-l'Alleud	50.6854	4.3779
+division	Brandenburg	52.8455492	13.2461296
+division	Braničevo District	44.452519699999996	21.527150035837593
+division	Brasov	45.6580	25.6012
+division	Bratislava	48.1486	17.1077
+division	Brazil	-10.3333332	-53.1999999
+division	Brazilian Cruise	-15.982399	-35.864365
+division	Brazzaville	-4.2694407	15.2712256
+division	Bremen	53.0758196	8.8071646
+division	Bretagne	48.202	-2.9326
+division	Breza	44.0181	18.2613
+division	British Columbia	54.010982	-124.745183
+division	British Virgin Islands	18.4024395	-64.5661642
+division	Brod-Posavina County	45.2444285	17.9232927
+division	Brugge	51.205987	3.226255
+division	Brunei	4.5353	114.7277
+division	Brussels	50.8503	4.3517
+division	Bryansk	52.8873315	33.415853
+division	Bryansk Oblast	52.8873315	33.415853
+division	Bucharest	44.4268	26.1025
+division	Budapest	47.482728	19.084269
+division	Bueng Kan	18.3658615	103.6511582
+division	Buenos Aires	-34.6037	-58.3816
+division	Bukhara Region	40.229366	63.5470584
+division	Bulgaria	42.6073975	25.4856617
+division	Bungoma	0.78292445	34.71916810731902
+division	Buraimi	24.268575	55.826808
+division	Burgas	42.446600000000004	27.20620689265119
+division	Burgenland	47.517438	16.468160
+division	Buriram	14.9955693	103.1079187
+division	Burkina Faso	12.789980	-1.683734
+division	Bursa	40.1827657	29.0677305
+division	Burundi	-3.3634357	29.8870575
+division	Buryatia	52.311711	108.916732
+division	Bushehr	28.8936645	51.3204877
+division	Busia	0.3712048	34.26479520608315
+division	Buskerud	59.5435778	11.4230694
+division	Buzau	45.143297	26.816251
+division	Caaguazu	-25.4661756	-56.0181685
+division	Caazapá	-26.166667	-56.0
+division	Cabinda	-5.056395	12.3211749
+division	Cabo Delgado	-12.4254942	39.4168743
+division	Cabo Verde	16.0000552	-24.0083947
+division	Cacak	43.891816	20.362815
+division	Cagayan Valley	17.677229	121.88902982109876
+division	Cahul	45.9044087	28.1946583
+division	Cairo	30.041045	31.237176
+division	Cajamarca	-6.25	-78.833333
+division	Calabarzon	14.1638114	121.35366010781269
+division	Calabria	39.0565974	16.5249864
+division	Calarasi	44.315187449999996	27.13901564813344
+division	Caldas	5.314226	-75.340073
+division	Cali	3.420251	-76.522405
+division	California	36.357039	-119.690182
+division	Callao	-12.0522626	-77.1391133
+division	Cambodia	13	105
+division	Cameroon	4.6125522	13.1535811
+division	Camp Lemonnier	11.54254665	43.15624732653296
+division	Campania	40.922286	14.904416
+division	Campeche	19.329205549999998	-89.9439148263377
+division	Canada	61.0666922	-107.991707
+division	Canakkale	40.030844	26.733769
+division	Cañar	-2.574484	-78.9804678
+division	Canary Islands	28.2916	-16.6291
+division	Canelones	-34.6222482	-55.9903797
+division	Canindeyu	-24.25	-55.25
+division	Cantabria	43.1595664	-4.0878382
+division	Canterbury	-43.346635	172.190743
+division	Cao Bang	22.7730867	106.0017225
+division	Capital And Coast	-41.271456689211895	174.7000050015941
+division	Capital Governorate	26.2285	50.5860
+division	Caqueta	1.1153385	-74.1056838
+division	Carabobo	10.166667	-68.083333
+division	Caraga	9.2471392	125.85578188652231
+division	Carchi	0.8375163	-78.2075154
+division	Carinthia	46.7500001	13.8333333
+division	Carlow	52.69053605	-6.8250188975846555
+division	Carlsbad	50.2304694	12.8710769
+division	Cartago CO	4.748755	-75.928118
+division	Cartago CR	9.864015	-83.917122
+division	Casablanca	33.589370	-7.604170
+division	Casanare	5.5000085	-71.5000086
+division	Cascades	10.30718125	-4.435189320350396
+division	Caslavice	49.1522142	15.7724036
+division	Castel di Sangro	41.784	14.108
+division	Castilla la Mancha	39.2796	-3.0977
+division	Castilla y Leon	41.8357	-4.3976
+division	Catalunya	41.834815	1.606414
+division	Catamarca	-27.1910825	-67.105374
+division	Cauca	2.473774	-76.864221
+division	Causeni	46.6395913	29.4056631
+division	Cavan	54.03497495	-7.2937022825583675
+division	Cayman Islands	19.703182249999998	-79.9174627243246
+division	Cayo	16.94779405	-88.89088792620106
+division	Cazin	44.9690	15.9432
+division	Ceará	-5.4984	-39.3206
+division	Čelinac	44.724001	17.324755
+division	Celje	46.2293889	15.2616828
+division	Center Kalimantan	-2.2072919	113.9164372
+division	Central African Republic	7.0323598	19.9981227
+division	Central Banat District	45.4481444	20.8551358
+division	Central Bohemian Region	49.860420	14.668725
+division	Central District BW	-21.4790187	26.2154174
+division	Central District IL	31.9521	34.9066
+division	Central Greece	38.58000405	23.151988380646536
+division	Central Hungary	47.360008	19.252798
+division	Central Jakarta	-6.18233995	106.84287153600738
+division	Central Java	-5.6259648	110.37164897312938
+division	Central Kenya	-0.5843453000000001	36.969678675807025
+division	Central Luzon	15.390911849999998	120.68569951248944
+division	Central Macedonia	40.63697225	22.87548941816365
+division	Central Nepal	27.677801648807623	85.44039791982269
+division	Central Paraguay	-25.529981312294687	-57.47831007202186
+division	Central Province	7.3819490000000005	80.72342798602898
+division	Central Region	5.7244148	-1.3761749
+division	Central Region GH	5.7244148	-1.3761749
+division	Central Region MW	-13.744272500000001	33.712042353397834
+division	Central Region UG	-0.750285	31.4527977
+division	Central Sulawesi	-1.6937786	120.8088555
+division	Central Uganda	0.32690195	32.58405552994708
+division	Central Visayas	10.264054	123.86939597334481
+division	Central Zambia	-14.183507	29.0375543
+division	Centrale Region TG	8.607113	1.0458553669392443
+division	Centre	12.36732	-1.5430869129979032
+division	Centre BF	12.3200255	-1.5280584
+division	Centre CM	3.8455898	11.492962
+division	Centre Region	4.7110718279033685	11.99038925972398
+division	Centre-Val de Loire	47.481221	1.698793
+division	Cerro Largo	-32.333333	-54.333333
+division	Cesar	9.654915	-73.528255
+division	Cetinje	42.389633	18.9246085
+division	Ceuta	35.888361	-5.304138
+division	Chachoengsao	13.6093192	101.5467201
+division	Chaco	-26.3829647	-60.8816092
+division	Chad	15.6134137	19.0156172
+division	Chai Nat	15.1853305	100.1250568
+division	Chaiyaphum	16.2720349	101.7153824
+division	Chalkidiki	40.28948215	23.409392443373925
+division	Chandigarh	30.7334421	76.7797143
+division	Changhua County	24.0755667	120.5444667
+division	Chanthaburi	12.9081033	102.0159145
+division	Charleroi	50.418039	4.440646
+division	Charles Hill	-22.279611	20.073887
+division	Chattogram	22.3569	91.7832
+division	Cheb	50.0793511	12.3703526
+division	Chechen	43.4023	45.7187
+division	Chechen Republic	43.3976147	45.6985005
+division	Chelyabinsk	54.4319	60.8789
+division	Cherkasy	49.1460165	31.2271744
+division	Chernivtsi	48.2633717	25.9504602
+division	Chhattisgarh	21.6637359	81.8406351
+division	Chiang Mai	18.7882778	98.9868056
+division	Chiang Rai	19.7589517	99.6734592
+division	Chiapas	16.520858	-92.643133
+division	Chiayi City	23.4811089	120.4535412
+division	Chiba	35.463961	140.223882
+division	Chihuahua	28.633	-106.0691
+division	Chile	-31.7613364	-71.3187696
+division	Chimaltenango	14.6539748	-90.92727412053142
+division	Chimborazo	-1.9262626	-78.7297799
+division	China	33.394333	104.689839
+division	Chiquimula	14.6891037	-89.3959868807435
+division	Chiriqui	8.3971129	-82.3223443
+division	Chisinau	47.0244707	28.8322534
+division	Choco	5.705238	-76.890815
+division	Choluteca	13.3696253	-87.07564445652513
+division	Chonburi	13.1857117	101.1210777
+division	Chongqing	29.858721	107.375623
+division	Chtouka	33.3136606	-8.1672835
+division	Chubu	35.183334	136.899994
+division	Chubut	-43.7128356	-68.7461817
+division	Chungcheongnam	36.685948	126.799198
+division	Chuquisaca	-19.0477251	-65.2594306
+division	Chushikoku	34.237636	133.058999
+division	Chuvash Republic	55.4259922	47.0849429
+division	Chyne	50.0606462	14.2272998
+division	Cimislia	46.5214777	28.7832993
+division	Clare	52.857257450000006	-8.937435925994537
+division	Cluj	46.83694611603694	23.714428530857838
+division	Cluj Napoca	46.769379	23.5899542
+division	Coahuila	27.3333331	-102.0000001
+division	Cochabamba	-17.401245799999998	-66.1676392078777
+division	Cocle	8.4604873	-80.4305652
+division	Coimbra	40.2033	-8.4103
+division	Colima	19.166667	-104.0
+division	Colombia	2.893108	-73.7845142
+division	Colombo	6.9349969	79.8538463
+division	Colon	9.3553005	-79.8974085
+division	Colón Department	15.748009485658718	-85.6185722612813
+division	Colon Province	9.222399517951887	-80.02471661621364
+division	Colonia	-34.4698592	-57.8433679
+division	Colorado	39.5501	-105.7821
+division	Comayagua	14.55509585	-87.67794635681561
+division	Comines	45.8175	13.7483
+division	Comunitat Valenciana	39.337	-0.354
+division	Conakry	9.5170602	-13.6998434
+division	Concepción	-22.79407055	-57.27154546573678
+division	Connecticut	41.678117	-72.669773
+division	Constanta	44.1598	28.6348
+division	Copán	14.8954912	-88.92572717284826
+division	Copenhagen	55.6761	12.5683
+division	Copperbelt	-13.0214171	27.8876177
+division	Coquimbo	-30.7546652	-70.9005536
+division	Cordillera	-25.25	-57.0
+division	Cordillera Administrative Region	17.35971005	121.07525291788875
+division	Cordoba AR	-31.402893	-64.191608
+division	Cordoba CO	8.342953	-75.757692
+division	Cork	51.895349	-8.474381
+division	Corozal	18.2242711	-88.29194387759722
+division	Corrientes	-28.5912315	-57.9394658
+division	Corse	42.188089649999995	9.068413771427695
+division	Cortés	15.477399850000001	-88.03421491859675
+division	Costa Rica	10.2735633	-84.0739102
+division	Côte d'Ivoire	7.9897371	-5.5679458
+division	Cotonou	6.372284	2.365266
+division	Cotopaxi	-3.4804754	-80.2302215
+division	Counties Manukau	-37.101403	175.005947
+division	Covasna	45.896679250000005	26.010180611745668
+division	Cox'S Bazar	21.16587175	92.03996424949702
+division	Coyah	9.709041	-13.388956
+division	Crete	35.3084749	24.463320724202934
+division	Crimea	45.28350435	34.20081877526554
+division	Croatia	45.1	15.2
+division	Cross River State	5.8671966	8.5204774
+division	Csongrád County	46.7084	20.1436
+division	Cuando Cubango	-16.0457694	19.5621532
+division	Cuanza Norte	-9.0296752	15.0926324
+division	Cuanza Sul	-10.7707527	15.0975712
+division	Cuba	23.0131338	-80.8328748
+division	Cumilla	23.4610615	91.1808748
+division	Cundinamarca	5.049758	-74.076048
+division	Cunene	-16.5568536	15.7867319
+division	Cuprija	43.9335612	21.3712355
+division	Curacao	12.1845	-68.9640875031406
+division	Cuzco	-13.5170887	-71.9785356
+division	Cyprus	34.965802	33.171772
+division	Czech Republic	49.8175	15.473
+division	Da Nang	16.068	108.212
+division	Dabola	10.742172	-11.106486
+division	Dadra and Nagar Haveli	20.2733604	73.0044988
+division	Dadra and Nagar Haveli and Daman and Diu	20.718174949999998	70.93238341010638
+division	Daegu	35.8713	128.6018
+division	Dagestan	43.0574916	47.1332224
+division	Dakar	14.725966	-17.46181
+division	Dakhiliyah	22.316676	57.359135
+division	Dakhla	23.6940663	-15.9431274
+division	Dala	-5.930523	15.1101404
+division	Dalarna	61.0917	14.6664
+division	Dambovita	44.92677275	25.48318210912525
+division	Damitta	31.4167427	31.8213657
+division	Dandé	11.578919549999998	-4.555904567599022
+division	Darien	8.2158991	-78.0172551
+division	Daule	-1.92000685	-79.91293069792368
+division	Davao Region	6.61093365	125.37823858699517
+division	Debar	41.523466	20.5269779
+division	Debrecen	47.5316	21.6273
+division	Delaware	38.6920451	-75.4013315
+division	Delhi	28.7041	77.1025
+division	Delta	5.5273061	6.1784167
+division	Delta Amacuro	8.6282101	-61.5648108
+division	Democratic Republic of the Congo	-4.0383	21.7587
+division	Dendermonde	51.032573	4.099329
+division	Denizli	37.7830	29.0963
+division	Denmark	56.2639	9.5018
+division	Departamento Colon	15.7110008623772	-85.62402914640445
+division	Departamento de Amazonas	-1.420517	-71.257925
+division	Departamento Florida	-33.77756072100707	-55.89156584305957
+division	Departamento Rio Negro	-32.74987614834329	-57.488110257077594
+division	Departamento San Jose	-34.270719079415876	-56.750977760339524
+division	Dhaalu Atoll	2.8349032000000003	72.93193262805516
+division	Dhahirah	22.65052325	56.0616295382364
+division	Dhaka	23.789370	90.415192
+division	Dhi Qar Province	31.464444	45.1025
+division	Dhofar	18.2356054	54.266734945996774
+division	Diamond Princess	35.046935	139.419325
+division	Diana	-12.2735552	49.2845719
+division	Diebougou	10.964809299999999	-3.267444061847092
+division	Diksmuide	51.050218	2.859454
+division	Dimbokro	6.6494254	-4.7040555
+division	Dinajpur	25.6260712	88.6346228
+division	Dinant	50.239336	4.939426
+division	Diourbel	14.7043898	-16.0511737
+division	Distrito Capital	10.5053491	-66.9147206
+division	Distrito Federal	-15.7998	-47.8645
+division	Djelfa	34.342841	3.217253079090331
+division	Djibouti	11.85677545	42.757784519943655
+division	Dnipro	48.4680221	35.0417711
+division	Dobrich	43.663634	27.900177939598652
+division	Doha	25.270283	51.52297
+division	Dolakha	27.757778	86.033737
+division	Doľany	49.021347	20.647670680715226
+division	Dolj	44.2141283	23.669234908203126
+division	Dolnośląskie	51.122543	16.404924
+division	Dolny Kubin	49.2145239	19.2953168
+division	Dominica	15.4185147	-61.3363561
+division	Dominican Republic	19.0974031	-70.3028026
+division	Donegal	54.92075415	-7.952385214651309
+division	Donezk	47.95860355706318	37.772593605438416
+division	Donostia-San Sebatian	43.306272	-1.979035
+division	Douala	4.0429408	9.706203
+division	Drahovce	48.5183461	17.7985046
+division	Drama	41.1499443	24.1468286
+division	Drenthe	52.846963	6.608915
+division	Dschang	5.4469923	10.053309
+division	Dubai	25.0750095	55.18876088183319
+division	Dubasari	47.26707351140303	29.156212273744096
+division	Dublin	53.3431	-6.262191
+division	Dubnica Nd Váhom	48.969555799999995	18.153944404948856
+division	Dubréka	9.7889809	-13.5169725
+division	Dubrovnik	42.651307	18.102801
+division	Dubrovnik-Neretva County	42.7580845	17.3352326
+division	Duesseldorf	51.236437	6.809537
+division	Dupnitza	42.2613	23.1125
+division	Durango	24.019546	-104.658028
+division	Durazno	-33.0833329	-56.0833331
+division	East Azerbaijan Province	37.9211202	46.6821517
+division	East Java	-7.6977397	112.4914199
+division	East Kalimantan	0.241323	116.558975
+division	East-Kazakhstan Region	48.6130209	81.7489928
+division	East Kenya	0.6929497	38.494159425156525
+division	East New Britain	-5.1386278	151.9020187
+division	East Nusa Tenggara	-8.5656787	120.6978581
+division	East Region	3.802043097500812	14.25634550776261
+division	Eastern Bohemia	50.09432848142632	16.008774307550546
+division	Eastern Cape	-32.344458	26.497832
+division	Eastern Macedonia and Thrace	41.1271333	25.09323306309048
+division	Eastern Paraguay	-24.515009819513484	-56.26350946272442
+division	Eastern Province	23.3036077	50.1258804
+division	Eastern Province LK	7.64857989585601	81.52923095002983
+division	Eastern Province RW	-1.9510033	30.435394426431735
+division	Eastern Province SA	23.3036077	50.1258804
+division	Eastern Region GH	6.2583714101413825	-0.5894044915588438
+division	Eastern Region MK	41.90338969322595	22.44468002723218
+division	Eastern Visayas	11.327827249999999	124.99755612215378
+division	Eastern Zambia	-13.252682328968941	32.228763385086225
+division	Ebolowa	2.71091425	11.253788461354606
+division	Ebonyi	6.1996918	8.0348906
+division	Ecuador	-1.3397667	-79.3666964
+division	Edessa	40.8009492	22.050117
+division	Edo	6.6076575	5.9722713
+division	Eeklo	51.193464	3.562381
+division	Egypt	26.2540493	29.2675469
+division	Ehime	33.6013646	132.8185275
+division	Ekiti State	7.736891	5.2738326
+division	El Oro	-3.498709232958782	-79.848108566191
+division	El Oued	33.215441	7.155321399098325
+division	El Paraíso	13.9619099	-86.56281611342774
+division	El Progreso	14.852206	-90.0648909
+division	El Salvador	13.8000382	-88.9140683
+division	Elad	32.0495	34.9507
+division	Eldoret	0.5118422	35.2341926
+division	Elgeyo Marakwet	0.7433817	35.561618320756416
+division	Elkana	32.1106	35.0321
+division	Emilia-Romagna	44.641437	11.119072
+division	England	52.405994	-1.671707
+division	Entre Rios	-31.6252842	-59.3539578
+division	Enugu	6.5536094	7.4143061
+division	Epirus	39.649766299999996	20.69097798672906
+division	Equatorial Guinea	1.613172	10.5170357
+division	Erbil	36.1911624	44.0094652
+division	Erongo	-22.0278147	15.389358
+division	Eschen	47.2126274	9.5233202
+division	Escuintla	14.3022857	-90.7866243
+division	Eskisehir	39.773703	30.518708
+division	Esmeraldas	0.7343619	-79.3858867
+division	Espirito Santo	-19.1834	-40.3089
+division	Estado de Mexico	19.4839446	-99.6899716
+division	Estonia	59	26
+division	Ethiopia	9.1450	40.4897
+division	Europe	49.646237	10.799454
+division	Évora	38.5707742	-7.9092808
+division	Evros	40.0809716	23.978897
+division	Extremadura	39.1748426	-6.1529891
+division	Fagge	12.0121343	8.5101018
+division	Faiyum	29.340736999999997	30.61964337571458
+division	Falcon	11.0	-69.833333
+division	Far North	-22.7789702	29.4285175
+division	Faroe Islands	62.157709	-6.987672
+division	Federal Capital Territory	8.8311228	7.1724673
+division	Feeali	3.2703179	73.0022072
+division	Fejer	47.0939434	18.6088562
+division	Fergana Region	40.5	71.25
+division	Ferizaj	42.3682168	21.1532848
+division	Ferkessedougou	9.5939778	-5.1975952
+division	Fianarantsoa	-21.456444	47.085149
+division	Fiji	-18.1239696	179.0122737
+division	Finland	61.751734	26.186437
+division	Flacq	-20.221731249999998	57.72234951618523
+division	Flanders	51.096246199999996	4.178629103169916
+division	Flandre-Orientale	51.016552	3.770099
+division	Flemish Brabant	50.8686516	4.7886237984620905
+division	Flevoland	52.48851	5.615829
+division	Flines-lès-Mortagne	50.5037	3.4641
+division	Flores	-33.583333	-56.833333
+division	Florida	27.6648	-81.5158
+division	Florina	40.779442	21.407594
+division	Fomboni	-12.2911897	43.7275632
+division	Forecariah	9.4300088	-13.0833859
+division	Formosa	-24.5955306	-60.4289718
+division	France	46.2276	2.2137
+division	Francisco Morazán	14.34304775	-87.11422636083512
+division	Francistown	-21.16636	27.502515
+division	Free State	-28.7853618	26.4978933
+division	Freiburg	46.8030044	7.1512891
+division	French Guiana	4.0039882	-52.999998
+division	Fribourg	46.804570	7.162854
+division	Friesland	53.1642	5.7818
+division	Friuli Venezia Giulia	46.2259	13.1034
+division	Fujian	26.284852	118.122938
+division	Fukui	35.9263502	136.6068127
+division	Fukuoka	33.6251241	130.6180016
+division	Fukushima	37.3662591	140.2511854
+division	Gaafu Alifu Atoll	7.025023	75.9545415609148
+division	Gaafu Dhaalu Atoll	0.53066445	72.99862566360878
+division	Gabon	-0.8999695	11.6899699
+division	Gaborone	-24.6581357	25.9088474
+division	Gabrovo	42.96597	25.21308065823368
+division	Gafsa	34.43367	8.79079875204918
+division	Galapagos	-0.62881505	-90.3638752022324
+division	Galati	45.4338215	28.0549395
+division	Galicia	42.5751	-8.1339
+division	Galle	6.0328139	80.214955
+division	Galway	53.2744122	-9.0490632
+division	Gambia	13.5	-15.5
+division	Gampaha	7.0925595	79.9951396
+division	Gamprin-Bendern	47.218268329898166	9.511064043646217
+division	Gandaki	27.86266215	84.69527530316
+division	Gani Tikva	32.06111	34.87444
+division	Gansu	38.0000001	101.9999999
+division	Garoua	9.3070698	13.3934527
+division	Gasabo	-1.8834562	30.0630569
+division	Gauteng	-26.199815	28.110057
+division	Gavleborgs Lan	61.514766	16.400925
+division	Gaza	-23.328398	32.8066057
+division	Gedera	31.8123	34.7770
+division	Gelderland	52.042091	6.01486
+division	Geneva	46.216038	6.136984
+division	Gent	51.04154	3.697961
+division	Georgia	32.1656	-82.9001
+division	Georgia (Asia)	42.013868	43.575124
+division	Germany	51.1657	10.4515
+division	Gevgelija	41.1388664	22.5033192
+division	Ghana	8.0300284	-1.080027
+division	Ghanzi District	-22.145794	22.7610828
+division	Giannitsa	40.7929908	22.4140645
+division	Gibraltar	36.140807	-5.3541295
+division	Gicumbi	-1.6186575	29.969704
+division	Gifu	35.7867449	137.0460777
+division	Gilan	37.5115476	49.355442984970665
+division	Gilgit Baltistan	35.589113	75.614837
+division	Giurgiu	43.8959058	25.9658111
+division	Giza	29.9870753	31.2118063
+division	Gjilan	42.463515	21.4693599
+division	Glarus	47.018842	8.979742
+division	Goa	15.3004543	74.0855134
+division	Gobojango	-21.8166465	28.7745568
+division	Goiais	-15.932272	-49.593573
+division	Goiás	-15.8270	-49.8362
+division	Golfe	6.1862688469732365	1.2239741907971098
+division	Gomel Region	52.4238936	31.0131698
+division	Goodhope	-25.4329313	25.4091599
+division	Gorazde	43.6685	18.9749
+division	Gorenjska	46.2636081	14.158939180045914
+division	Gorgan	36.8392776	54.4320858
+division	Goriska	46.10411015	13.812337532144351
+division	Gorj	44.961167450000005	23.325679902293135
+division	Gornji Vakuf	43.9375	17.5880
+division	Gorontalo	0.7186174	122.4555927
+division	Gostivar	41.7920222	20.9081703
+division	Gotland	57.4174802	18.536957927499856
+division	Goumenissa	40.9466441	22.4519413
+division	Grand Canary Islands	27.9202	-15.5474
+division	Grand Cape Mount	7.0496206	-11.129843
+division	Grand Est	48.691467	5.566495
+division	Grand Lome	6.4206767	1.2115914
+division	Grand Port	-20.40385065	57.63305171301659
+division	Grand Princess	37.579905	-123.67313
+division	Grand Princess 2nd cruise	38.579905	-124.67313
+division	Graubünden	46.709551	9.606903
+division	Greater Accra	5.761619	0.040546
+division	Greece	39	22
+division	Grenada	12.1360374	-61.6904045
+division	Grevena	40.0856892	21.4284718
+division	Groningen	53.2190652	6.5680077
+division	Guadalajara	20.676026	-103.332671
+division	Guadeloupe	16.2490067	-61.5650444
+division	Guaira	-25.75	-56.5
+division	Guam	13.464887	144.792016
+division	Guanacaste	10.489280	-85.455092
+division	Guanajuato	20.9876996	-101.0
+division	Guangdong	23.615762	114.483257
+division	Guangxi	23.717754	108.701872
+division	Guardav	40.5308	-7.2221
+division	Guatemala	15.6356088	-89.8988087
+division	Guatemala City	14.6222328	-90.5185188
+division	Guaviare	1.6894444	-72.8202864
+division	Guayas	-1.9575	-79.9193
+division	Gueckedou	8.561649	-10.132821
+division	Guerrero	17.463444	-99.792052
+division	Guiania	2.5000086	-69.0000086
+division	Guiglo	6.43034025	-7.5909032112704775
+division	Guinea	10.7226226	-10.7083587
+division	Guinea-Bissau	12.100035	-14.9000214
+division	Gujarat	22.2587	71.1924
+division	Guna Yala	9.20030225	-77.93252243147037
+division	Gunma	36.52198	139.033483
+division	Guranwala	30.1033919	70.6270825
+division	Guyana	4.8417097	-58.6416891
+division	Gwale	11.9813175	8.4803473
+division	Gwangju	35.1595775	126.8515089
+division	Gyeonggi Province	37.397957	127.380864
+division	Győr-Moson-Sopron County	47.6610134	17.3796437
+division	Ha Nam	20.5269088	105.9543527
+division	Ha Tinh	18.2879059	105.7842774
+division	Haa Alif Atoll	7.00898255	72.92348820538749
+division	Haa Dhaalu Atoll	6.3103185	72.61034925814599
+division	Hadžići	43.8226456	18.2025181
+division	Hai Duong	20.9443681	106.3780373
+division	Hai Phong	20.858864	106.6749591
+division	Haifa District	32.62574995	34.98251402462225
+division	Hainaut	50.524821	3.976235
+division	Haiti	19.1399952	-72.3570972
+division	Hajdú-Bihar County	47.4407848	21.4752281
+division	Halland	56.964727	12.796906
+division	Halle-Vilvoorde	50.927353	4.424742
+division	Hambantota	6.1249126	81.1242563
+division	Hamburg	53.5437641	10.0099133
+division	Hamedan	34.7983271	48.5148499
+division	Hangzhou	30.2741	120.1551
+division	Hanoi	21.0278	105.8342
+division	Harare	-17.831773	31.045686
+division	Hardap	-24.4140944	17.4134051
+division	Harhoura	33.914435	-6.970269
+division	Harjumaa	59.4090892	24.73689671734141
+division	Haryana	29.0588	76.0856
+division	Haskovo	41.7637519	25.925984569140283
+division	Hasselt	50.925347	5.311394
+division	Haut-Katanga	-10.457682	27.690512
+division	Haut-Ogooue	-1.638962	13.5895258
+division	Haut-Uélé	2.7936527	27.6435943
+division	Haute Matsiatra	-21.44975755	47.08703075
+division	Hauts-Bassins	11.389027500000001	-4.041364986476256
+division	Hauts de France	49.934396	2.783002
+division	Hawaii	19.8968	-155.5828
+division	Hawali	29.3378	48.0235
+division	Hawalli	29.32287695	48.11628897398228
+division	Hawkes Bay	-39.4343279	176.7652742
+division	Hebei	39.0000001	116.0
+division	Hebron	31.528902	35.0944873
+division	Heilongjiang	47.286490	127.992676
+division	Helsinki	60.1698848	24.9384991
+division	Henan	33.817629	113.690243
+division	Herceg Novi	42.4517622	18.5367516
+division	Heredia	9.997549	-84.121162
+division	Herrera	7.8432774	-80.75877048589277
+division	Herselt	51.0524	4.8807
+division	Herzegowina-Neretva	43.2454799	17.791328206678866
+division	Herzogenrath	50.8684545	6.0950514
+division	Hesse	50.6118537	9.1909725
+division	Heverlee	50.8626	4.6959
+division	Heves County	47.8058	20.2039
+division	Hhohho	-26.1022695	31.364094517500757
+division	Hidalgo	20.5	-99.0
+division	Hiiu	58.8373105	22.6659817
+division	Himachal Pradesh	31.81676015	77.34932051968858
+division	Himandhoo	3.9209208	72.7447785
+division	Himmafushi	4.3085207	73.57141546823254
+division	Hincesti	46.8302002	28.5871433
+division	Hiroshima	34.3916058	132.4518156
+division	Hlohovec	48.4278838	17.798782
+division	Hnusta	48.5787043	19.9531888
+division	Ho Chi Minh City	10.790417	106.653985
+division	Hoa Binh	20.6609177	105.3924747
+division	Hokkaido	43.2203	142.8635
+division	Hokuriku	37.9154	139.0356
+division	Hokurikushinsyu	36.708064	137.806500
+division	Holon	32.0158	34.7874
+division	Holsbeek	50.9211	4.7570
+division	Homa Bay	-0.5628536	34.3187808351349
+division	Hon-Hergies	50.3266071	3.8206409
+division	Honduras	15.2572432	-86.0755145
+division	Hong Kong	22.3964	114.1095
+division	Hormozgan	27.7198095	56.335807
+division	Hostivice	50.0815167	14.2585743
+division	Houthalen-Helchteren	51.0312	5.3765
+division	Hovedstaden	55.86170985	12.313743483194546
+division	Howland Island	0.8075145	-176.61686999040523
+division	Hradec Králové Region	50.2094963	15.832719
+division	Hranice Na Moravě	49.5497	17.7349
+division	Hsinchu County	24.8267	121.0128333
+division	Huambo	-12.6076318	15.7411039
+division	Huancavelica	-13.0	-75.0
+division	Huanuco	-9.893964	-76.299456
+division	Huasco	-28.467340	-71.221674
+division	Hubei	31.095477	112.676644
+division	Huehuetenango	15.6634185	-91.5839796
+division	Huila AO	-14.691078668962609	14.901093717998128
+division	Huila CO	2.6114582592556297	-75.56243492125189
+division	Hukuk	32.8798972	35.4958000
+division	Humenne	48.9350033	21.9020268
+division	Hunan	27.6662087	111.7487063
+division	Hunedoara	45.7958547	22.944483784106403
+division	Hung Yen	20.8193369	106.0314504
+division	Hungary	47	20
+division	Huraa	4.33383905	73.60198247100672
+division	Huy	50.510704	5.209278
+division	Hyogo	34.914934	134.860666
+division	Ialomița	44.5975731	27.203076221241535
+division	Iasi	47.1615341	27.5836142
+division	Ibaraki	36.2869536	140.4703384
+division	Ica	-14.079922	-75.740852
+division	Iceland	64.9841821	-18.1059012
+division	Ida-Viru	59.3477264	28.1693889
+division	Idaho	43.810421	-114.351215
+division	Ieper	50.857716	2.874138
+division	Ilava	48.9985674	18.2307598
+division	Ile de France	48.724751	2.491522
+division	Ilfov	44.5017074	26.244907651159284
+division	Ilidza	43.8314	18.3002
+division	Ilijas	43.9486	18.2649
+division	Illinois	40.088552	-89.301876
+division	Ilocos	17.2046698	120.4703870788443
+division	Imathia	40.51703795	22.18071972652394
+division	Imbabura	0.3753621	-78.355681
+division	Imo	5.5859456	7.0669651
+division	India	21.077353	78.723951
+division	Indiana	40.2672	-86.1349
+division	Indonesia	0.240253	114.878847
+division	Ingushetia	43.11542075	45.01713552301937
+division	Inhambane	-22.779116	34.5661741
+division	Innlandet	61.26810555	10.485458802304304
+division	Ioannina	39.6639818	20.8522784
+division	Ionian Islands	39.4715111	19.9370027
+division	Iowa	41.878	-93.0977
+division	Iran	34.5732	51.876
+division	Iraq	33.0955793	44.1749775
+division	Iraqi Kurdistan	36.4239244	44.3283934
+division	Irbid	32.5568	35.8469
+division	Ireland	52.865	-7.979
+division	Irkutsk Region	56.6370122	104.719221
+division	Isfahan	32.6707877	51.6650002
+division	Ishikawa	36.570185	136.732454
+division	Islamabad	33.714095	73.066832
+division	Islamabad Capital Territory	33.63573935	73.20311557158395
+division	Israel	31.5	34.75
+division	Istanbul	41.0082	28.9784
+division	Istria	45.189488	13.889205
+division	Italian cruise ship	41.831176	11.491061
+division	Italy	43.382775	12.183629
+division	Itapúa	-26.833333	-55.833333
+division	Itasy	-19.0535322	46.99220107204388
+division	Ivanka Pri Dunaji	48.1885931	17.2578039
+division	Ivano-Frankivsk	48.9225224	24.7103188
+division	Ivanovo	57.04529735	41.37804415061976
+division	Ivory Coast	7.9897371	-5.5679458
+division	Iwate	39.9724169	141.2124422
+division	Ixelles	50.8333	4.3666
+division	Izabal	15.7379098	-88.5888038
+division	Järva	58.882046	25.5509865
+division	Jahra	29.498561549999998	47.544040757906274
+division	Jakarta	-6.221537	106.838429
+division	Jalapa	14.65079355	-89.93908531263284
+division	Jalisco	20.422362	-103.793697
+division	Jamaica	18.1096	-77.2975
+division	Jambi	-1.6454854	102.93517597904014
+division	Jambyl Region	44.4168463	72.134166
+division	Jammu	32.7266	74.8570
+division	Jammu and Kashmir	33.796268	76.481097
+division	Jamtland	63.1712	14.9592
+division	Jamtland Harjedalen	62.162882	13.755564
+division	Japan	35.68536	139.75309
+division	Jarva Maakond	58.9380564	25.73324175837961
+division	Jarvis Island	-0.37228059999999996	-159.99736118989586
+division	Jász-Nagykun-Szolnok County	47.2556	20.5232
+division	Jatov	48.1284623	18.028264
+division	Jeddah	21.4858	39.1925
+division	Jenin	32.4618837	35.297566
+division	Jeonnam	34.8159	126.4629
+division	Jericho	31.855987	35.4598851
+division	Jerusalem	32.1142635	35.0344905
+division	Jerusalem District	31.7648	34.9948
+division	Jesenice	46.4323791	14.0623337
+division	Jharkhand	23.4559809	85.2557301
+division	Jhenaidha	23.547692	89.175424
+division	Jiangsu	33.077761	119.825116
+division	Jiangxi	27.458973	115.535326
+division	Jihlava	49.3984	15.5870
+division	Jihocesky Kraj	49.0864548	14.600172741470452
+division	Jihomoravsky Kraj	49.1249179	16.682771628867208
+division	Jilin	42.9995032	125.9816054
+division	Jining	35.4125047	116.5849266
+division	Johnson Atoll	16.730014876272758	-169.53297092697503
+division	Johor	2.0229012	103.3147721
+division	Jonavos Apskritis	55.11587936658516	24.28549931199114
+division	Jonkoping	57.7826	14.1618
+division	Jordan	31.1667049	36.941628
+division	Judea and Samaria	31.9471636	35.38157137271088
+division	Jugovzhodna	45.7217251	14.901382167933114
+division	Jujuy	-23.3161458	-65.7595288
+division	Junik	42.4761209	20.2773737
+division	Junin	-11.5	-75.0
+division	Jura	47.368929	7.163449
+division	Jutiapa	14.14768595	-89.88725080941776
+division	Jõgeva	58.7634819	26.399928038398983
+division	Kaafu Atoll	4.95876855	73.46352773909533
+division	Kabardino-Balkaria	43.4428286	43.4204809
+division	Kabul	34.5260109	69.1776838
+division	Kaduna State	10.3825318	7.8533226
+division	Kagawa	34.22908906089769	133.9909139071147
+division	Kaggevinne	50.9794	5.0190
+division	Kagoshima	31.521587	130.5474077
+division	Kahramanmaras	37.7830345	36.830655
+division	Kaisiadorys	54.8602337	24.4544785
+division	Kajiado	-2.12171705	36.78625503675998
+division	Kakamega	0.4957104	34.801548861634615
+division	Kakanj	44.1280	18.1178
+division	Kalasin	16.4320082	103.506929
+division	Kalimantan Selatan	-2.9285686	115.3700718
+division	Kalinga	17.46	121.31
+division	Kaliningrad Region	54.7293041	21.1489473
+division	Kalmar	56.6634	16.3568
+division	Kalmykia	46.495588	45.44294457678551
+division	Kaluga	54.3141064	35.324112237538515
+division	Kalutara	6.5835219	79.9612508
+division	Kalyoubia	30.283113	31.247786
+division	Kamchatka Krai	57.1914882	160.0383819
+division	Kamenicna	47.8162871	18.0426149
+division	Kamnik	46.2257358	14.6118936
+division	Kampala	0.3177137	32.5813539
+division	Kamphaeng Phet	16.4183581	99.6111616
+division	Kamphaengphet	16.4183581	99.6111616
+division	Kanagawa	35.403801	139.294288
+division	Kanchanaburi	14.44019	99.2676727
+division	Kandy	7.2930922	80.6350768
+division	Kankan	10.6248355	-9.3175166
+division	Kano State	11.8948389	8.5364136
+division	Kansai	34.778675	135.880055
+division	Kansas	39.0119	-98.4842
+division	Kanta-Häme	60.93769605	24.15319200958258
+division	Kanto	36.167777	139.170466
+division	Kapilvastu	27.61923765	82.98222657989004
+division	Karachay-Cherkess	43.7368326	41.7267991
+division	Karachi	24.8607	67.0011
+division	Karaganda Region	48.1144938	70.1404868
+division	Karaj	35.82478305	50.95955469625573
+division	Karaman	37.165058	33.294127
+division	Kardzhali	41.57161625	25.399198889947556
+division	Karelia	62.6194031	33.4920267
+division	Kargil	34.5539	76.1349
+division	Karlovac County	45.2826564	15.4190997
+division	Karlovarsky Kraj	50.1753532	12.806086309968043
+division	Karlovy Vary	50.2304694	12.8710769
+division	Karnali	29.2989975	82.47499387507119
+division	Karnataka	15.3173	75.7139
+division	Karongi	-2.17395	29.3667295
+division	Kars Province	40.6076749	43.0948497
+division	Kasane	-17.799239	25.156546
+division	Kashmar	35.2444908	58.464248
+division	Kastamonu	41.550202	33.742886
+division	Kastoria	40.5171556	21.2688435
+division	Kasur	31.1175143	74.4478314
+division	Katerini	40.2713616	22.5087618
+division	Kathmandu	27.712907	85.323557
+division	Katiola	8.0912137	-5.150708249056292
+division	Katsina State	12.5630825	7.6207063
+division	Kaulille	51.1872	5.5257
+division	Kauno Apskritis	55.0163259	24.085757831305433
+division	Kavadarci	41.4332802	22.0122593
+division	Kavango	-19.2632632	17.708643
+division	Kavango East	-18.3982355	20.72468
+division	Kavango West	-18.256111	18.970201
+division	Kavre	28.0301754	83.7116467
+division	Kayseri	38.7205	35.4826
+division	Kazakhstan	47.2286086	65.2093197
+division	Kecskemet	46.8964	19.6897
+division	Kedah	5.8098265	100.6715035
+division	Kedainiai	55.2887322	23.9758359
+division	Kedia	-21.3963968	24.619486
+division	Keelung	25.1276	121.7392
+division	Kefalonia	38.17297630358924	20.56537713229682
+division	Kelantan	5.4021302	102.0635972
+division	Kemerovo	54.5335781	87.342861
+division	Kendari	-3.9918068	122.5180066
+division	Kenitra	34.26457	-6.570169
+division	Kentucky	37.649540	-85.450190
+division	Kenya	0.0236	37.9062
+division	Kepulauan Bangka Belitung	-2.7052886	106.3585607
+division	Kepulauan Riau	0.7439240871682783	104.2466702933411
+division	Kerala	10.359825	76.39955
+division	Kericho	-0.3666	35.2833
+division	Kerman	29.571858	57.301047
+division	Kerouane	9.2705687	-9.0076196
+division	Kerry	52.14533445	-9.517401092833236
+division	Keski-Suomi	62.609365800000006	25.579461022851078
+division	Keur Massar	14.7863883	-17.3206958
+division	Kfar Saba	32.180607	34.912861
+division	Kgalagadi District	-24.8490576	21.7883349
+division	Kgatleng District	-24.1447751	26.4204756
+division	Khabarovsk	50.5888	135
+division	Khakassia	53.4399379	90.0664303
+division	Khanty-Mansi	61.0259025	69.0982628
+division	Kharkiv	49.9902794	36.2303893
+division	Khartoum	15.5635972	32.5349123
+division	Khemisset	33.830287	-6.072605
+division	Kherson	46.5421715	33.4079326
+division	Khmelnytskyi	49.4196404	26.9793793
+division	Khomas	-22.9082553	17.09198004041758
+division	Khon Kaen	16.6022387	102.6352933
+division	Khulna	22.815139549999998	89.44492672055918
+division	Khyber Pakhtunkhwa	33.696621	72.636031
+division	Kiambu	-1.03207695	36.815686702129064
+division	Kicukiro	-2.0162752	30.1076243
+division	Kien Giang	9.9113945	105.2533879
+division	Kigali	-1.950851	30.061507
+division	Kildare	53.15436455	-6.8184175660976445
+division	Kilifi	-3.15073925	39.67507159193717
+division	Kilinochchi	9.3840068	80.4087224
+division	Kilkenny	52.6510216	-7.2484948
+division	Kilkis	40.9935874	22.8741455
+division	Kindia	10.1154374	-13.1916883
+division	Kingman Reef	6.41581875	-162.43869642053994
+division	Kinshasa	-4.2978	15.2962
+division	Kirov Oblast	57.9665589	49.4074599
+division	Kiryat Gat	31.6111	34.7685
+division	Kiryat Ono	32.059259	34.859216
+division	Kisantu	-5.1367411	15.0592273
+division	Kishoregonj	24.433904289338148	90.78213209247555
+division	Kisii	-0.7385550000000001	34.757159597379605
+division	Kissidougou	9.2101274	-10.1215917
+division	Kisumu	-0.1029109	34.7541761
+division	Klaipedos Apskritis	55.7826477	21.170343190765912
+division	Kocaeli	40.886367	29.905212
+division	Kochi	33.518628	133.505674
+division	Koersel	51.0584	5.2718
+division	Kogi State	7.7949602	6.6868669
+division	Kolárovo	47.9182347	17.9966591
+division	Kolda	12.9493	-14.4723
+division	Kolubara District	44.3276249	19.85822351638606
+division	Komarno	47.7574079	18.1298249
+division	Komárom-Esztergom	47.6511599	18.2551911
+division	Kombo	13.294035	-16.656832
+division	Komi	63.9881421	54.3326073
+division	Kongo Central	-5.8162516	13.4908753
+division	Konya	37.859743	32.495438
+division	Koprivnica	46.168157	16.827208
+division	Koprivnica-Križevci County	46.12020575	16.779842997977994
+division	Korinthia	37.93081650716975	22.612476654682165
+division	Koroska	46.52317615	15.077925785868148
+division	Kortrijk	50.802287	3.264668
+division	Kosice	48.7164	21.2611
+division	Kosovo	42.6026	20.9030
+division	Kosovska Mitrovica	42.8790424	20.8657862
+division	Kostanay Region	52.0615626	62.9372689
+division	Kostoliste	48.4467	16.9868
+division	Kostroma Region	58.37795228570701	43.268817529168906
+division	Koulikoro Region	12.8646318	-7.5561287
+division	Kozani	40.3007259	21.7883119
+division	Krabi	8.1111653	99.1097298
+division	Kragujevac	44.0125745	20.91877
+division	Kraljevo	43.7238	20.6873
+division	Kralovehradecky Kraj	50.40939265	15.68500539430977
+division	Kralovehradecky Region	50.40939265	15.68500539430977
+division	Kranj	46.2432635	14.3549501
+division	Kranjska Gora	46.485132	13.7843957
+division	Krapina-Zagorje County	46.0983218	15.9377404
+division	Krasnodar	45.6415	39.7056
+division	Krasnoyarsk	64.248	95.1104
+division	Kravany	48.759757	21.6406951
+division	Kribi	2.8655757499999996	9.892047402266869
+division	Krivá	49.2825832	19.4791415
+division	Kronoberg	56.80067805	14.411160995108743
+division	Krusevac	43.5825653	21.326599
+division	Kuala Lumpur	3.139	101.6869
+division	Kujawsko-Pomorskie	53.3220016	18.3392939
+division	Kumamoto	32.6450475	130.6341345
+division	Kunene	-19.6792809	13.9756564
+division	Kunice	49.481491899999995	16.4859933170341
+division	Kursk Region	52.4431763	78.9225201
+division	Kuwait	29.452987	47.447194
+division	Kwale	-4.1836067	39.10509552821773
+division	Kwara State	9.172913	4.409729
+division	KwaZulu-Natal	-28.704798	30.693005
+division	Kweneng District	-23.9028101	24.9214122
+division	Kwilu	-5.0213398	18.8445746
+division	Kyiv	50.4500336	30.5241361
+division	Kyoto	35.007542	135.768455
+division	Kyrgyzstan	41.927675	75.142149
+division	Kyushu	32.4820915	131.10090358324425
+division	Kyustendil	42.2869	22.6939
+division	Kyusyu	32.5900	130.8000
+division	Kyzylorda Region	45.2058853	63.9155202
+division	La Guaira	10.5390525	-67.2104664250707
+division	La Guajira	11.2780115	-72.6135766
+division	La Libertad	-8.0	-78.5
+division	La Libertad PE	-7.99818015717154	-78.57667913824513
+division	La Louvière	50.469989	4.158129
+division	La Pampa	-37.2314643	-65.3972948
+division	La Paz	-16.4955455	-68.1336229
+division	La Paz BO	-16.4955455	-68.1336229
+division	La Paz HN	14.2910717	-87.7912101
+division	La Rioja	42.2871	-2.5396
+division	La Rioja AR	-29.62487279826059	-66.86176517635946
+division	La Rioja ES	42.31366609897772	-2.583157318755303
+division	Laamu Atoll	1.95328225	73.40034650846036
+division	Labe	11.7614835	-12.0118889
+division	Labe Region	11.779801270893191	-12.018973872151442
+division	Ladakh	34.152588	77.577049
+division	Lääne	58.9174716	23.749800066925467
+division	Lääne-Viru	59.2453182	26.3207945
+division	Laghouat	33.750440499999996	2.6431093610595155
+division	Lagos	6.54252	3.286661
+division	Lahore	31.5656822	74.3141829
+division	Laikipia	0.2858452	36.825771076829064
+division	Laken	50.8778	4.3481
+division	Lakes	-38.5882085	175.9492056
+division	Lakshadweep	10.8132489	73.6804620941119
+division	Lalitpur	27.6676649	85.3183888179628
+division	Lambarene	-0.695844	10.2215963
+division	Lambayeque	-6.707066	-79.907239
+division	Lamentin	16.2703423	-61.6303025
+division	Lampang	18.6799728	99.7332501
+division	Lamphun	18.2661422	98.96749
+division	Lampung	-4.8555039	105.0272986
+division	Lamu	-2.2675396	40.9010641
+division	Lanao del Norte	7.963911700000001	123.90410957888747
+division	Landen	39.3120	-84.2830
+division	Lang Son	21.8567012	106.4424353
+division	Lao Cai	22.3381	104.1487
+division	Laois	52.998490450000006	-7.377700166944578
+division	Laos	20.0171109	103.378253
+division	Lapland	67.700017	26.273752
+division	Lara	10.2284518	-69.8197975
+division	Larnaca	34.9236095	33.6236184
+division	Las Piedras	-34.7274904	-56.2164982
+division	Latvia	56.799689	25.441386
+division	Lavalleja	-33.9971964	-54.9992242
+division	Lazio	41.994328	12.622686
+division	Le Gosier	16.2072112	-61.4931309
+division	Le Moule	16.3316709	-61.3476233
+division	Lebanon	33.8750629	35.843409
+division	Leiden	52.154612	4.484671
+division	Leinster	53.11846495	-6.991818291829787
+division	Leiria	39.7437902	-8.8071119
+division	Leitrim	54.140162200000006	-8.052478216276088
+division	Leningrad Oblast	60.0793	31.8927
+division	Leribe	-28.866891	28.0579408
+division	Les Abymes	16.2706436	-61.5057749
+division	Leskovac	42.9951304	21.9464271
+division	Lesotho	-29.6039267	28.3350193
+division	Leuven	50.880674	4.700109
+division	Levice	48.205679700000005	18.61568863599158
+division	Liaoning	40.9975197	122.9955469
+division	Liberec Region	50.7702648	15.0583947
+division	Liberia	5.7499721	-9.3658524
+division	Libochovicky	50.172572	14.2395992
+division	Libreville	0.390002	9.454001
+division	Libya	26.4215275	17.30331995251014
+division	Liechtenstein	47.1416307	9.5531527
+division	Liège	50.6326	5.5797
+division	Liguria	44.4777617	8.7026296
+division	Lika-Senj County	44.66818	15.3324696
+division	Lima	-11.971424	-77.070229
+division	Limburg	50.612763	5.936255
+division	Limburg BE	51.018966	5.426288
+division	Limburg NL	51.2015196	5.9046302
+division	Limerick	52.662235	-8.627565
+division	Limon	10.3787478	-83.5848401
+division	Limpopo	-23.4013	29.4179
+division	Linter	50.802855	5.056890
+division	Lipetsk	52.5265	39.2032
+division	Lisbon	38.7223	-9.1393
+division	Lithuania	55.41667	24
+division	Litomerice-Brnay	50.534253	14.131013
+division	Litoral	1.6026374	9.841569
+division	Littoral	4.203033	10.0563057
+division	Livingstone	-17.853135	25.861429
+division	Livno	43.8250	17.0077
+division	Ljubljana	46.0499803	14.5068602
+division	Lobatse	-25.2100604	25.6819594
+division	Łódzkie	51.4721678	19.3460637
+division	Loei	17.3158563	101.4638277
+division	Lofa	6.81332	-10.65391
+division	Loja	-4.0528506	-79.8053425
+division	Lokossa	6.6431448	1.7094469
+division	Lombardy	45.4791	9.8452
+division	Longford	53.726262750000004	-7.791969209626598
+division	Lop Buri	15.026458	100.8089178
+division	Loreto	-5.0	-75.0
+division	Lorraine	48.71557405	6.142460196100687
+division	Los Lagos	-42.300844	-73.105387
+division	Los Rios CL	-39.9742911	-72.667478
+division	Los Rios EC	-1.396432682365568	-79.56045566122232
+division	Los Roques	7.9953096	-67.4879994
+division	Los Santos	7.87734705	-80.42906166183488
+division	Louisiana	30.9843	-91.9623
+division	Louth	53.9508	-6.5406
+division	Lovech	43.0443145	24.487966724322504
+division	Lower Austria	48.360214	15.824134
+division	Lower Manya Krobo	6.1467264	0.0111251
+division	Lower Saxony	52.8398531	9.075962
+division	Lualaba	-9.69691495	23.02254385532696
+division	Luanda	-8.8272699	13.2439512
+division	Luapula	-11.9004565	29.7949916
+division	Lubelskie	50.8586338	22.7732404
+division	Lubombo	-26.55452	31.86191156647494
+division	Lubuskie	52.18772680160436	15.244301130159887
+division	Lucerne	47.0502	8.3093
+division	Lucknow	26.851073	80.934261
+division	Lumbini	27.4823171	83.2777696
+division	Lummen	50.9876	5.1951
+division	Lusaka	-15.4164488	28.2821535
+division	Luxembourg	49.755428	6.119486
+division	Luxembourg BE	49.978352826667525	5.501312530195323
+division	Luxembourg LU	49.8158683	6.1296751
+division	Lviv	49.841952	24.0315921
+division	M'Sila Province	35.7087553	4.5371552
+division	Maafushi	3.9411571	73.48992800644209
+division	Maaseik	51.104005	5.714000
+division	Mabeleapodi	-22.2133194	26.824408
+division	Mabuo	-25.780844	21.2609999
+division	Machakos	-1.27900465	37.39526976452546
+division	Madagascar	-18.9249604	46.4416422
+division	Madhya Pradesh	22.9734	78.6569
+division	Madinah	24.5247	39.5692
+division	Madre de Dios	-12.0	-70.25
+division	Madrid	40.4168	-3.7038
+division	Mae Hong Son	19.3927456	98.2031112
+division	Mafeteng	-29.8224468	27.2388281
+division	Mafraq	32.536378799999994	38.13152652312604
+division	Magadan	59.5604768	150.7988617
+division	Magallanes	-53.3527518	-71.5547782
+division	Magdalena	10.258546	-74.366995
+division	Maglaj	44.5455	18.1034
+division	Maha Sarakham	16.1861887	103.2955401
+division	Mahajanga	-15.7181492	46.3172577
+division	Mahama Refugee Camp	-2.3118581	30.840314
+division	Maharashtra	19.7515	75.7139
+division	Maiduguri	11.8395375	13.1536214
+division	Maine	45.709097	-68.8590201
+division	Makindu	-2.2814417	37.8147483
+division	Makkah	21.3891	39.8579
+division	Maku	39.46963445	44.61957980765516
+division	Malacky	48.4347503	17.020348
+division	Malatswae	-21.8139644	25.9313284
+division	Malawi	-13.2687204	33.9301963
+division	Malaysia	2.3923759	112.8471939
+division	Maldives	4.7064352	73.3287853
+division	Maldonado	-34.904210	-54.969183
+division	Malé	4.1779879	73.5107387
+division	Mali	16.3700359	-2.2900239
+division	Malopolskie	49.7225	20.2503
+division	Malta	35.8885993	14.4476911
+division	Maluku	-5.3580518	130.35838229206553
+division	Malý Dunaj	48.13132375	17.19760319392066
+division	Mamou	10.6619269	-12.1139542
+division	Manabi	-0.7588025	-80.0612131
+division	Mandalay	21.9812746	96.082375
+division	Mandera	3.2285332	40.70561647260599
+division	Mangystau Region	43.7362452	53.1681252
+division	Manica	-18.7805296	33.01596358735862
+division	Manila	14.652678	121.043936
+division	Manipur	24.7208818	93.9229386
+division	Manitoba	55.182879	-97.823531
+division	Mannar	8.9772444	79.9137786
+division	Manzini	-26.4958706	31.3695887
+division	Maputo	-25.966213	32.56745
+division	Maradi	13.501206	7.102534
+division	Maramures	47.672161	24.195473673014465
+division	Maranhão	-4.9609	-45.2744
+division	Marche	43.374025	13.161012
+division	Marche-en-Famenne	50.2265147	5.3407365
+division	Mardin	37.3129	40.7340
+division	Margibi	6.6053676	-10.1758429
+division	Mari El	56.5767504	47.8817512
+division	Maribor	46.5576439	15.6455854
+division	Marijampoles Apskritis	54.679230399999994	23.200468079034664
+division	Maritime	6.53703405	1.244338916227091
+division	Maritime Region	6.53703405	1.244338916227091
+division	Marmara	40.62164065	27.629427220927305
+division	Maroodi Jeex	6.1206	47.952599
+division	Martin	49.0617	18.919
+division	Martinique	14.6367927	-61.01582685063731
+division	Maryland	39.0458	-76.6413
+division	Maryland LR	4.6355376	-7.7281669
+division	Maseru	-29.310054	27.478222
+division	Mashonaland Central	-16.742872	31.2952086
+division	Mashonaland East Province	-17.7927323	31.7678044
+division	Masovia	54.033698650000005	21.77436913174548
+division	Massachusetts	42.340741	-71.998513
+division	Masvingo	-20.307118600000003	30.88137696875768
+division	Matale	7.4720453	80.6234307
+division	Matara	5.947822	80.5482919
+division	Mathiveri	4.1920793	72.74568640153404
+division	Matlhakola	-22.7193629	27.3017217
+division	Mato Grosso	-12.6819	-56.9211
+division	Mato Grosso do Sul	-19.5852564	-54.4794731
+division	Maule	-35.5972284	-71.48868
+division	Maun	-19.9860951	23.4224352
+division	Maunatlala	-22.5925557	27.6232338
+division	Mauren	47.2196512	9.5418065
+division	Mauritania	20.2540382	-9.2399263
+division	Mauritius	-20.2759451	57.5703566
+division	Mayo	53.9087056	-9.298304863654256
+division	Mayotte	-12.8253862	45.148626111147614
+division	Mazowieckie	52.467791	21.224779
+division	Mbabane	-26.325745	31.144663
+division	Mbalambi	-20.4993247	27.3350357
+division	Mbour	14.427132	-16.966574
+division	Meath	53.649784350000004	-6.588529492009938
+division	Mechelen	51.033475	4.444398
+division	Mecklenburg-Vorpommern	53.7735064	12.5755471
+division	Medea	36.265344	2.766957
+division	Medenine	33.3434395	10.4910529
+division	Medimurje County	46.4232963	16.4661353
+division	Medvedja	42.842459	21.5847305
+division	Medvedzie	49.3417948	19.53357086713877
+division	Meemu Atoll	2.7878094	73.53429865906894
+division	Meghalaya	25.5379432	91.2999102
+division	Mehedinti	44.6042177	23.05267739338317
+division	Meknes	33.897877	-5.5320345
+division	Melaka	2.2245111	102.2614662
+division	Melbourne	-37.8136	144.9631
+division	Melilla	35.291746	-2.938261
+division	Melnik	50.364202	14.482176
+division	Menabe	-20.03559335	45.10848883290599
+division	Mendoza	-34.787093049999996	-68.43818677312292
+division	Mepel	52.704669	6.196582
+division	Merida	8.5875788	-71.1572352
+division	Messinia	37.043788	22.113446177614726
+division	Meta	3.275638	-73.120232
+division	Métropole	16.2532002	-61.2750706
+division	Meuse	49.01296845	5.428669076639772
+division	Mexico	19.4325301	-99.1332101
+division	Mexico City	19.404497	-99.143041
+division	Miaoli County	24.5647667	120.8205167
+division	Michigan	45.021203	-84.762273
+division	Michoacan	19.207098	-101.878113
+division	Midcentral	-40.398721	175.799685
+division	Midlands	-19.2785043	29.8790852
+division	Midtjylland	56.23564835	9.234602771636588
+division	Midway Islands	70.47911904852143	-148.3112732497243
+division	Mie	34.7339685	136.5154489
+division	Migori	-1.0211616000000001	34.30964322421073
+division	Miklavž na Dravskem Polju	46.5073791	15.6973717
+division	Miloslavov	48.0990612	17.3014502
+division	Mimaropa	13.0152201	121.40641830505142
+division	Minas Gerais	-18.35789	-44.411895
+division	Minnesota	46.126042	-94.619581
+division	Minsk	53.902334	27.5618791
+division	Minsk Region	54.1603039	27.7558157
+division	Mioveni	44.957951	24.939220
+division	Miranda	10.25	-66.416667
+division	Mirpur	23.808569	90.363307
+division	Misiones	-26.737224	-54.4315257
+division	Misiones AR	-26.737224	-54.4315257
+division	Misiones PY	-27.0	-57.0
+division	Mississippi	32.9715645	-89.7348497
+division	Missouri	37.9643	-91.8318
+division	Mitrovica	42.8790424	20.8657862
+division	Miyagi	34.9743154	139.8396996
+division	Miyazaki	31.9076334	131.4204022
+division	Mizoram	23.2146169	92.8687612
+division	Mochudi	-24.3828605	26.1489495
+division	Mogilev Region	53.7254147	30.3863145
+division	Mohale's Hoek	-30.1516305	27.4770113
+division	Mohammedia	33.6958383	-7.3893292
+division	Moheli	-12.32045735	43.720431326729724
+division	Moka	-20.25229235	57.588131282011744
+division	Moldova	47.2879608	28.5670941
+division	Molenbeek-Saint-Jean	50.849476	4.329267
+division	Molise	41.686461	14.608668
+division	Mombasa	-4.05052	39.667169
+division	Monaco	43.73844905	7.424224092532953
+division	Monaghan	54.161066399999996	-6.946364847585796
+division	Monaragala	6.8725497	81.3507069
+division	Monastir	35.60547975	10.787694768513926
+division	Mongolia	47.504782	102.997672
+division	Monimoimdji	-12.2819882	43.7391035
+division	Mono	6.457624	1.867408
+division	Mons	50.445439	3.962794
+division	Montana	46.974704	-110.872530
+division	Montana BG	43.479324	23.116235720844614
+division	Montenegro	42.9868853	19.5180992
+division	Montevideo	-34.823827	-56.211799
+division	Montserrado	6.4095537	-10.6059403
+division	Montserrat	16.73603205085212	-62.19174679903016
+division	Mopti	14.514489000000001	-3.646458060483871
+division	Mopti Region	14.4877275	-4.1892469
+division	Moquegua	-16.833333	-70.916667
+division	Moravian-Silesian Region	49.83883545	18.153614708783117
+division	Moravica District	43.772132	20.32936932343302
+division	More Og Romsdal	62.8452777	7.518194072637362
+division	Morelos	18.75	-99.0
+division	Morne À l'Eau	16.3311175	-61.4579237
+division	Morocco	32.525925	-5.843761
+division	Morona Santiago	-2.6232969	-78.0048106
+division	Moscow	55.7558	37.6173
+division	Moscow Oblast	55.5043158	38.0353929
+division	Moscow Region	55.3404	38.2918
+division	Mostar	43.356900	17.795491
+division	Motopi	-20.2171191	24.1239381
+division	Mount Lebanon	33.7520021	35.60610882127588
+division	Mouscron	50.7459	3.2193
+division	Mouzdalifa-Moheli	12.3351559	43.6765303
+division	Mozambique	-19.302233	34.9144977
+division	Mpumalanga	-25.5653	30.5279
+division	Muchinga	-11.385112	31.9525422
+division	Mudug	6.6507279	48.3009945
+division	Multan	30.1979793	71.4724978
+division	Mumbai	19.0760	72.8777
+division	Munich	48.144747	11.561739
+division	Muranska Huta	48.778768	20.1105543
+division	Murcia	37.9922	-1.1307
+division	Mures	46.60645805	24.625192636852347
+division	Murmansk	68.0000418	33.9999151
+division	Murska Sobota	46.6624644	16.1655256
+division	Musandam	26.15232155	56.32948945983575
+division	Muscat	23.580244	58.362707
+division	Mutne Dulov	49.4355087	19.3147604
+division	Muzafargarh	30.071223	71.1228115
+division	Myanmar	20.600856	96.287616
+division	Myeik	12.4319552	98.5955711
+division	Mymensingh	24.8386014	90.41126950462677
+division	Myto Pod Dumbierom	48.8556374	19.62969423799256
+division	Māzandarān	36.3159159	51.8968597
+division	N'Djamena	12.1191543	15.0502758
+division	Nabeul	36.4512854	10.7355969
+division	Nablus	32.2205316	35.2569374
+division	Nachod	50.41472735	16.166904528325247
+division	Nagaland	26.1630556	94.5884911
+division	Nagano	36.1143945	138.0319015
+division	Nagasaki	32.796447	129.818142
+division	Nairobi	-1.3031689499999999	36.826061224105075
+division	Nakhon Nayok	14.1494474	101.2177459
+division	Nakhon Pathom	13.8918425	100.0165659
+division	Nakhon Ratchasima	15.2241917	101.9313754
+division	Nakhon Sawan	15.7054772	99.9288481
+division	Nakhon Si Thammarat	8.6772337	99.7309635
+division	Nakhonnayok	14.180467	101.096533
+division	Nakuru	-0.2802724	36.0712048
+division	Nam Dinh	20.2712241	106.1629895
+division	Namestovo	49.423550250000005	19.458483687700223
+division	Namibe	-15.2669341	12.7064561
+division	Namibia	-23.2335499	17.3231107
+division	Nampula	-14.966969	39.2707752
+division	Namur	50.457215	4.879493
+division	Nan	18.7544594	100.624804
+division	Nandi	0.22539325	35.124492921854724
+division	Naousa	37.1235202	25.238741
+division	Napo	-0.7626471	-77.9701878
+division	Nara	34.371026	135.887389
+division	Narathiwat	6.4277319	101.8212475
+division	Narino	1.592142	-77.851790
+division	Narok	-1.2779365500000002	35.47742284932569
+division	Nasarawa State	8.4387868	8.2382849
+division	National Capital Region	14.632748	121.027441
+division	Navarra	42.687776	-1.645699
+division	Navassa Island	18.409422917106408	-75.01198769630226
+division	Nay Pyi Taw	19.7540045	96.1344976
+division	Nayarit	21.8438765	-104.87148535201122
+division	Neamt	46.990657	26.48491657449838
+division	Nebraska	41.4925	-99.9018
+division	Neembucu	-27.0	-58.0
+division	Negeri Sembilan	2.7831895	102.1925319
+division	Nelson Marlborough	-41.436949	173.142614
+division	Nepal	28	84
+division	Netanya	32.3215	34.8532
+division	Netherlands	52.1326	5.2913
+division	Netivot	31.4232	34.5953
+division	Neuchâtel	46.9895828	6.9292641
+division	Neufchâteau	49.84934539327035	5.439299732392767
+division	Neuquen	-38.3695057	-69.832275
+division	Nevada	38.8026	-116.4194
+division	Nevsehir	38.767304	34.698996
+division	New Brunswick	46.57077	-66.308191
+division	New Hampshire	43.1939	-71.5724
+division	New Jersey	40.0583	-74.4057
+division	New Mexico	34.5199	-105.8701
+division	New South Wales	-32.68843	146.228414
+division	New Taipei City	25.017	121.4628
+division	New York	40.703395	-73.904193
+division	New Zealand	-41.500083	172.8344077
+division	Newfoundland and Labrador	53.655784	-61.203723
+division	Ngazidja	-11.652670350000001	43.33078712107961
+division	Nghe An	19.3738868	104.9233469
+division	Ngororero	-1.8628788	29.6227455
+division	Niakara	8.660329	-5.291088
+division	Niamey	13.524834	2.109823
+division	Niassa	-13.0638577	36.4669964
+division	Nicaragua	12.6090157	-85.2936911
+division	Nidwalden	46.942756	8.4119773
+division	Niedersachsen	52.8398531	9.075962
+division	Niger	18.061703	10.145544
+division	Niger State	9.9326083	5.6511088
+division	Nigeria	10	8
+division	Niigata	37.6452283	138.7669125
+division	Niksic	42.7739388	18.9488097
+division	Nile River Cruise	23.998417	32.873216
+division	Nimba	6.8088813	-8.7461448
+division	Nis	43.3211301	21.8959232
+division	Nitra	48.31295	18.0894593
+division	Nivelles	50.594427	4.331238
+division	Nizhny Novgorod	55.4718033	44.0911594
+division	Nógrád	47.9873616	19.5472495
+division	Nong Bua Lam Phu	17.2022252	102.440702
+division	Nong Khai	17.8812453	102.7490052
+division	Nonthaburi	13.852511	100.522791
+division	Nord Kivu	-0.5645647	28.7061945
+division	Nordjylland	56.8152793	9.727330772696376
+division	Nordland	67.27564050000001	13.862360639913621
+division	Normandie	48.8799	0.1713
+division	Norrbotten	66.936364	20.341728
+division	Norte de Santander	8.107454	-72.862123
+division	North Aegean	38.72996345	25.95373062710608
+division	North Aegean Islands	38.72996345	25.95373062710608
+division	North America	28.2367447	-97.738017
+division	North Bačka District	45.901328	19.583524660084475
+division	North Banat District	45.888395700000004	20.19005050882369
+division	North Batinah	24.577310	56.435470
+division	North Brabant	51.4827	5.2322
+division	North Carolina	35.7596	-79.0193
+division	North Central Province	8.3286788	80.4874005
+division	North Dakota	47.6201461	-100.540737
+division	North District	32.8972	35.3027
+division	North-East District	-21.0244816	27.5147504
+division	North Holland	52.5206	4.7885
+division	North Jeolla	34.759837149999996	127.65168920003353
+division	North Kalimantan	3.0235817	116.2049306
+division	North Macedonia	41.6171214	21.7168387
+division	North Maluku	0.6301215	127.9720219
+division	North Rhine Westphalia	51.44	7.705
+division	North Sharqiyah	22.157117399999997	58.51833487712584
+division	North Sulawesi	0.950357	124.450132
+division	North Sumatra	2.1923519	99.3812201
+division	North-West	-26.524595	25.625515
+division	North-West CH	47.330017637070874	7.563016736235331
+division	North-West ZA	-26.1347819	25.6546729
+division	North Western Province	7.9745867	79.97200526412345
+division	North-Western Zambia	-13.0143658	25.4624692
+division	Northeast Kenya	1.1613639999999998	40.19574646888216
+division	Northeastern Region MK	42.1670929	22.002467993493266
+division	Northern Cape	-29.573402	21.2051361
+division	Northern Ireland	54.60219	-6.687146
+division	Northern Mariana Islands	14.149020499999999	145.21345248318923
+division	Northern Mindanao	8.40488525	124.68719606690779
+division	Northern Province	9.28	80.28717778193072
+division	Northern Province RW	-1.6369420903021759	29.894401588007735
+division	Northern Region GH	9.343728560287136	-0.7792804562512756
+division	Northern Region MW	-11.04916995	33.7722246394023
+division	Northern Region UG	2.9780857973089314	32.94084206076348
+division	Northern Territory	-19.4914	132.551
+division	Northland	-35.3712702	173.7405337
+division	Norway	64.574131	11.52701029
+division	Nossa Senhora da Graça	17.10265065	-25.037743474498058
+division	Nossa Senhora da Luz	16.885447399999997	-24.98805016948336
+division	Nottinghamshire	53.134734	-0.989052
+division	Nouvelle-Aquitaine	45.4039367	0.3756199
+division	Nova Scotia	44.879119	-64.020314
+division	Nove Mesto nad Vahom	48.7633248	17.8303857
+division	Nove Zamky	47.9861843	18.1631415
+division	Novgorod	58.2843833	32.5169757
+division	Novi Pazar	43.1407	20.5214
+division	Novi Sad	45.269432	19.830203
+division	Novi Travnik	44.1748	17.6634
+division	Novo Mesto	45.8040475	15.1696684
+division	Novosibirsk	54.9720169	79.4813924
+division	Ñuble	-36.6331577	-71.9384821
+division	Nučice	49.9555237	14.884394
+division	Nueva Esparta	10.9738509	-64.0597676
+division	Nueva Loja	0.0850662	-76.883564
+division	Nuevo Leon	26.2384363	-99.8873
+division	Nur-Sultan	51.147862	71.433377
+division	Nusa Tenggara Barat	-8.7892855	117.146169
+division	Nuwara Eliya	6.9738863	80.767127
+division	Nyabihu	-1.6413681	29.4403421
+division	Nyamagabe	-2.3997098	29.3252898
+division	Nyamasheke	-2.3592647	29.0139988
+division	Nyandarua	-0.39155344999999997	36.49776838093413
+division	Nyanza	-4.337497	29.5949968
+division	Nyarugenge	-1.9712276	29.9620505
+division	Nyeri	-0.4192962	36.9517005
+division	Nzerekore Region	8.372084107777571	-8.834666578951598
+division	O'Higgins	-34.534538	-71.0354822
+division	Oaxaca	17.0	-96.5
+division	Obalnokraska	45.6444142	13.990988309164146
+division	Obwalden	46.8779	8.2512
+division	Occitanie	43.8927	3.2828
+division	Oceania	-25.0562891	152.008576
+division	Ocotepeque	14.42512415	-89.22489266426062
+division	Odesa	46.4873195	30.7392776
+division	Odisha	20.9517	85.0985
+division	Odolena Voda	50.2334117	14.4107808
+division	Öland	56.78159615	16.662156060319074
+division	Offaly	53.13323525	-7.8975681583464015
+division	Ogun State	7.006146	3.401761
+division	Ohangwena	-17.5877369	16.7737955
+division	Ohio	40.199215	-82.825637
+division	Oita	33.1819875	131.4270217
+division	Okayama	34.6553944	133.9194595
+division	Okinawa	26.4748948	127.91146866408414
+division	Oklahoma	35.370608	-97.186200
+division	Olancho	14.821102799999998	-85.9549881416508
+division	Olomouc Region	49.859105799999995	16.956126746749305
+division	Oltenia	44.849834792454956	23.760364011993996
+division	Omaheke	-21.9074676	19.3929661
+division	Oman	21.0000287	57.0036901
+division	Omsk	55.0555	73.3167
+division	Omusati	-18.2862314	14.8856679
+division	Ondo State	6.970395	5.101463
+division	Ontario	44.429	-79.377
+division	Oost-Vlaanderen	51.0375423	3.8117830113324556
+division	Oostende	51.210615	2.914232
+division	Opolskie	50.8918612	17.9321175
+division	Oran	35.7032751	-0.6492976
+division	Orange Walk	17.78310235	-88.85774666564073
+division	Orapa	-21.3361957	25.364964
+division	Oravska Lesna	49.3689979	19.1852951
+division	Orebro	59.2753	15.2134
+division	Orebro Lan	59.378174	14.948348
+division	Oregon	43.8041	-120.5542
+division	Orellana	-0.78618	-76.4803184
+division	Orenburg	51.7634	54.6188
+division	Oromia	7.6721644	40.0299727
+division	Oroshaza	46.5684	20.6545
+division	Oruro	-18.666667	-67.666667
+division	Oryol	52.9685433	36.0692477
+division	Osaka	34.64872	135.525013
+division	Oshana	-18.4702308	15.7434419
+division	Oshikoto	-18.5464046	17.1019606
+division	Osijek	45.552719	18.693245
+division	Osijek-Baranja	45.5548719	18.6953719
+division	Osijek-Baranja County	45.541111	18.4384615
+division	Oslo	59.903687	10.7497
+division	Osrednjeslovenska	46.046963950000006	14.494813327739415
+division	Ostergotland	58.402269	15.748012
+division	Ostrobothnia	62.9651857	21.2099367431475
+division	Osun State	7.592215	4.505599
+division	Otago	-45.412319	169.855268
+division	Otjozondjupa	-19.9424962	18.395886
+division	Ouargla	30.9980145	6.766453639443059
+division	Ouarzazate	30.9335	6.9370
+division	Oudenaarde	50.857635	3.629018
+division	Oueme	6.625372	2.532611
+division	Overijssel	52.436273	6.463628
+division	Oyo State	8.154414	3.632978
+division	Pa Trento	46.096712	11.130704
+division	Paal	51.032994	5.166286
+division	Päijät-Häme	61.2297202	25.810550681272005
+division	Pärnu	58.1508253	24.9707991
+division	Pahang	3.8126	103.3256
+division	Pakistan	30	70
+division	Palestine	31.94696655	35.27386547291496
+division	Palmyra Atoll	5.882204	-162.0748745
+division	Palu	-0.8957793	119.8679974
+division	Pamplemousses	-20.098318499999998	57.573905604159094
+division	Panama	8.3096067	-81.3066245
+division	Panama Center	9.207626	-79.426783
+division	Panama City	8.98333	-79.5166
+division	Panama Oeste	8.69162985	-79.88247020644809
+division	Pando	-11.183333	-67.183333
+division	Panevezio Apskritis	55.9156048	25.031159892185855
+division	Papua	-4.11501855	137.9966136
+division	Papua New Guinea	-5.6816069	144.2489081
+division	Para	-4.281398	-52.582417
+division	Paraguari	-25.6203507	-57.1505142
+division	Paraguay	-23.3165935	-58.1693445
+division	Paraiba	-7.1219366	-36.7246845
+division	Paraná	-25.2521	-52.0215
+division	Pardesia	32.3050	34.9117
+division	Pardubice Region	50.0385812	15.7791356
+division	Partizanske	48.6264092	18.3730067
+division	Pasco	-10.5	-75.25
+division	Pastaza	-1.724421	-76.870721
+division	Pathum Thani	14.018153	100.723973
+division	Pattani	6.8678652	101.2504538
+division	Pavlodar Region	51.8111545	76.4285287
+division	Pavlovce nad Uhom	48.6128015	22.0691252
+division	Pays de la Loire	47.640237	-0.647258
+division	Paysandu	-32.3217257	-58.0892136
+division	Pazardzhik	42.1928	24.3336
+division	Peje	42.6594354	20.288468
+division	Pelagonia	41.230157000000005	21.457169901765802
+division	Peloponnese	37.36332825	22.239537343995494
+division	Penang	5.4065013	100.2559077
+division	Pennsylvania	41.2033	-77.1945
+division	Penza	53.200001	45.0
+division	Perak	4.812181	100.9797908
+division	Perlis	6.4868392	100.2577623
+division	Perm Krai	58.5951603	56.3159546
+division	Pernambuco	-8.8137	-36.9541
+division	Pernica	46.5780413	15.7265468
+division	Pernik	42.62802685	22.88250453463423
+division	Peru	-10	-75.25
+division	Peshawar	34.0123846	71.5787458
+division	Pest County	47.3715943	19.3452624
+division	Petah Tikva	32.0840	34.8878
+division	Peten	16.9	-89.9
+division	Pezinok	48.2854539	17.270194
+division	Phang Nga	8.5058295	98.5680335
+division	Phatthalung	7.543525	99.9971582
+division	Phayao	19.341673	100.1854539
+division	Phetchabun	16.4165039	101.1595234
+division	Phetchaburi	13.0692869	99.6044376
+division	Philippeville	50.178836	4.592270
+division	Philippines	12.8797	121.774
+division	Phitsanulok	16.9779975	100.3848239
+division	Phnom Penh	11.568271	104.9224426
+division	Phrae	18.2930601	100.0886757
+division	Phu Tho	21.4000047	105.2238899
+division	Phuket	7.959471	98.339272
+division	Piaui	-7.7183	-42.7289
+division	Pichincha	-0.1465	-78.4752
+division	Piedmont	45.0522	7.5154
+division	Piestany	48.5895247	17.8213848
+division	Pingtung County	22.6828017	120.487928
+division	Pirkanmaa	61.71743305	23.71571148842662
+division	Pirot	43.1547342	22.5865039
+division	Pitesti	44.8572343	24.8719422
+division	Pitsane	-25.470751	25.587929
+division	Piura	-5.0	-80.333333
+division	Plaine-Wilhems	-20.32250438758201	57.50491168170886
+division	Plana	48.94367	14.4527685
+division	Planken	47.1858848	9.5452211
+division	Plateau Central	12.40414	-0.8864160224616928
+division	Plateau State	9.0583446	9.6826289
+division	Plateaux	7.450501	1.0892702070507665
+division	Pleven	43.4170	24.6067
+division	Pljevlja	43.3565611	19.3584715
+division	Ploiesti	44.9417468	26.0236504
+division	Plovdiv	42.1418541	24.7499297
+division	Plzeň Region	49.7477415	13.3775249
+division	Plzensky Kraj	49.522810199999995	13.206311785137638
+division	Podgorica	42.4415238	19.2621081
+division	Podkarpackie	49.9927121	22.177107
+division	Podlaskie	53.2668455	22.8525787
+division	Podravska	46.4809178	15.745088519392077
+division	Podunavlje District	44.447787453394106	20.99815259869355
+division	Pointe-A-Pitre	16.2408636	-61.5334077
+division	Poland	52.0977181	19.0258159
+division	Polleur	50.580257	5.866744
+division	Poltava	49.8607809	33.7498787
+division	Pomoravlje District	44.02211065	21.44085667572235
+division	Pomorskie	54.2944	18.1531
+division	Pomurska	46.67145575	16.232207554958055
+division	Poprad	49.0541521	20.2976401
+division	Port City	6.93383425	79.83260861118586
+division	Port-Gentil	-0.7149116	8.7797434
+division	Port Louis	-20.1637281	57.5045331
+division	Portugal	39.54046	-8.174701
+division	Portuguesa	8.96739065	-69.3917347493333
+division	Posavska	45.94246699999999	15.525654263313344
+division	Potosi	-20.666667	-66.666667
+division	Pozega-Slavonia County	45.4381151	17.5133687
+division	Prachinburi	14.1542055	101.5547823
+division	Prachuap Khiri Khan	12.0432669	99.7487235
+division	Prague	50.0755	14.4378
+division	Prahova	45.10875455	26.03762296377709
+division	Presidente Hayes	-23.5	-58.833333
+division	Prešov	48.9975724	21.2401811
+division	Prienai	54.6338459	23.9428415
+division	Prievidza	48.7718361	18.6234916
+division	Primorje-Gorski Kotar County	45.4225937	14.6172032
+division	Primorskonotranjska	45.680034199999994	14.319543919418814
+division	Primorsky	45.0526	135
+division	Prince Edward Island	46.344935	-63.405688
+division	Pristina	42.6638771	21.1640849
+division	Prizren	42.2130151	20.7363339
+division	Prnjavor	44.8686369	17.6631777
+division	Provence-Alpes-Côte d'Azur	44.0580563	6.0638506
+division	Province 1	27.2308035	87.17636350640461
+division	Province 2	26.943053499999998	85.60748359660322
+division	Pskov	56.7709	29.094
+division	Pskov Oblast	57.5358729	28.8586826
+division	Ptolemaida	40.5122349	21.6785518
+division	Puducherry	10.91564885	79.80694879844232
+division	Puebla	19.0414	-98.2063
+division	Puerto Rico	18.2208	-66.5901
+division	Pula	44.870671	13.867625
+division	Punjab	31.1471	75.3412
+division	Punjab IN	30.9293211	75.5004841
+division	Punjab PK	31.0	72.0
+division	Puno	-15.0	-70.0
+division	Puntarenas	10.0730022	-84.8622981
+division	Putrajaya	2.9140567	101.6838531
+division	Putumayo	0.5000086	-76.0000086
+division	Põlva	58.05789625	27.062388312390027
+division	Qacha's Nek	-30.113327	28.6810971
+division	Qalqilya	32.1922845	34.9670224
+division	Qalyubiyya	30.33362925	31.22135686416373
+division	Qashqadaryo Region	38.5639397	65.5311095
+division	Qatar	25.27932	51.52245
+division	Qazvin	36.0156291	49.8398161
+division	Qom	34.6423117	50.8800969
+division	Quangninh	21.0064	107.2925
+division	Quebec	52.9399	-73.5491
+division	Queensland	-23.094025	144.192275
+division	Quelimane	-17.87751	36.890216
+division	Queretaro	20.5888	-100.3899
+division	Quetzaltenango	14.7360257	-91.6152074
+division	Quiche	15.4195605	-90.9460526
+division	Quindio	4.477059	-75.690565
+division	Quintana Roo	19.642598	-88.040442
+division	Quito	-0.18126	-78.4599
+division	Quthing	-30.3601252	27.9855738
+division	Raa Atoll	5.620160650000001	72.93728530224641
+division	Raanana	32.189052	34.868626
+division	Rabat	33.976469	-6.843796
+division	Rabca	49.4833334	19.4833333
+division	Radviliskio Apskritis	55.69341675	23.650119846962173
+division	Rajanpur	29.1042715	70.3283163
+division	Rajasthan	26.498229	73.881085
+division	Rajshahi	24.372633	88.606356
+division	Rakhine	19.5212991	94.0072428
+division	Rakhuna	-25.559968	25.58894
+division	Rakops	-21.038323	24.393661
+division	Ramallah and al-Bireh Governorate	31.989547412077712	35.19407713569646
+division	Ramat Gan	32.0684	34.
+division	Ramla	31.9316	34.8729
+division	Rangpur	25.748894	89.260669
+division	Rapla	58.99921345	24.804658825202406
+division	Rasdhoo	4.2628232	72.9919981
+division	Rasina District	43.5002565	21.178018203810293
+division	Raška District	43.2862179	20.6147325
+division	Ratchaburi	13.6317897	99.3558216
+division	Rautahat	26.98897655	85.28288985670432
+division	Rawalpindi	33.583175	73.049347
+division	Rayong	12.7943716	101.3705344
+division	Razgrad	43.5258211	26.5230603
+division	Red River Delta	21.010949	105.786621
+division	Red Sea	24.6601831	34.1399929
+division	Red Sea State	20.0	36.0
+division	Region Metropolitana de Santiago	-33.5739341	-70.6205518
+division	Republic of Bashkortostan	54.4747553	55.9784582
+division	Republic of Crymea	45.3453	34.4997
+division	Republic of Mordovia	54.4419829	44.4661144
+division	Republic of North Ossetia-Alania	42.9920711	44.2636348
+division	Republic of Sakha	66.7613	124.1238
+division	Republic of Srpska	44.669577200000006	17.365715484504605
+division	Republic of Tatarstan	55.1802	50.7264
+division	Republic of the Congo	-0.7264327	15.6419155
+division	Réunion	-21.130737949999997	55.536480112992315
+division	Revuca	48.6833333	20.1166667
+division	Reykjavik	64.1445	-21.9418
+division	Rezina	47.7485938	28.9507249
+division	Rheinland-Pfalz	49.9531599	7.310646
+division	Rhode Island	41.5801	-71.4774
+division	Riau	0.94000845	101.65561770919261
+division	Riau Island	0.94000845	101.65561770919261
+division	Riau Islands	-0.1547846	104.5803745
+division	Riga	56.960679	24.10716
+division	Rimavska Sobota	48.3833603	20.0180584
+division	Rio de Janeiro	-22.89445	-43.2099
+division	Rio Grande do Norte	-5.4026	-36.9541
+division	Rio Grande do Sul	-29.615543	-53.220125
+division	Rio Negro	-40.8261	-63.0266
+division	Risaralda	4.921633	-75.900759
+division	Rivera	-30.906491	-55.540612
+division	Rivers	4.8416028	6.8604088
+division	Riviere Du Rempart	-20.0667738	57.65058957251499
+division	Rivne	50.6196175	26.2513165
+division	Riyadh	23.197563	45.243845
+division	Rocha	-34.0	-54.0
+division	Rodopi	41.07803825	25.491327963731663
+division	Roermond	51.1933903	5.9882649
+division	Roeselaere	50.9444948	3.124765
+division	Roeselare	50.9444948	3.124765
+division	Rogaland	58.93631375	5.805878643040238
+division	Roi Et	15.7486448	103.7013017
+division	Rolpa	28.32642895	82.64483525627038
+division	Romania	45.9852129	24.6859225
+division	Rondonia	-10.943145	-62.8277863
+division	Roraima	2.135138	-61.3631922
+division	Roscommon	53.6982695	-8.218250761296193
+division	Rostock	54.130776	12.106778
+division	Rostov	47.2213858	39.7114196
+division	Rozaje	42.8416663	20.1659665
+division	Ruggell	47.2397575	9.5262871
+division	Ruse	43.8480413	25.9542057
+division	Rusizi	-2.5584815	28.9747354
+division	Russia	64.6863136	97.7453061
+division	Ruzomberok	49.0815718	19.3034168
+division	Rwanda	-1.9646631	30.0644358
+division	Ryazan	54.6295687	39.7425039
+division	Saare	57.9115944	22.05579
+division	Saarland	49.3841872	6.9537369
+division	Sabac	44.7571535	19.6953972
+division	Sabah	5.4257359	117.0326392
+division	Sabaragamuwa Province	6.8124018	80.33547643025922
+division	Sacatepequez	14.5531759	-90.75470179488752
+division	Saga	33.2185408	130.1296585
+division	Sagaing	24.4768486	95.47473996361609
+division	Sahy	48.0694559	18.9493378
+division	Saint Barthélemy	17.9036287	-62.811568843006896
+division	Saint-François	16.2532002	-61.2750706
+division	Saint Kitts and Nevis	17.250512	-62.6725973
+division	Saint Lucia	13.8250489	-60.975036
+division	Saint Martin	18.0668544	-63.0848869
+division	Saint-Petersburg	59.88208	30.3308
+division	Saint-Saulve	50.374816	3.569855
+division	Saint Vincent and the Grenadines	12.90447	-61.2765569
+division	Sainte-Anne	16.225685	-61.3859128
+division	Sainte-Rose	16.3327353	-61.698147
+division	Saitama	35.909903	139.659758
+division	Sakarya	40.753425	30.384694
+division	Sakhalin	50.691	142.9506
+division	Sakon Nakhon	17.1904453	103.9730898
+division	Sala	48.151379	17.8748587
+division	Salahuddin	34.499078850886754	43.63076584850825
+division	Salatiga	-7.3302642	110.4995353
+division	Salé	34.044889	-6.814017
+division	Salta	-25.1076701	-64.3494964
+division	Salto	-31.38889	-57.9608876
+division	Salzburg	47.356774	13.227550
+division	Samara	53.4184	50.4726
+division	Samut Prakan	13.6531651	100.8182578
+division	Samut Prakarn	13.581663	100.721344
+division	Samut Sakhon	13.5708192	100.2585874
+division	Samut Songkhram	13.410190	99.949071
+division	San Andres	6.8180711	-72.82070608235979
+division	San Andres y Providencia	12.8086902	-81.4908431
+division	San Jose	9.9281	-84.0907
+division	San Juan	-30.7054363	-69.1988222
+division	San Luis	-33.2762202	-65.9515546
+division	San Luis Potosi	22.5000001	-100.5000001
+division	San Marcos	14.9533135	-91.91204441598504
+division	San Martin	-7.0	-76.833333
+division	San Miguelito	9.0551061	-79.4933063
+division	San Pedro	-24.25	-56.5
+division	San Salvador	13.6989939	-89.1914249
+division	Sangmelima	2.936176	11.975646
+division	Sankt Gallen	47.419862	9.374697
+division	Sanmihaiu Roman	45.7044543	21.0889028
+division	Santa Barbara	15.0944971	-88.37232178296776
+division	Santa Catarina	-27.15767	-49.888561
+division	Santa Cruz	-17.333333	-61.5
+division	Santa Cruz AR	-49.12597752714287	-69.8566398343734
+division	Santa Cruz BO	-17.30673328564769	-61.43042480176609
+division	Santa Elena	-2.1954593	-80.5669167
+division	Santa Fe	-30.3154739	-61.1645076
+division	Santa Rosa	14.150152349999999	-90.35088183533747
+division	Santander	6.746570	-73.476456
+division	Santarem	39.2849	-8.7041
+division	Santarem PT	39.2363637	-8.6867081
+division	Santiago de Veraguas	8.0989867	-80.9803978
+division	Santiago del Estero	-27.6431016	-63.5408542
+division	Santo Domingo	-0.34018899999999996	-79.17154939601922
+division	Santo Domingo de los Tsachilas	-0.2546212	-79.1686724
+division	São Paulo	-23.59806	-46.660537
+division	Saraburi	14.5249471	100.9160757
+division	Sarajevo	43.8563	18.4131
+division	Saratov	51.530018	46.034683
+division	Sarawak	2.5023855	112.9547283
+division	Sardinia	40.1209	9.0129
+division	Sargodha	32.0898005	72.6782574
+division	Sarlahi	26.96881835	85.56383497003685
+division	Saskatchewan	53.934278	-106.16006
+division	Satun	7.0366682	99.9615397
+division	Saudi Arabia	25	45
+division	Savanne	-20.45806125	57.489206513345835
+division	Savinja	46.3171858	15.0169865
+division	Savinjska	46.238152400000004	15.341413795874667
+division	Saxony	50.9295798	13.4585052
+division	Saxony-Anhalt	52.0089065	11.7003344
+division	Schaan	47.1663397	9.510312
+division	Schaanwald	47.2165446	9.5700026
+division	Schaarbeek	50.8676041	4.3737121
+division	Schaffhausen	47.712000	8.638976
+division	Schellenberg	47.2312022	9.5458021
+division	Scherpenheuvel-Zchem	50.9890	4.9776
+division	Schleswig-Holstein	54.1853998	9.8220089
+division	Schwyz	47.055398	8.73645
+division	Scotland	56.415858	-4.090641
+division	Séguéla	7.9662547	-6.675572
+division	Selangor	3.0738	101.5183
+division	Semnan	35.2256	54.4342
+division	Senec	48.2199473	17.3969901
+division	Senegal	14.5	-14.25
+division	Seoul	37.548278	126.990916
+division	Serbia	43.745902	20.848918
+division	Sergipe	-10.5741	-37.3857
+division	Serres	41.0910711	23.5498031
+division	Sétif	36.1892751	5.403493
+division	Settat	33.002397	-7.619867
+division	Setúbal	38.5260	-8.8909
+division	Seychelles	-4.6574977	55.4540146
+division	Sezimovo Usti	49.38422095	14.715199399581845
+division	Sfax	34.72312735	10.33587885553419
+division	Shandong	36.298013	118.193884
+division	Shanghai	31.171447	121.429896
+division	Sharjah	25.3525369	55.4378628
+division	Shaviyani Atoll	7.025023	75.9545415609148
+division	Sheikhupura	31.7085285	73.9864014
+division	Shiga	35.2018209	135.9245843
+division	Shimane	35.07286694117996	132.51777362880563
+division	Shiraz	29.6060218	52.5378041
+division	Shiselweni	-27.024344	31.313400298036466
+division	Shizuoka	34.979149	138.38299
+division	Shoam	31.9958	34.9488
+division	Shumen	43.2703797	26.9247362
+division	Si Sa Ket	15.116794	104.332348
+division	Siauliu Apskritis	55.93985585	23.39385766209714
+division	Siaya	-0.06040135	34.200135009996295
+division	Sibenik-Knin County	43.8410419	16.022628
+division	Sibiu	45.7973912	24.1519202
+division	Sichuan	30.709229	102.693949
+division	Sicily	37.636932	14.193097
+division	Sidi Bel Abbes	34.682268	-0.43575550651239253
+division	Sidi Bouzid	34.881181	9.526359847182345
+division	Sidi Kacem	34.226412	-5.711434
+division	Sidi Lahcen	33.7890814	-4.6804442
+division	Sidi Slimane	34.259878	-5.927253
+division	Sierra Leone	8.6400349	-11.8400269
+division	Siguiri	11.4195265	-9.1751513
+division	Sihanoukville	10.616351	103.512278
+division	Siirt	37.911394	42.115166
+division	Sikasso Region	11.3164979	-5.6777499
+division	Sikkim	27.601029	88.45413638680145
+division	Sikwane	-24.63852	26.406361
+division	Silistra	44.1191686	27.2613605
+division	Sinai	29.52316965	33.805472576508
+division	Sinaloa	25.0000001	-107.5000001
+division	Sindh	25.5	69.0
+division	Singapore	1.344189	103.867546
+division	Singburi	14.9936716	100.3602963
+division	Sint Maarten	18.039242824396645	-63.056012861628446
+division	Sint-Michiels	51.18087935	3.207862106248589
+division	Sint-Niklaas	51.1559	4.1544
+division	Sint-Truiden	50.8157	5.1863
+division	Sirajganj	24.4566253	89.7081281
+division	Sisak-Moslavina County	45.33265805	16.49359516326847
+division	Sistan and Baluchestan	28.1292481	60.8236848
+division	Sjaelland	55.545959550000006	11.697905825948633
+division	Skane	55.9903	13.5958
+division	Skofija Loka	46.16884815239272	14.312701486533827
+division	Skopje	41.9960924	21.4316495
+division	Skydra	40.7677111	22.1552339
+division	Slask	50.406080	18.976345
+division	Slaskie	50.5687422	19.2343995
+division	Slavetin	49.6685717	15.7727816
+division	Sligo	54.2720696	-8.4751357
+division	Sliven	42.6817633	26.3153528
+division	Slovakia	48.66667	19.5
+division	Slovenia	45.8133113	14.4808369
+division	Slovenska Bistrica	46.391944	15.5727757
+division	Småland	57.528294	14.463824
+division	Smolensk Region	54.77897005	32.04718121915615
+division	Smolyan	41.5774	24.7011
+division	Sobral de Monte AgracO	39.01835	-9.15171
+division	Soccsksargen	6.6052578	124.48994400286716
+division	Sodermanland	59.0336	16.7519
+division	Sofala	-19.0771666	34.7164804
+division	Sofia	42.6977	23.3219
+division	Sohag	26.547748	31.699263
+division	Soignies	50.567422	4.040613
+division	Sokoto	13.0611195	5.3152203
+division	Soliman	36.6944327	10.4865924
+division	Solothurn	47.207025	7.528326
+division	Somalia	8.3676771	49.083416
+division	Somogy County	46.439656	17.6212956
+division	Son la	21.1508502	103.8884294
+division	Songkhla	6.8790221	100.5498542
+division	Sonora	29.3333331	-110.6666671
+division	Soriano	-33.4921266	-57.7893105
+division	Sormland	59.061157	16.697407
+division	Soroca	48.1580642	28.2796328
+division	Souss-Massa	30.187722	-8.6322498
+division	Sousse	35.8288175	10.6405392
+division	South	33.33971235	35.29259105
+division	South Aegean	36.66801095	25.7351568839658
+division	South Aegean Region	36.8	26.2
+division	South Africa	-28.8166235	24.991639
+division	South America	-13.083583	-58.470721
+division	South Australia	-30.0002	136.2092
+division	South Bačka District	45.449139599999995	19.768030255295788
+division	South Banat District	44.994743150000005	20.939077025910777
+division	South Batinah	23.760421	57.045212
+division	South Canterbury	-43.49417615	171.8098447584145
+division	South Carolina	33.8361	-81.1637
+division	South Central Coast	13.323058450000001	109.22808897663754
+division	South China	27.022173229024762	103.91491112256124
+division	South Dakota	44.6471761	-100.348761
+division	South District	30.8296	35.0388
+division	South Holland	52.006053	4.485728
+division	South Kalimantan	-2.9285686	115.3700718
+division	South Kazakhstan Region	42.61668616573577	68.41903047442649
+division	South Khorasan	35.94848505	61.162053539424434
+division	South Korea	36.609249	127.917932
+division	South Moravian Region	49.1249179	16.682771628867208
+division	South Region	2.713807095443802	11.527986838051406
+division	South Sinai	28.64495635	33.87113129565117
+division	South Sudan	7.8699431	29.6667897
+division	South Sulawesi	-3.6446718	119.9471906
+division	South Sumatra	-3.1266842	104.0930554
+division	South Tyrol	46.762051	11.427443
+division	South-West	6.4550575	3.3941795
+division	South West Region	5.175015058174576	9.316606448940886
+division	South Yorkshire	53.4697	-1.326
+division	Southeast Region	10.356735749999999	108.59241422176846
+division	Southeast Sulawesi	-3.5491199	121.7279646
+division	Southeastern Region	41.4522215	22.657550068796596
+division	Southern	-46.040582	169.144142
+division	Southern Bohemia Region	49.0864548	14.600172741470452
+division	Southern District	-24.7998688	24.5800692
+division	Southern East	-24.911789240188916	24.61204567229615
+division	Southern Finland	60.7373759	25.814587585061936
+division	Southern Province	6.149	80.73181777500001
+division	Southern Province RW	-2.3952365459800933	29.719444186683475
+division	Southern Region MW	-15.30637685	35.32814794075438
+division	Southern Zambia	-16.5381715	26.7374997
+division	Southland	-45.7255555	168.2936808
+division	Southwestern Region	41.384177	20.831282438959253
+division	Spain	40.4637	-3.7492
+division	Special Region of Yogyakarta	-7.9778383999999996	110.36722565020224
+division	Split	43.514220	16.461441
+division	Split-Dalmatia County	43.07361015	16.027989049469006
+division	Srem District	44.919434949999996	19.970689942688402
+division	Sri Lanka	7.75	80.75
+division	St Eustatius	17.4865252	-62.9653116
+division	St-Louis	16.0326	-16.4818
+division	St. Lucia	13.8250489	-60.975036
+division	Stann Creek	16.9666599	-88.2247368
+division	Stara Boleslav	50.1999551	14.6786406
+division	Stara Zagora	42.4247421	25.6257235
+division	Stavropol	44.941379850000004	43.66309345141463
+division	Stefan Voda	46.5173976	29.6620148
+division	Steung Treng	13.5313006	105.9729938
+division	Stockholm	59.33267	18.061849
+division	Straseni	47.146331	28.6148909
+division	Stredocesky Region	50.0601579	13.83074794209991
+division	Stropkov Region	49.2020091	21.6521343
+division	Stupava	48.2731324	17.0327458
+division	Styria	47.3593	14.4700
+division	Suceava	47.667761	26.266066
+division	Sucre	9.0	-75.0
+division	Sucumbios	-0.039138	-76.5119678
+division	Sud Kivu	-3.223156	28.386665
+division	Sud-Ouest	10.38692085	-3.283188627811005
+division	Sudan	14.5844444	29.4917691
+division	Sudurpaschim	28.7037278	80.5666463
+division	Sukhothai	17.1446985	99.4375845
+division	Sulawesi Selatan	-3.6446718	119.9471906
+division	Šumadija District	44.1202429	20.85199400301452
+division	Sumatera Barat	-1.33589025	100.07222762395327
+division	Sumatera Selatan	-3.1266842	104.0930554
+division	Sumatera Utara	2.1923519	99.3812201
+division	Sumatra	-0.14329415	101.62410241439257
+division	Sumy	50.9070007	34.798386
+division	Surany	48.0861055	18.1868344
+division	Surat Thani	9.4674663	98.830042
+division	Surin	14.8841804	103.4906232
+division	Suriname	4.1413025	-56.0771187
+division	Sverdlovsk	59.0077	61.9316
+division	Sveti Nikole	41.8647339	21.9420506
+division	Svit	49.0582357	20.1965291
+division	Sweden	59.6749712	14.5208584
+division	Swietokrzyskie	50.7504894	20.7829122
+division	Switzerland	46.8182	8.2275
+division	Świętokrzyskie Voivodeship	50.7504894	20.7829122
+division	Syddanmark	55.3784583	9.13192766793894
+division	Sylhet	24.8949	91.8687
+division	Syria	34.6401861	39.0494106
+division	Szabolcs-Szatmár-Bereg County	48.0395	22.0033
+division	Szeged	46.2530	20.1414
+division	Tabasco	17.95078635	-92.48312213241397
+division	Tachira	7.9805778	-72.097576
+division	Tacna	-18.0138521	-70.2511614
+division	Tacuarembo	-32.166667	-55.5
+division	Tahiti	-17.68734395	-149.44516811423745
+division	Taichung	24.163162	120.6478282
+division	Tainan	22.9912348	120.184982
+division	Taipei City	25.0375198	121.5636796
+division	Taita Taveta	-3.4178355	38.36706756969934
+division	Taiwan	23.8169	121.031365
+division	Tajikistan	38.8610	71.2761
+division	Tak	17.1053568	98.9953943
+division	Tamaulipas	23.9891553	-98.7026825
+division	Tambov Region	52.9019574	41.3578918
+division	Tamil Nadu	11.1271	78.6569
+division	Tamu	24.18735435	94.39209374929968
+division	Tana River	-1.53651195	39.55083745466502
+division	Tangail	24.248630	89.917926
+division	Tanzania	-6.5247123	35.7878438
+division	Taoyuan City	24.9929995	121.3010003
+division	Tapesovo	49.3740873	19.4467954
+division	Taranaki	-39.2711067	174.154795
+division	Tarapacá	-20.1636672	-69.5463448
+division	Targovishte	43.251196	26.5727944
+division	Tarija	-21.583333	-63.833333
+division	Tartu	58.3801207	26.72245
+division	Tashkent	40.4807487	68.758868
+division	Tasmania	-42.14220555	146.6723517878467
+division	Tatarstan	56.130014	53.371181
+division	Tatranská Štrba	49.0853881	20.0691919
+division	Taurages Apskritis	55.35608325	22.404879243700208
+division	Tbilisi	41.733699	44.818487
+division	Tchibanga	-2.9170995	10.9955955
+division	Tehran	35.6892	51.3890
+division	Tekirdag	40.9781	27.5117
+division	Tel Aviv District	32.0929	34.8072
+division	Telangana	18.094062	79.141493
+division	Teleorman	44.0160	25.2987
+division	Telsiai	55.9846135	22.2490753
+division	Telsiai Apskritis	55.9846135	22.2490753
+division	Temara	33.917166	-6.923804
+division	Tennessee	35.5175	-86.5804
+division	Teramo	42.6611	13.6987
+division	Terengganu	4.8630743	102.9949297
+division	Tervuren	50.8259	4.5078
+division	Tessin	46.3356506	8.753706
+division	Tete	-15.5205193	32.7682742
+division	Tetouan	35.5851327	-5.4014973
+division	Tetovo	42.0068297	20.9728556
+division	Texas	31.146868	-99.188758
+division	Thaa Atoll	2.36123205	73.13345167817616
+division	Thai Binh	20.5296832	106.3876068
+division	Thai Nguyen	21.592477	105.8435398
+division	Thailand	14.8971921	100.83273
+division	Thanh Hoa	20.026365	105.439044
+division	Thessaloniki	40.636023	22.943965
+division	Thessaly	39.5649006	22.15384856543278
+division	Thies	14.791	-16.9359
+division	Thrace	40.7229413	22.9237909
+division	Thuin	50.326454	4.308720
+division	Thurgau	47.576816	9.072051
+division	Thuringia	50.7333163	11.0747905
+division	Ticino	46.345334	8.774813
+division	Tielt	51.001589	3.355702
+division	Tienen	50.8106	4.9362
+division	Tierra del Fuego	-54.4071064	-67.8974895
+division	Tilburg	51.567213	5.047957
+division	Timbuktu	16.7719091	-3.0087272
+division	Timis	45.69131845	21.632126831488254
+division	Timisoara	45.7538355	21.2257474
+division	Timor-Leste	-8.809397	125.909527
+division	Tindouf	27.54390695	-6.240053867373146
+division	Tinghir	31.52133	-5.531164
+division	Tipaza	36.52727415	2.16836872941747
+division	Tipperary	52.4738	-8.1619
+division	Tirat Zvi	32.4225	35.5283
+division	Tissemsilt	35.785897500000004	1.8340956752427218
+division	Tizi-Ouzou	36.6816175	4.237186047040007
+division	Tiznit	29.701011	-9.7480363
+division	Tlaxcala	19.416667	-98.166667
+division	Tlhareseleele	-25.50636	25.630693
+division	Toamasina	-18.1553985	49.4098352
+division	Tocantins	-10.8855129	-48.3716912
+division	Tochigi	36.3818177	139.733591
+division	Togo	8.886250	1.069709
+division	Tohoku	40.7280	141.2578
+division	Tokat	40.3235	36.5522
+division	Tokushima	34.0698307	134.5550353
+division	Tokyo	35.683441	139.766131
+division	Toledo	16.28022575	-88.55432196222363
+division	Tolemaida	4.2448718	-74.6580418
+division	Toliara	-23.354173	43.66966
+division	Tolima	4.065944	-75.215716
+division	Tongeren	50.774275	5.464625
+division	Topolcany	48.5594345	18.1754394
+division	Totonicapan	15.0424999	-91.40610219934399
+division	Tottori	35.3555075	133.8678525
+division	Touba	14.856713	-15.87911
+division	Touggourt	33.12505	5.8531413
+division	Tougue	11.4394566	-11.6629484
+division	Toulouse	43.597198	1.431465
+division	Tournai	50.616724	3.395329
+division	Tournai-Mouscron	50.610622	3.406319
+division	Toyama	36.6957569	137.2136215
+division	Trang	7.529936	99.611699
+division	Trans-Nzoia	1.0454582499999998	34.97904397271594
+division	Trat	12.2593544	102.4268871
+division	Travnik	44.2259454	17.6661738
+division	Trebnje	45.9079394	15.0071462
+division	Treinta y Tres	-33.0	-54.25
+division	Trencianska Tepla	48.9344602	18.1200726
+division	Trenčín	48.8923583	18.0393715
+division	Trentino	46.051733	11.014531
+division	Trentino-Alto Adige	46.441472	11.282121
+division	Triesen	47.106994	9.5274876
+division	Trincomalee	8.576425	81.2344952
+division	Trinidad	10.36701726107432	-61.233044896832965
+division	Trinidad and Tobago	10.8677845	-60.9821067
+division	Tripura	23.7750823	91.7025091
+division	Trnava	48.3767652	17.5858175
+division	Trois-Rivières	15.9767433	-61.6441603
+division	Troms Og Finnmark	69.720052	23.450581
+division	Trondelag	63.87759235	10.195050547141093
+division	Trondheim	63.4305	10.3951
+division	Trutnov District	50.5769353594111	15.801705572065439
+division	Tshesebe	-20.7343594	27.5771641
+division	Tshidilamolomo	-25.8258858	24.6806347
+division	Tubas	32.3397411	35.3601893
+division	Tubize	50.6905	4.2026
+division	Tucuman	-26.8083	-65.2176
+division	Tula Region	53.9570701	37.3690909
+division	Tulcea	45.177518	28.8016348
+division	Tulkarem	32.3111468	35.0275505
+division	Tumbes	-3.833333	-80.5
+division	Tungurahua	-3.4797966	-80.2310435
+division	Tunis	36.806134	10.179324
+division	Tunisia	33.654143	9.065134
+division	Turkana	3.52559005	36.074506156741236
+division	Turkey	39	35
+division	Turkistan Region	42.4267196	68.0028934
+division	Turks and Caicos Islands	21.7214683	-71.6201783
+division	Turnhout	51.321956	4.940098
+division	Tuscany	43.4586541	11.1389204
+division	Tuzla	44.537787	18.680139
+division	Tver	57.0022	33.9853
+division	Tveria	32.7959	35.5310
+division	Tvrdosin	49.3365743	19.5541875
+division	Tvrdosovce	48.0952012	18.0619537
+division	Tyr	33.2721211	35.1964023
+division	Tyrol	47.220292	11.277287
+division	Tyumen Region	58.8206488	70.3658837
+division	Uasin Gishu	0.4771938	35.30505973699228
+division	Ubonratchathani	15.226428	104.8581711
+division	Ucayali	-9.0	-73.5
+division	Udon Thani	17.5211917	102.6680012
+division	Uganda	1.3733	32.2903
+division	Uhlirske Janovice	49.8807582	15.064492
+division	Uige	-7.1367951	14.896178
+division	UK	54.234125	-2.078794
+division	Ukraine	49.4871968	31.2718321
+division	Ulcinj	41.926012	19.2055563
+division	Ulyanovsk Oblast	54.1463177	47.2324921
+division	Umbria	42.965916	12.490236
+division	Una-Sana	44.8064912	15.8874438
+division	Unhost	50.08499	14.1318613
+division	Union of the Comoros	-12.2045176	44.2832964
+division	United Arab Emirates	23.546651	54.065059
+division	United Kingdom	54.242833	-2.088739
+division	Upper Austria	48.166283	13.869698
+division	Upper East Region	10.8070481	-0.6870286
+division	Upper West Region	10.3669525	-2.0921426
+division	Uppsala	59.8586	17.6389
+division	Uri	46.774206	8.628190
+division	Urmia	37.5493473	45.0682863
+division	Uruguay	-33	-56
+division	USA	38.916963	-98.891372
+division	Ustecky Region	50.5663266	13.820670539566608
+division	Usti nad Labem	50.656527	14.053702
+division	Utah	39.4225192	-111.7143583
+division	Utena	55.4984381	25.6025772
+division	Utena Apskritis	55.4984381	25.6025772
+division	Uthai Thani	15.3912084	99.4560531
+division	Utrecht	52.08532	5.184968
+division	Uttar Pradesh	26.8467	80.9462
+division	Uttaradit	17.625163	100.4029452
+division	Uttarakhand	30.091993549999998	79.32176659343018
+division	Uusimaa	60.2187	25.2716
+division	Uva Province	7.0788965	81.336532
+division	Uzbekistan	41.32373	63.9528098
+division	Uzhgorod	48.6223732	22.3022569
+division	Uzice	43.852499	19.847479
+division	Vaavu Atoll	3.4708637	73.545913
+division	Vaduz	47.1392862	9.5227962
+division	Västra Götaland	58.203026949999995	12.649730022427754
+division	Vakinankaratra	-19.71130945	46.83554814522457
+division	Valais	46.166982	7.563441
+division	Valcea	45.754095	25.176737
+division	Valga	57.777034	26.0315628
+division	Valle	13.524658500000001	-87.5778564118468
+division	Valle D'Aosta	45.746178	7.353924
+division	Valle del Cauca	3.747163	-76.415809
+division	Vallée du Bandama	8.270286	-4.9452089
+division	Valparaiso	-33.0472	-71.6127
+division	Varazdin	46.304239	16.337102
+division	Varaždin County	46.2317	16.3361
+division	Vardar	41.5924916	21.9204345
+division	Varmland	59.894483	13.209991
+division	Varna	43.2069025	27.9150855
+division	Vas	47.1371935	16.780898
+division	Vaslui	46.4977648	27.803085484685425
+division	Vasterbotten	64.863611	17.7435
+division	Vasternorrland	63.286259	17.641659
+division	Vastmanland	59.6714	16.2159
+division	Vastra Gotaland	58.2528	13.0596
+division	Vaud	46.619469	6.472479
+division	Vaupes	0.2500086	-70.7500086
+division	Vavuniya	8.7593517	80.5000778
+division	Važec	49.0592773	19.9816464
+division	Velenje	46.3592869	15.1150301
+division	Veliko Tyrnovo	43.0820584	25.6321312
+division	Velke Prilepy	50.1606031	14.314113
+division	Velký Harcáš	47.7469355	18.1783256
+division	Velky Krtis	48.2093428	19.3490365
+division	Veneto	45.4415	12.3153
+division	Venezuela	7.838891	-65.916409
+division	Veracruz	19.333333	-96.666667
+division	Veraguas	8.029857	-81.25318952087585
+division	Veria	40.5215342	22.2036834
+division	Vermont	44.5588	-72.5778
+division	Verona	45.4384	10.9916
+division	Verviers	50.578077	5.872924
+division	Vestfold Og Telemark	59.39626765	9.061898163187937
+division	Vestland	60.9291011	6.107886941976156
+division	Vestlandet	60.958303	6.533228
+division	Veszprém County	47.0928058	17.9140147
+division	Veurne	51.046671	2.663125
+division	Vichada	5.0000086	-69.5000086
+division	Victoria	-37.121673	144.106178
+division	Vidin	43.9962	22.8679
+division	Vienna	48.2082	16.3738
+division	Vietnam	16.16667	107.83333
+division	Vieux Habitants	16.0592721	-61.7636362
+division	Vihiga	0.0831199	34.708033906814826
+division	Viken	59.9263265	9.904234519577855
+division	Vilimalé	4.1732095	73.4842739
+division	Viljandi	58.3646073	25.5876563
+division	Vilkaviskis	54.6501751	23.0358705
+division	Villa Nueva	14.5308826	-90.5963325
+division	Villavicencio	4.134000	-73.623483
+division	Vilniaus Apskritis	54.82269205	25.249534001679514
+division	Vilnius	54.697979	25.279095
+division	Vinhphuc	21.348702	105.548594
+division	Vinnytsia	49.2320162	28.467975
+division	Virgin Islands	18.3358	-64.8963
+division	Virginia	37.926868	-78.024902
+division	Virovitica-Podravina County	45.7732751	17.5789161
+division	Virton	49.5605149	5.5196466
+division	Vitebsk Region	55.2381972	28.7742203
+division	Vitez	44.1525	17.7903
+division	Vlaams-Brabant	50.8686516	4.7886237984620905
+division	Vlaanderen	51.096246199999996	4.178629103169916
+division	Vladimir Region	56.0503336	40.6561633
+division	Vogosca	43.901488	18.3433749
+division	Vojvodina	45.4094426	19.976249203097026
+division	Volgograd Region	49.6048339	44.2903582
+division	Vologda	59.218876	39.893276
+division	Vologda Oblast	60.0391461	43.1215213
+division	Volta	6.5348624	0.4556055
+division	Volta Region	7.2582313	-0.7220547
+division	Volyn	50.765553049999994	25.34908213724668
+division	Vorarlberg	47.232027	9.897419
+division	Voronezh	50.9800393	40.1506507
+division	Vrancea	44.545232	22.598705
+division	Vranje	42.5558337	21.8976673
+division	Vratsa	43.398819	23.715723218470906
+division	Vukovar-Srijem County	45.2283407	18.8590442
+division	Vysocina Region	49.442644	15.672714
+division	Võru	57.8385759	27.0086505
+division	Waikato	-37.777199	175.528928
+division	Wairarapa	-41.073572	175.737609
+division	Waitemata	-36.579105	174.548718
+division	Wajir	1.9394402	40.02449393200057
+division	Wakayama	34.234617	135.1782181
+division	Wake Island	19.28988935	166.64921739111432
+division	Wales	52.306085	-3.621944
+division	Wallis and Futuna	-13.289402	-176.204224
+division	Wallis and Futuna Islands	-13.289402	-176.204224
+division	Wallonia	50.154533099999995	5.3991821671645575
+division	Waremme	50.692236	5.260861
+division	Warminsko-Mazurskie	53.924679	20.844499
+division	Washington	47.183945	-119.950361
+division	Washington DC	38.895650	-77.018707
+division	Waterford	52.2609997	-7.1119081
+division	Wele Nzas	1.4648719	11.131676
+division	Wellington	-41.273449	174.857634
+division	Werda	-25.2669737	23.2670903
+division	West Bank	32.0254688	35.2888075
+division	West Bengal	23.361461	87.724077
+division	West Coast Region	13.2229	16.582
+division	West Java	-6.8891904	107.6404716
+division	West Kalimantan	-1.2003376000000001	109.93193384532759
+division	West-Kazakhstan Region	49.5568479	50.2227409
+division	West New Britain	-5.8891465	149.699546
+division	West Nusa Tenggara	-8.7892855	117.146169
+division	West Papua	-1.3842356	132.902528
+division	West Region	5.442287638761613	10.663684216690914
+division	West Sulawesi	-2.4974546	119.3918955
+division	West Sumatra	-1.33589025	100.07222762395327
+division	West Virginia	38.4758406	-80.8408415
+division	West-Vlaanderen	51.04047465	2.9994213387887116
+division	Western	-15.8543496	23.8016799
+division	Western Area	8.33460325	-13.065601629260717
+division	Western Australia	-27.055937	122.236663
+division	Western Cape Province	-33.493715	20.219852
+division	Western Greece	38.2529473	21.71176250372898
+division	Western Kordofan	12.014654475935094	28.420112571282516
+division	Western Macedonia	40.387091850000004	21.441244505955293
+division	Western North Region	6.2279367	-2.8234891
+division	Western Pomerania	53.84713085	13.351339698378764
+division	Western Province	6.8275297	79.93129599390583
+division	Western Region	5.4261241	-2.1286574
+division	Western Visayas	10.67295935	122.72299087286851
+division	Westmeath	53.5577902	-7.3478558260097575
+division	Wexford	52.46018745	-6.606515459159162
+division	Whanganui	-39.9324904	175.0519306
+division	Wicklow	52.9808	-6.0446
+division	Wielkopolskie	52.2800	17.3523
+division	Wilayah Persekutuan	3.1386603	101.6851081
+division	Willemstad	12.110006949999999	-68.9370850600204
+division	Windward Islands	-17.6782719	-149.50000910618445
+division	Wisconsin	44.535145	-89.527762
+division	Wyoming	43.076	-107.2903
+division	Xanthi	41.1380289	24.8862688
+division	Xinjiang	42.4804953	85.4633464
+division	Yala	6.3344846	101.1409694
+division	Yamagata	38.2553393	140.3400205
+division	Yamaguchi	34.1781317	131.4737077
+division	Yamalo-Nenets	67.1471631	74.3415488
+division	Yamanashi	35.6928452	138.6871263
+division	Yambol	42.483935	26.5105553
+division	Yamoussoukro	6.869145	-5.2823277
+division	Yangon	16.7967129	96.1609916
+division	Yaoundé	3.8689867	11.5213344
+division	Yaracuy	10.333333	-68.75
+division	Yaroslavl	57.7781976	39.0021095
+division	Yavne	31.8780	34.7394
+division	Yazd	31.489462	54.46578718200166
+division	Yemen	16.3471243	47.8915271
+division	Yen Bai	21.69611	104.8752392
+division	Yerevan	40.1776121	44.5125849
+division	Yeumbeul	14.771188	-17.358556
+division	Yogyakarta	-7.8011945	110.364917
+division	Yoro	15.2994474	-87.29169807731974
+division	Yucatan	20.6845957	-88.8755669
+division	Yunnan	24.556297	101.36621
+division	Zabaykalsky Krai	52.248521	115.956325
+division	Zabiedovo	49.320123	19.6069033
+division	Zabreh Na Morave	49.8837547	16.879471619265
+division	Zabrezi	50.4109017	15.7362133
+division	Zacapa	14.9661596	-89.5180314
+division	Zacatecas	23.0000001	-103.0000001
+division	Zachodniopomorskie	53.532925406940386	15.480819266107156
+division	Zadar County	44.2232882	15.3739652
+division	Zagora	30.328035	-5.837139
+division	Zagreb	45.8131847	15.9771774
+division	Zagreb County	45.7017634	16.2347136
+division	Zaire	-6.6925131	13.5293029
+division	Zambezi	-17.6912922	24.1377371
+division	Zambezia	-16.6460178	36.991932
+division	Zambia	-14.5186239	27.5599164
+division	Zamboanga Peninsula	7.77301775	122.75600476636146
+division	Zamfara State	12.0078998	6.4191432
+division	Zamora-Chinchipe	-4.0620183	-78.7751588
+division	Zarqa	32.0668425	36.0885771
+division	Zasavska	46.085500249999996	14.912332116610104
+division	Zavidovici	44.4383939	18.1453909
+division	Zeeland	51.484078	3.802245
+division	Zefat	32.9646	35.4960
+division	Zelezniki	46.2257913	14.1693085
+division	Zenica	44.2010759	17.9055721
+division	Zenica-Doboj	44.2010759	17.9055721
+division	Zepce	44.4287	18.0379
+division	Zhejiang	29.22571	120.299125
+division	Zielonogorskie	52.2275	15.2559
+division	Zilina	49.2234674	18.7393139
+division	Zimbabwe	-18.4554963	29.7468414
+division	Zinder	13.8063421	8.9891659
+division	Ziri	46.0510703	14.1106226
+division	Zlatibor District	43.587981600000006	19.761440498601697
+division	Zlin	49.226766	17.6667415
+division	Zlín Region	49.19692	17.646091635845135
+division	Zlonice	50.2874986	14.0921369
+division	Zolder	50.9905	5.2580
+division	Zuenoula	7.4280208	-6.0500349
+division	Zürich	47.441242	8.641154
+division	Zug	47.155891	8.525039
+division	Zulia	10.0437564	-72.2191181
+division	Zvolen	48.5782517	19.1247135
+division	ǁKaras	-26.8752094	17.7634818
+division	Сhukotka Region	66.95859821487666	171.89260087191087
+
+country	Afghanistan	33.7680065	66.2385139
+country	Albania	41.000028	19.9999619
+country	Algeria	28.0000272	2.9999825
+country	Andorra	42.5407167	1.5732033
+country	Angola	-11.8775768	17.5691241
+country	Antigua and Barbuda	17.2234721	-61.9554608
+country	Argentina	-37.052315	-64.869142
+country	Armenia	40.7696272	44.6736646
+country	Aruba	12.5013629	-69.9618475
+country	Australia	-24.7761085	134.755
+country	Austria	47.5162	14.5501
+country	Azerbaijan	40.3936294	47.7872508
+country	Bahamas	24.7736546	-78.0000547
+country	Bahrain	26.0667	50.5577
+country	Bangladesh	24.506442	90.041454
+country	Barbados	13.1500331	-59.5250305
+country	Belarus	53.704205	28.247691
+country	Belgium	50.707735	4.677726
+country	Belize	16.8259793	-88.7600927
+country	Benin	9.961027	2.327362
+country	Bermuda	32.3018217	-64.7603583
+country	Bolivia	-17.0568696	-64.9912286
+country	Bonaire	12.167	-68.29096143734236
+country	Bosnia and Herzegovina	43.9159	17.6791
+country	Botswana	-23.1681782	24.5928742
+country	Brazil	-10.3333332	-53.1999999
+country	Brunei	4.5353	114.7277
+country	Bulgaria	42.782450	25.193668
+country	Burkina Faso	12.78998	-1.683734
+country	Burundi	-3.3634357	29.8870575
+country	Cabo Verde	16.0000552	-24.0083947
+country	Cambodia	13.0	105.0
+country	Cameroon	4.6125522	13.1535811
+country	Canada	61.0666922	-107.991707
+country	Central African Republic	7.0323598	19.9981227
+country	Chad	15.6134137	19.0156172
+country	Chile	-31.7613364	-71.3187696
+country	China	33.394333	104.689839
+country	Colombia	2.893108	-73.7845142
+country	Costa Rica	10.0379	-83.818759
+country	Côte d'Ivoire	7.9897371	-5.5679458
+country	Crimea	45.28350435	34.20081877526554
+country	Croatia	45.1	15.2
+country	Cuba	23.0131338	-80.8328748
+country	Curacao	12.1845	-68.9640875031406
+country	Cyprus	34.965802	33.171772
+country	Czech Republic	49.8175	15.473
+country	Democratic Republic of the Congo	-4.0383	21.7587
+country	Denmark	56.2639	9.5018
+country	Djibouti	11.85677545	42.757784519943655
+country	Dominica	15.4185147	-61.3363561
+country	Dominican Republic	19.0974031	-70.3028026
+country	Ecuador	-1.0541	-78.1489
+country	Egypt	26.8206	30.8025
+country	El Salvador	13.8000382	-88.9140683
+country	Equatorial Guinea	1.613172	10.5170357
+country	Estonia	58.850111	25.808524
+country	Eswatini	-26.5624806	31.3991317
+country	Ethiopia	9.1450	40.4897
+country	Fiji	-18.1239696	179.0122737
+country	Finland	61.751734	26.186437
+country	France	46.2276	2.2137
+country	French Polynesia	-16.03442485	-146.0490931059517
+country	Gabon	-0.8999695	11.6899699
+country	Gambia	13.5	-15.5
+country	Georgia	41.989378	43.597463
+country	Germany	51.1657	10.4515
+country	Ghana	7.811417	-1.089272
+country	Gibraltar	36.140807	-5.3541295
+country	Greece	39.0	22.0
+country	Grenada	12.1360374	-61.6904045
+country	Guadeloupe	16.2490067	-61.5650444
+country	Guam	13.464887	144.792016
+country	Guatemala	15.6356088	-89.8988087
+country	Guinea	10.7226226	-10.7083587
+country	Guinea-Bissau	12.100035	-14.9000214
+country	Guyana	4.8417097	-58.6416891
+country	Haiti	19.1399952	-72.3570972
+country	Honduras	15.2572432	-86.0755145
+country	Hong Kong	22.3964	114.1095
+country	Hungary	47.0	20.0
+country	Iceland	64.90614	-18.4826
+country	India	21.077353	78.723951
+country	Indonesia	-0.897599	114.181602
+country	Iran	34.5732	51.876
+country	Iraq	33.0955793	44.1749775
+country	Ireland	52.865	-7.979
+country	Israel	31.217736	34.903129
+country	Italy	43.382775	12.183629
+country	Ivory Coast	7.9897371	-5.5679458
+country	Jamaica	18.1096	-77.2975
+country	Japan	35.68536	139.75309
+country	Jordan	31.1667049	36.941628
+country	Kazakhstan	48.886304	67.283729
+country	Kenya	0.0236	37.9062
+country	Kosovo	42.6026	20.9030
+country	Kuwait	29.452987	47.447194
+country	Kyrgyzstan	41.2044	74.7661
+country	Laos	20.0171109	103.378253
+country	Latvia	56.799689	25.441386
+country	Lebanon	33.945959	35.868630
+country	Lesotho	-29.6039267	28.3350193
+country	Liberia	5.7499721	-9.3658524
+country	Libya	26.4215275	17.30331995251014
+country	Liechtenstein	47.1416307	9.5531527
+country	Lithuania	55.378752	23.945328
+country	Luxembourg	49.755428	6.119486
+country	Madagascar	-18.9249604	46.4416422
+country	Malawi	-13.2687204	33.9301963
+country	Malaysia	4.264153	102.222436
+country	Maldives	4.7064352	73.3287853
+country	Mali	16.3700359	-2.2900239
+country	Malta	35.8885993	14.4476911
+country	Mauritania	20.2540382	-9.2399263
+country	Mauritius	-20.2759451	57.5703566
+country	Mexico	19.4325301	-99.1332101
+country	Moldova	47.2879608	28.5670941
+country	Monaco	43.73844905	7.424224092532953
+country	Mongolia	47.504782	102.997672
+country	Montenegro	42.9868853	19.5180992
+country	Morocco	32.549785	-5.480765
+country	Mozambique	-19.302233	34.9144977
+country	Myanmar	20.600856	96.287616
+country	Namibia	-23.2335499	17.3231107
+country	Nepal	28.0	84.0
+country	Netherlands	52.1326	5.2913
+country	New Zealand	-41.500083	172.8344077
+country	Nicaragua	12.6090157	-85.2936911
+country	Niger	18.061703	10.145544
+country	Nigeria	10.0	8.0
+country	North Macedonia	41.6171214	21.7168387
+country	Norway	61.3109	8.73701
+country	Oman	20.565641	56.861042
+country	Pakistan	30.0	70.0
+country	Palau	5.3783537	132.9102573
+country	Palestine	31.94696655	35.27386547291496
+country	Panama	8.98333	-79.5166
+country	Papua New Guinea	-5.6816069	144.2489081
+country	Paraguay	-23.3165935	-58.1693445
+country	Peru	-9.650468	-75.328211
+country	Philippines	11.383086	123.521862
+country	Poland	52.0977181	19.0258159
+country	Portugal	39.54046	-8.174701
+country	Qatar	25.230573	51.183951
+country	Republic of the Congo	-0.516362	15.877811
+country	Romania	45.9432	24.9668
+country	Russia	64.6863136	97.7453061
+country	Rwanda	-1.9646631	30.0644358
+country	Saint Barthélemy	17.900773100000002	-62.7971665877911
+country	Saint Kitts and Nevis	17.250512	-62.6725973
+country	Saint Lucia	13.8250489	-60.975036
+country	Saint Martin	18.0668544	-63.0848869
+country	Saint Vincent and the Grenadines	12.90447	-61.2765569
+country	Saudi Arabia	25.0	45.0
+country	Senegal	14.5	-14.25
+country	Serbia	43.745902	20.848918
+country	Seychelles	-4.6574977	55.4540146
+country	Sierra Leone	8.6400349	-11.8400269
+country	Singapore	1.344189	103.867546
+country	Sint Maarten	18.038916377498968	-63.059102766267536
+country	Slovakia	48.66667	19.5
+country	Slovenia	45.8133113	14.4808369
+country	Solomon Islands	-8.7053941	159.1070693851845
+country	Somalia	8.3676771	49.083416
+country	South Africa	-28.8166235	24.991639
+country	South Korea	36.609249	127.917932
+country	South Sudan	7.8699431	29.6667897
+country	Spain	40.4637	-3.7492
+country	Sri Lanka	7.8731	80.7718
+country	St. Lucia	13.8250489	-60.975036
+country	Sudan	14.5844444	29.4917691
+country	Suriname	4.1413025	-56.0771187
+country	Sweden	59.6749712	14.5208584
+country	Switzerland	46.8182	8.2275
+country	Syria	34.6401861	39.0494106
+country	Taiwan	23.8169	121.031365
+country	Tajikistan	38.8610	71.2761
+country	Tanzania	-6.5247123	35.7878438
+country	Thailand	14.8971921	100.83273
+country	Timor-Leste	-8.809397	125.909527
+country	Togo	8.88625	1.069709
+country	Trinidad	10.447801502473043	-61.23664353857157
+country	Trinidad and Tobago	10.8677845	-60.9821067
+country	Tunisia	33.654143	9.065134
+country	Turkey	39.046746	36.767068
+country	Uganda	1.861287	32.55149
+country	Ukraine	49.4871968	31.2718321
+country	Union of the Comoros	-12.2045176	44.2832964
+country	United Arab Emirates	23.546651	54.065059
+country	United Kingdom	54.242833	-2.088739
+country	Uruguay	-33.0	-56.0
+country	USA	38.916963	-98.891372
+country	Uzbekistan	41.32373	63.9528098
+country	Vanuatu	-16.5255069	168.1069154
+country	Venezuela	7.838891	-65.916409
+country	Vietnam	16.16667	107.83333
+country	Yemen	16.3471243	47.8915271
+country	Zambia	-14.5186239	27.5599164
+country	Zimbabwe	-18.4554963	29.7468414
+
+country	Africa	4.070194	21.824559
+country	Asia	30.451098	86.654576
+country	Europe	49.646237	10.799454
+country	North America	28.2367447	-97.738017
+country	Oceania	-25.0562891	152.008576
+country	South America	-13.083583	-58.470721
+
+region	Asia	30.451098	86.654576
+


### PR DESCRIPTION
### Description of proposed changes    

Adds "division" as an Auspice color-by, filter, and geographic resolution for all live Nextstrain builds. Updates the lat/longs file from the better ncov workflow version and actually uses this file (which appears to have been unused by the live builds).

### Related issue(s)  

Fixes #70

### Testing

 - [x] Test with the example data used for CI
 - [x] Test with full builds