### PR TITLE
max_date: Add an extra month to today's date

### DIFF
--- a/Snakefile_base
+++ b/Snakefile_base
@@ -58,7 +58,9 @@ def max_date(w):
         date_offset = pd.DateOffset(months=config["frequency_max_date_month_offset"])
         return numeric_date(pd.to_datetime(date.today()) - date_offset)
     else:
-        return numeric_date(date.today())
+        # Adding an extra month as a short-term fix for a bug in augur frequencies
+        # caused by pandas.data_range not working as expected.
+        return numeric_date(date.today()) + (1/12)
 
 def clock_rate(w):
     # these rates are from 12y runs on 2019-10-18


### PR DESCRIPTION
This is a short term solution to getting the WHO running again as `augur frequencies` was running into an error where the root cause is pandas.date_range was not producing the date range we expected.¹

This change can be reverted once the underlying bug in augur has been resolved.

¹ https://bedfordlab.slack.com/archives/C03KWDET9/p1673039234734289

---

I'm running the WHO build with this change on AWS Batch (`370bfb5f-78cc-4bc0-9845-8a5d7fbd55bd`) and will merge this once that has completed successfully. 