### PR TITLE
Remove weighting of frequencies by region

### DIFF
--- a/Snakefile_base
+++ b/Snakefile_base
@@ -654,12 +654,10 @@ rule tip_frequencies:
     input:
         tree = rules.refine.output.tree,
         metadata = rules.parse.output.metadata,
-        weights = "config/frequency_weights_by_region.json"
     params:
         narrow_bandwidth = 2 / 12.0,
         wide_bandwidth = 3 / 12.0,
         proportion_wide = 0.0,
-        weight_attribute = "region",
         min_date = min_date,
         max_date = max_date,
         pivot_interval = pivot_interval
@@ -675,8 +673,6 @@ rule tip_frequencies:
             --narrow-bandwidth {params.narrow_bandwidth} \
             --wide-bandwidth {params.wide_bandwidth} \
             --proportion-wide {params.proportion_wide} \
-            --weights {input.weights} \
-            --weights-attribute {params.weight_attribute} \
             --pivot-interval {params.pivot_interval} \
             --min-date {params.min_date} \
             --max-date {params.max_date} \


### PR DESCRIPTION
## Description of proposed changes

Given changes in recent circulation patterns of seasonal flu, our
original region-specific weighting is no longer reasonable. For example,
although H3N2 has not been observed in China in over a year, we still
heavily weight the older strains that were observed, giving the
impression in frequency plots that its corresponding genotypes are
actively circulating when they are not. Given that we already perform
region-based subsampling to create our trees, this additional level of
weighting is not worth the noise it adds to the data.

## Testing

 - [x] Tested by CI
 - [x] Test with full Nextstrain builds for H3N2, H1N1pdm, and Vic