### PR TITLE
Fix export_entropy rule: convert start to int

### DIFF
--- a/scripts/entropy.py
+++ b/scripts/entropy.py
@@ -19,7 +19,7 @@ def calc_SNV_frequencies(aln, alphabet='ACGT-'):
 def calc_entropy(af, aa=False, start=0):
     res = {}
     res['val'] = [round(x,4) for x in np.sum(-af*np.log(af+1e-15), axis=0)]
-    res['pos'] = [int(x) for x in start + (3 if aa else 1)*np.arange(af.shape[1])]
+    res['pos'] = [int(x) for x in int(start) + (3 if aa else 1)*np.arange(af.shape[1])]
     if aa:
         res['codon'] = [int(x) for x in np.arange(af.shape[1])]
     else:


### PR DESCRIPTION
Starting with Docker image nextstrain/base:build-20221201T013147Z, the WHO flu builds began to fail at the rule `export_entropy` with the following error:

```
Traceback (most recent call last):
  File "/nextstrain/build/scripts/entropy.py", line 64, in <module>
    entropy[gene] = calc_entropy(calc_SNV_frequencies(MultipleSeqAlignment(seqs), alphabets['aa']),
  File "/nextstrain/build/scripts/entropy.py", line 22, in calc_entropy
    res['pos'] = [int(x) for x in start + (3 if aa else 1)*np.arange(af.shape[1])]
  File "/usr/local/lib/python3.10/site-packages/Bio/SeqFeature.py", line 2109, in __add__
    return self.__class__(int(self) + offset)
  File "/usr/local/lib/python3.10/site-packages/Bio/SeqFeature.py", line 2095, in __new__
    return int.__new__(cls, position)
TypeError: only size-1 arrays can be converted to Python scalars
```

I'm still not entirely sure why this started to fail, but I suspect the bump of biopython from version 1.79 to 1.80 or the bump of numpy from version 1.23.4 to 1.23.5.

This commit fixes the error by converting the start position to an integer. I'm stopping myself from wasting anymore time on figuring out why this started failing...

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
