### PR TITLE
Fix select-strains

### DIFF
--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -196,8 +196,10 @@ def parse_metadata(segments, metadata_files, date_format = "%Y-%m-%d"):
         tmp_meta, columns = read_metadata(fname)
 
         numerical_dates = get_numerical_dates(tmp_meta, fmt=date_format)
-        for x in tmp_meta:
+        for x in list(tmp_meta.keys()):
             if numerical_dates[x] is None:
+                # Remove strain that does not have valid date
+                del tmp_meta[x]
                 continue
             tmp_meta[x]['num_date'] = np.mean(numerical_dates[x])
             tmp_meta[x]['year'] = int(tmp_meta[x]['num_date'])


### PR DESCRIPTION
Creating this PR for visibility. 

A quick fix for `select_strains` to skip strains that do not have valid dates. 
Fixes the error that I ran into for today's flu builds:
```
[batch] [Thu Apr 21 17:28:56 2022]
[batch] Error in rule select_strains:
[batch]     jobid: 487
[batch]     output: results/strains_cdc_h1n1pdm_2y_cell_hi.txt
[batch]     shell:
[batch]         
[batch]         python3 scripts/select_strains.py             --sequences results/filtered_h1n1pdm_ha_cell.fasta results/filtered_h1n1pdm_na_cell.fasta             --metadata results/metadata_h1n1pdm_ha.tsv results/metadata_h1n1pdm_na.tsv             --segments ha na             --include config/references_h1n1pdm.txt             --lineage h1n1pdm             --resolution 2y             --viruses-per-month 90             --titers data/cdc_h1n1pdm_cell_hi_titers.tsv             --output results/strains_cdc_h1n1pdm_2y_cell_hi.txt
[batch]         
[batch]         (one of the commands exited with non-zero exit code; note that snakemake uses bash strict mode!)
[batch] Traceback (most recent call last):
[batch]   File "scripts/select_strains.py", line 324, in <module>
[batch]     completeness=completeness
[batch]   File "scripts/select_strains.py", line 92, in flu_subsampling
[batch]     for strain, record in metadata.items()
[batch]   File "scripts/select_strains.py", line 93, in <dictcomp>
[batch]     if time_interval_start <= record["num_date"] <= time_interval_end
[batch] KeyError: 'num_date'
```

I'm not entirely sure why this error has not popped up before, I assume it's due to the recent changes in date handling in augur.