### PR TITLE
fix: shift nucleotide coordinates for h3n2 clade files

### DIFF
--- a/config/h3n2/ha/clades-long.tsv
+++ b/config/h3n2/ha/clades-long.tsv
@@ -6,14 +6,14 @@ clade	gene	site	alt
 3B	HA1	223	I
 3B	HA1	312	S
 3B	HA2	158	N
-3B	nuc	1195	C
-3B	nuc	1671	G
+3B	nuc	1212	C
+3B	nuc	1688	G
 3C	HA1	48	I
 3C	HA1	45	N
-3C	nuc	456	T
+3C	nuc	473	T
 3C.2	HA2	160	N
-3C.2	nuc	693	A
-3C.2	nuc	1518	G
+3C.2	nuc	710	A
+3C.2	nuc	1535	G
 3C.3	HA1	128	A
 3C.3	HA1	142	G
 3C.3	nuc	1296	A
@@ -21,7 +21,7 @@ clade	gene	site	alt
 3C.2a	HA1	144	S
 3C.2a	HA1	159	Y
 3C.2a	HA1	160	T
-3C.2a	nuc	1260	A
+3C.2a	nuc	1277	A
 3C.3a	HA1	138	S
 3C.3a	HA1	159	S
 3C.3a	HA1	225	D
@@ -41,7 +41,7 @@ clade	gene	site	alt
 3C.2a1	HA2	155	E
 3C.2a1a	HA1	135	K
 3C.2a1a	HA2	150	E
-3C.2a1a	nuc	472	A
+3C.2a1a	nuc	489	A
 3C.2a1b	HA1	62	G
 3C.2a1b	HA1	142	G
 3C.2a1b	HA1	311	Q

--- a/config/h3n2/ha/emerging_clades.tsv
+++ b/config/h3n2/ha/emerging_clades.tsv
@@ -6,14 +6,14 @@ clade	gene	site	alt
 3B	HA1	223	I
 3B	HA1	312	S
 3B	HA2	158	N
-3B	nuc	1195	C
-3B	nuc	1671	G
+3B	nuc	1212	C
+3B	nuc	1688	G
 3C	HA1	48	I
 3C	HA1	45	N
-3C	nuc	456	T
-3C.2	HA2	160	N
-3C.2	nuc	693	A
-3C.2	nuc	1518	G
+3C	nuc	473	T
+3C.2	HA2	160	N0
+3C.2	nuc	710	A
+3C.2	nuc	1535	G
 3C.3	clade	3C
 3C.3	HA1	128	A
 3C.3	HA1	142	G
@@ -21,7 +21,7 @@ clade	gene	site	alt
 3C.2a	HA1	144	S
 3C.2a	HA1	159	Y
 3C.2a	HA1	160	T
-3C.2a	nuc	1260	A
+3C.2a	nuc	1277	A
 3C.3a	HA1	138	S
 3C.3a	HA1	159	S
 3C.3a	HA1	225	D
@@ -41,7 +41,7 @@ clade	gene	site	alt
 3C.2a1	HA2	155	E
 3C.2a1a	HA1	135	K
 3C.2a1a	HA2	150	E
-3C.2a1a	nuc	472	A
+3C.2a1a	nuc	489	A
 3C.2a1b	HA1	62	G
 3C.2a1b	HA1	142	G
 3C.2a1b	HA1	311	Q


### PR DESCRIPTION
when moving to a different reference, the h3n2 nucleotide coordinates needed to be changed. this was already in place for the `config/h3n2/ha/clades.tsv`, but not the `clades-long` and emerging variants file. 