### PR TITLE
Use augur io and dates

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - augur=13.0.0
+  - augur=16.0.0
   - epiweeks=2.1.2
   - iqtree=2.1.2
   - mafft=7.475

--- a/scripts/age_distributions.py
+++ b/scripts/age_distributions.py
@@ -1,10 +1,6 @@
-import argparse, sys, os, glob
+import argparse
 import numpy as np
-from datetime import datetime, timedelta, date
-from collections import defaultdict
-from Bio import SeqIO, AlignIO
 from treetime.utils import numeric_date
-from augur.utils import read_metadata, get_numerical_dates
 from select_strains import read_strain_list, determine_time_interval, parse_metadata
 from flu_regions import region_names, region_properties
 

--- a/scripts/construct-recency-from-submission-date.py
+++ b/scripts/construct-recency-from-submission-date.py
@@ -1,7 +1,6 @@
 import argparse
 from augur.utils import read_metadata, write_json
 import datetime
-import json
 import numpy as np
 import pandas as pd
 

--- a/scripts/construct-recency-from-submission-date.py
+++ b/scripts/construct-recency-from-submission-date.py
@@ -1,5 +1,6 @@
 import argparse
-from augur.utils import read_metadata, write_json
+from augur.io import read_metadata
+from augur.utils import write_json
 import datetime
 import numpy as np
 import pandas as pd
@@ -53,8 +54,7 @@ if __name__ == '__main__':
     )
     args = parser.parse_args()
 
-    meta, columns = read_metadata(args.metadata)
-    meta = pd.DataFrame.from_dict(meta, "index")
+    meta = read_metadata(args.metadata)
     meta[args.submission_date_field] = pd.to_datetime(meta[args.submission_date_field])
 
     node_data = {'nodes': {}}

--- a/scripts/full_region_alignments.py
+++ b/scripts/full_region_alignments.py
@@ -1,12 +1,8 @@
-import argparse, sys, os, glob
-import numpy as np
-from datetime import datetime, timedelta, date
+import argparse
 from random import sample
-from collections import defaultdict
-from Bio import SeqIO, AlignIO, SeqRecord, Seq
+from Bio import SeqIO, SeqRecord, Seq
 from treetime.utils import numeric_date
-from augur.utils import read_metadata, get_numerical_dates, load_features
-from augur import align
+from augur.utils import load_features
 from augur.translate import safe_translate
 from select_strains import read_strain_list, determine_time_interval, parse_metadata
 from codon_align import codon_align, get_cds

--- a/scripts/generate_locations_file.py
+++ b/scripts/generate_locations_file.py
@@ -1,6 +1,7 @@
 import time
 from geopy.geocoders import Nominatim as geocoder
-from augur.utils import read_lat_longs, read_metadata
+from augur.io import read_metadata
+from augur.utils import read_lat_longs
 
 geoloc = geocoder(user_agent='augur/flu')
 last_request = 0
@@ -64,11 +65,11 @@ if __name__ == '__main__':
     parser.add_argument('--output', type=str, help="output file")
     args = parser.parse_args()
 
-    metadata, columns = read_metadata(args.metadata)
+    metadata = read_metadata(args.metadata)
     subset = {}
     if args.filter:
         assert len(args.filter)%2==0
-        for sname, s in metadata.items():
+        for sname, s in metadata.iterrows():
             if all([s[args.filter[2*fi]].lower()==args.filter[2*fi+1].lower() for fi in range(len(args.filter)//2)]):
                 subset[sname]=s
     else:

--- a/scripts/generate_locations_file.py
+++ b/scripts/generate_locations_file.py
@@ -1,4 +1,3 @@
-import numpy as np
 import time
 from geopy.geocoders import Nominatim as geocoder
 from augur.utils import read_lat_longs, read_metadata
@@ -42,7 +41,7 @@ def determine_coordinates(metadata, field, custom_coordinates=None):
                 loc = get_geo_info(loc_tuple)
             except:
                 print("request failed")
-                
+
             if loc:
                 new_coordinates[(field, m[field].lower())] = {'latitude':loc.latitude,
                                                     'longitude':loc.longitude}

--- a/scripts/scores.py
+++ b/scripts/scores.py
@@ -1,9 +1,7 @@
-import argparse, sys, os, glob, json
+import argparse, json
 import numpy as np
-from collections import defaultdict
 from Bio import Phylo
-from augur.utils import read_metadata, get_numerical_dates
-from select_strains import read_strain_list, determine_time_interval, parse_metadata
+from select_strains import parse_metadata
 from vaccination_coverage import read_all_vaccination_data
 
 def calculate_average_on_tree(tree, func, min_clade_size=20):

--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -8,7 +8,7 @@ import Bio.SeqIO
 import numpy as np
 from treetime.utils import numeric_date
 from augur.io import read_metadata
-from augur.utils import get_numerical_dates
+from augur.dates import get_numerical_dates
 from flu_regions import region_names
 
 subcats = region_names
@@ -195,10 +195,11 @@ def parse_metadata(segments, metadata_files, date_format = "%Y-%m-%d"):
     metadata = {}
     for segment, fname in zip(segments, metadata_files):
         tmp_meta = read_metadata(fname)
+        numerical_dates = get_numerical_dates(tmp_meta, fmt=date_format)
+
         tmp_meta.insert(0, "strain", tmp_meta.index.values)
         tmp_meta = tmp_meta.to_dict(orient="index")
 
-        numerical_dates = get_numerical_dates(tmp_meta, fmt=date_format)
         for x in list(tmp_meta.keys()):
             if numerical_dates[x] is None:
                 # Remove strain that does not have valid date

--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -2,7 +2,7 @@ import argparse
 import sys
 import os
 from collections import defaultdict
-from datetime import datetime, timedelta, date
+from datetime import datetime, timedelta
 import Bio
 import Bio.SeqIO
 import numpy as np

--- a/scripts/select_strains.py
+++ b/scripts/select_strains.py
@@ -7,7 +7,8 @@ import Bio
 import Bio.SeqIO
 import numpy as np
 from treetime.utils import numeric_date
-from augur.utils import read_metadata, get_numerical_dates
+from augur.io import read_metadata
+from augur.utils import get_numerical_dates
 from flu_regions import region_names
 
 subcats = region_names
@@ -193,7 +194,9 @@ def determine_time_interval(time_interval, resolution):
 def parse_metadata(segments, metadata_files, date_format = "%Y-%m-%d"):
     metadata = {}
     for segment, fname in zip(segments, metadata_files):
-        tmp_meta, columns = read_metadata(fname)
+        tmp_meta = read_metadata(fname)
+        tmp_meta.insert(0, "strain", tmp_meta.index.values)
+        tmp_meta = tmp_meta.to_dict(orient="index")
 
         numerical_dates = get_numerical_dates(tmp_meta, fmt=date_format)
         for x in list(tmp_meta.keys()):


### PR DESCRIPTION
### Description of proposed changes
Replaces all uses of `augur.utils.read_metadata` with `augur.io.read_metadata` and uses of `augur.utils.get_numerical_dates` with `augur.dates.get_numerical_dates`. 

The new dates module was introduced in augur 16.0.0 so I also updated the augur dependency in the environment.yaml file.

### Related issue(s)
Related to https://github.com/nextstrain/augur/pull/934 and https://github.com/nextstrain/augur/issues/970

### Testing
Verified that `select_strains` still ran as expected (not sure how to compare outputs since it's a random subsampling)
Checked the following produce the same outputs before and after change:
- age_distributions
- construct-recency-from-submission-date (only difference is augur version)
- full_region_alignments
- generate_locations_file
- scores


