### PR TITLE
Add measurements panel in nextflu-private builds

### DIFF
--- a/Snakefile_nextflu
+++ b/Snakefile_nextflu
@@ -1,0 +1,232 @@
+configfile: "config/config.json"
+
+# passages = ['cell', 'egg']
+# assays = ['hi', 'fra']
+# centers = ['who']
+# resolutions = ['2y']
+# lineages = ['h3n2', 'h1n1pdm', 'vic', 'yam']
+# segments = ['ha', 'na']
+
+passages = ['cell']
+assays = ['fra']
+centers = ['who']
+resolutions = ['2y']
+lineages = ['h3n2']
+segments = ['ha', 'na']
+
+include: "Snakefile_base"
+localrules: all_builds, download_all, download_titers, download_sequences
+
+lineage_name_by_abbreviation = {
+    "h3n2": "H3N2",
+    "h1n1pdm": "H1N1pdm",
+    "vic": "Vic",
+    "yam": "Yam",
+}
+
+
+def all_builds(w):
+    builds = []
+    for lineage in lineages:
+        lineage_assays = assays if lineage=='h3n2' else ['hi']
+
+        builds.extend(
+            expand("auspice-nextflu/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}.json",
+                   center=centers, lineage=[lineage], segment=segments,
+                   resolution=resolutions, assay=lineage_assays, passage=passages)
+        )
+
+        builds.extend(
+            expand("auspice-nextflu/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_tip-frequencies.json",
+                center=centers, lineage=[lineage], segment=segments,
+                resolution=resolutions, assay=lineage_assays, passage=passages)
+        )
+
+        builds.extend(
+            expand("auspice-nextflu/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_measurements.json",
+                center=centers, lineage=[lineage], segment=["ha"],
+                resolution=resolutions, assay=lineage_assays, passage=passages)
+        )
+
+    return builds
+
+
+def region_translations(w):
+    genes = gene_names(w)
+    return ["results/full-aaseq-%s_%s_%s_%s_%s.fasta"%(g, w.region, w.lineage, w.segment, w.resolution)
+            for g in genes]
+
+rule all_nextflu:
+    input:
+        all_builds
+
+# separate rule for interaction with fauna
+rule download_all:
+    input:
+        titers = expand("data/{center}_{lineage}_{passage}_{assay}_titers.tsv",
+                         lineage=lineages, center=centers, assay=assays, passage=passages),
+        sequences = expand("data/{lineage}_{segment}.fasta", lineage=lineages, segment=segments)
+
+
+for seg, genes in genes_to_translate.items():
+    rule:
+        input:
+            metadata = rules.parse.output.metadata,
+            sequences = rules.parse.output.sequences,
+            exclude = files.outliers,
+            reference = files.reference
+        params:
+            genes=genes,
+            region="{region}"
+        output:
+            alignments = expand("results/full-aaseq-{gene}_{{region}}_{{lineage}}_{{segment}}_{{resolution}}.fasta",
+                                gene=genes)
+        conda: "environment.yaml"
+        shell:
+            """
+            python3 scripts/full_region_alignments.py  --sequences {input.sequences}\
+                                                 --metadata {input.metadata} \
+                                                 --exclude {input.exclude} \
+                                                 --genes {params.genes} \
+                                                 --region {params.region:q} \
+                                                 --resolution {wildcards.resolution} \
+                                                 --reference {input.reference} \
+                                                 --output {output.alignments:q}
+            """
+
+
+rule scores:
+    input:
+        metadata = rules.parse.output.metadata,
+        tree = rules.refine.output.tree
+    output:
+        scores = "results/scores_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}.json"
+    conda: "environment.yaml"
+    shell:
+        """
+        python3 scripts/scores.py  --metadata {input.metadata} \
+                                  --tree {input.tree} \
+                                  --output {output}
+        """
+
+
+def _get_node_data_for_report_export(wildcards):
+    """Return a list of node data files to include for a given build's wildcards.
+    """
+    # Define inputs shared by all builds.
+    inputs = [
+        rules.annotate_epiweeks.output.node_data,
+        rules.annotate_recency_of_submissions.output.node_data,
+        rules.refine.output.node_data,
+        rules.ancestral.output.node_data,
+        rules.translate.output.node_data,
+        rules.titers_tree.output.titers_model,
+        rules.titers_sub.output.titers_model,
+        rules.clades.output.clades,
+        rules.traits.output.node_data,
+        rules.lbi.output.lbi,
+        rules.scores.output.scores,
+    ]
+
+    # glycosilation only makes sense for surface proteins
+    if wildcards.segment in ['ha', 'na']:
+        inputs.append(rules.glyc.output.glyc)
+
+    # Only request a distance file for builds that have mask configurations
+    # defined.
+    if _get_build_distance_map_config(wildcards) is not None:
+        inputs.append(rules.distances.output.distances)
+
+    # Convert input files from wildcard strings to real file names.
+    inputs = [input_file.format(**wildcards) for input_file in inputs]
+    return inputs
+
+
+rule export_nextflu:
+    input:
+        tree = rules.refine.output.tree,
+        metadata = rules.parse.output.metadata,
+        auspice_config = "config/auspice_config_nextflu_{lineage}.json",
+        node_data = _get_node_data_for_report_export,
+        colors = files.colors,
+    output:
+        auspice_json = "auspice-nextflu/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}.json",
+        root_sequence = "auspice-nextflu/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_root-sequence.json"
+    conda: "environment.yaml"
+    params:
+        panels=["tree", "measurements", "map", "entropy", "frequencies"]
+    shell:
+        """
+        augur export v2 \
+            --tree {input.tree} \
+            --metadata {input.metadata} \
+            --node-data {input.node_data} \
+            --auspice-config {input.auspice_config} \
+            --panels {params.panels:q} \
+            --colors {input.colors} \
+            --output {output.auspice_json} \
+            --include-root-sequence \
+            --minify-json
+        """
+
+rule tip_frequencies_nextflu:
+    input:
+        tree = rules.refine.output.tree,
+        metadata = rules.parse.output.metadata,
+    params:
+        narrow_bandwidth = 2 / 12.0,
+        wide_bandwidth = 3 / 12.0,
+        proportion_wide = 0.0,
+        min_date = min_date,
+        max_date = max_date,
+        pivot_interval = pivot_interval
+    output:
+        tip_freq = "auspice-nextflu/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_tip-frequencies.json"
+    conda: "environment.yaml"
+    shell:
+        """
+        augur frequencies \
+            --method kde \
+            --tree {input.tree} \
+            --metadata {input.metadata} \
+            --narrow-bandwidth {params.narrow_bandwidth} \
+            --wide-bandwidth {params.wide_bandwidth} \
+            --proportion-wide {params.proportion_wide} \
+            --pivot-interval {params.pivot_interval} \
+            --min-date {params.min_date} \
+            --max-date {params.max_date} \
+            --output {output}
+        """
+
+rule export_measurements:
+    input:
+        distances="results/antigenic_distances_between_strains_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}.tsv",
+    output:
+        measurements="auspice-nextflu/flu_{center}_{lineage}_{segment}_{resolution}_{passage}_{assay}_measurements.json",
+    conda: "environment.yaml"
+    params:
+        strain_column="test_strain",
+        value_column="log2_titer",
+        grouping_column=["reference_strain", "clade_reference", "source"],
+        key=lambda wildcards: f"{wildcards.lineage}_{wildcards.segment}_{wildcards.resolution}_{wildcards.passage}_{wildcards.assay}",
+        title=lambda wildcards: f"{lineage_name_by_abbreviation[wildcards.lineage]} {wildcards.passage}-passaged {wildcards.assay.upper()} measurements",
+        x_axis_label="normalized log2 titer",
+        threshold=2.0,
+        filters=["reference_strain", "clade_reference", "source"],
+    shell:
+        """
+        augur measurements export \
+            --collection {input.distances} \
+            --strain-column {params.strain_column} \
+            --value-column {params.value_column} \
+            --grouping-column {params.grouping_column} \
+            --key {params.key} \
+            --title {params.title:q} \
+            --x-axis-label {params.x_axis_label:q} \
+            --threshold {params.threshold} \
+            --filters {params.filters} \
+            --show-threshold \
+            --hide-overall-mean \
+            --minify-json \
+            --output-json {output.measurements}
+        """

--- a/config/auspice_config_nextflu_h3n2.json
+++ b/config/auspice_config_nextflu_h3n2.json
@@ -1,0 +1,131 @@
+{
+  "title": "Real-time tracking of influenza A/H3N2 evolution",
+  "maintainers": [
+    {"name": "Jover Lee", "url": "https://bedford.io/team/jover-lee/"},
+    {"name": "Richard Neher", "url": "https://neherlab.org/richard-neher.html"},
+    {"name": "Trevor Bedford", "url": "https://bedford.io/team/trevor-bedford/"}
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "clade_membership",
+      "title": "Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "ne_star",
+      "title": "Mutational load",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiter",
+      "title": "Antigenic advance (tree model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiterSub",
+      "title": "Antigenic advance (sub model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiter_x",
+      "title": "HI antigenic novelty",
+      "type": "continuous"
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "ep",
+      "title": "Epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "ne",
+      "title": "Non-epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "rb",
+      "title": "RBS adjacent mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission date",
+      "type": "ordinal"
+    },
+    {
+      "key": "epiweek",
+      "title": "Epiweek (CDC)",
+      "type": "ordinal"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
+  },
+  "filters": [
+    "clade_membership",
+    "region",
+    "country",
+    "division",
+    "submitting_lab",
+    "recency",
+    "epiweek"
+  ],
+  "panels": [
+    "tree",
+    "measurements",
+    "map",
+    "entropy",
+    "frequencies"
+  ]
+}

--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,8 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - augur=13.0.0
+  - python=3.9
+  - augur=15.0.0
   - epiweeks=2.1.2
   - iqtree=2.1.2
   - mafft=7.475
@@ -13,3 +14,4 @@ dependencies:
   - seaborn>=0.11*
   - pip:
     - rethinkdb==2.3.0.post6
+    - "git+https://github.com/nextstrain/augur.git@measurements-command"


### PR DESCRIPTION
## Description of proposed changes

Adds a new Snakemake file, `Snakefile_nextflu`, that mirrors `Snakefile_WHO` and adds logic to build measurements JSONs for HA-based builds with [the new `augur measurements` command](https://github.com/nextstrain/augur/pull/879). The current prototype only works for H3N2. These builds would only be pushed to the nextflu-private Nextstrain Group.

We should decide as a team whether to proceed with this kind of implementation for now or to first test and merge [the refactored workflow](https://github.com/nextstrain/seasonal-flu/pull/76). The refactored workflow might be better suited for managing separate live and private builds. Our decision here should be part of a bigger plan to sunset the private nextflu site.

## Testing

Tested locally with the following command:

```
snakemake \
  -p \
  --use-conda \
  --conda-frontend mamba \
  -j 4 \
  --snakefile Snakefile_nextflu \
  auspice-nextflu/flu_who_h3n2_ha_2y_cell_fra.json \
  auspice-nextflu/flu_who_h3n2_ha_2y_cell_fra_tip-frequencies.json \
  auspice-nextflu/flu_who_h3n2_ha_2y_cell_fra_measurements.json

auspice view --datasetDir auspice-nextflu
```