### PR TITLE
Feat/treeknit refactor

### DIFF
--- a/profiles/europe/builds.yaml
+++ b/profiles/europe/builds.yaml
@@ -1,5 +1,6 @@
 custom_rules:
   - workflow/snakemake_rules/download_from_s3.smk
+  - workflow/snakemake_rules/treeknit.smk
 
 fauna_fasta_fields:
   - strain

--- a/scripts/make-branch-length-json.py
+++ b/scripts/make-branch-length-json.py
@@ -1,0 +1,108 @@
+import argparse
+from treetime.arg import assign_mccs
+from Bio import Phylo
+import numpy as np
+import pandas as pd
+import json
+import random
+
+def to_float(x):
+    try:
+        return float(x)
+    except:
+        return None
+
+def get_clock(fname):
+    with open(fname) as fh:
+        for line in fh:
+            if 'rate:' in line:
+                rate = float(line.strip().split(':')[-1])
+
+    return rate
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(
+        description="turn newick trees into branch length jsons",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument('--timetree', type = str, help='timetree for clock length.', required=True)
+    parser.add_argument('--divtree', type = str, help='divtree for branch length.', required=True)
+    parser.add_argument('--molecular-clock', type = str, help='file with clock rate.', required=True)    
+    parser.add_argument('--mccs', type = str, help='mccs.', required=True)
+    parser.add_argument('--dates', type=str, required=True)
+    parser.add_argument('--output-tree', type=str, required=True)
+    parser.add_argument('--output-node-data', help="name of the file to write node data to", required=True)
+    args = parser.parse_args()
+
+    dates = pd.read_csv(args.dates, sep='\t', index_col=0, skiprows=1)
+    rate = get_clock(args.molecular_clock)
+
+    timetree = Phylo.read(args.timetree, 'nexus')
+    timetree.root.up = None
+    for n in timetree.get_nonterminals():
+        for c in n:
+            c.branch_length *=  rate
+            c.up = n
+
+    divtree = Phylo.read(args.divtree, 'nexus')
+
+    MCCs = []
+    n_large_mccs = 0
+    with open(args.mccs) as fh:
+        for line in fh:
+            if line.strip():
+                MCCs.append(line.strip().split(','))
+                if len(MCCs[-1])>2:
+                    n_large_mccs += 1
+
+
+    MCCs.sort(key=lambda x:len(x), reverse=True)
+    mcc_map = list(range(len(MCCs)))
+    letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    random.seed(987)
+    #random.shuffle(mcc_map)
+
+    leaf_to_MCC = {}
+    for mi,mcc in enumerate(MCCs):
+        if mi<=n_large_mccs:
+            label = letters[mi%len(letters)]
+            if n_large_mccs>len(letters):
+                label = letters[mi//len(letters)] + label
+        else:
+            label = '--'
+        for leaf in mcc:
+            leaf_to_MCC[leaf] = label
+
+    assign_mccs(timetree, leaf_to_MCC, 0)
+
+    node_data = {}
+    for node in timetree.find_clades():
+        node_name = node.name or node.confidence
+        numdate = to_float(dates.loc[node_name,"numeric date"])
+        node.confidence = None
+        node.name = node_name
+        node.comment = ''
+        if node.is_terminal() and (numdate is None):
+            print("pruning node:", node_name, dates.loc[node_name,"numeric date"])
+
+        node_data[node_name] = {"branch_length":node.branch_length,
+                                "clock_length":node.branch_length,
+                                "date": dates.loc[node_name,"date"],
+                                "numdate": numdate,
+                                "num_date_confidence":
+                                    [to_float(dates.loc[node_name,"lower bound"]),
+                                     to_float(dates.loc[node_name,"upper bound"])],
+                                "mcc": node.mcc
+                                }
+
+
+    for node in divtree.find_clades():
+        node_name = node.name or node.confidence
+        if node_name in node_data:
+            node_data[node_name]["mutation_length"] = node.branch_length
+
+    Phylo.write(timetree, args.output_tree, 'newick')
+
+    with open(args.output_node_data, 'w') as fh:
+        json.dump({"nodes": node_data}, fh)

--- a/scripts/sanitize_trees.py
+++ b/scripts/sanitize_trees.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import argparse
 import sys
-
+from treetime import TreeAnc
 from augur.utils import read_tree, InvalidTreeError
 import Bio.Phylo
 
@@ -9,6 +9,7 @@ import Bio.Phylo
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument("--trees", nargs="+", help="trees to sanitize by pruning leaves that do not appear in all trees.")
+    parser.add_argument("--alignments", nargs="+", help="corresponding sequence alignments to remove short branches.")
     parser.add_argument("--output-trees", nargs="+", help="sanitized trees, one for each input tree.")
     args = parser.parse_args()
 
@@ -22,9 +23,12 @@ if __name__ == '__main__':
         sys.exit(1)
 
     common_leaves = set.intersection(*[set(x.name for x in tree.find_clades(terminal=True)) for tree in trees])
-    for output_tree_file, tree in zip(args.output_trees, trees):
+    for output_tree_file, tree, aln in zip(args.output_trees, trees, args.alignments):
         for leaf in set(x.name for x in tree.find_clades(terminal=True)).difference(common_leaves):
             tree.prune(leaf)
 
-        tree.ladderize()
-        Bio.Phylo.write(tree, output_tree_file, 'newick')
+        tt = TreeAnc(tree=tree, aln=aln)
+        tt.infer_ancestral_sequences(infer_gtr=True)
+        tt.prune_short_branches()
+        tt.tree.ladderize()
+        Bio.Phylo.write(tt.tree, output_tree_file, 'newick')

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -139,9 +139,9 @@ rule prune_reference:
 rule sanitize_trees:
     input:
         trees = expand("{build_dir}/{{build_name}}/{segment}/tree_without_outgroup.nwk",  segment=config['segments'], build_dir=[build_dir]),
+        alignments = expand("{build_dir}/{{build_name}}/{segment}/aligned.fasta",  segment=config['segments'], build_dir=[build_dir]),
     output:
         trees = expand("{build_dir}/{{build_name}}/{segment}/tree_common.nwk",  segment=config['segments'], build_dir=[build_dir]),
-        alignments = lambda w: [f"{build_dir}/{w.build_name}/{segment}/aligned.fasta" for segment in config['segments']],
     conda: "../envs/nextstrain.yaml"
     benchmark:
         "benchmarks/sanitize_trees_{build_name}.txt"

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -141,6 +141,7 @@ rule sanitize_trees:
         trees = expand("{build_dir}/{{build_name}}/{segment}/tree_without_outgroup.nwk",  segment=config['segments'], build_dir=[build_dir]),
     output:
         trees = expand("{build_dir}/{{build_name}}/{segment}/tree_common.nwk",  segment=config['segments'], build_dir=[build_dir]),
+        alignments = lambda w: [f"{build_dir}/{w.build_name}/{segment}/aligned.fasta" for segment in config['segments']],
     conda: "../envs/nextstrain.yaml"
     benchmark:
         "benchmarks/sanitize_trees_{build_name}.txt"
@@ -150,6 +151,7 @@ rule sanitize_trees:
         """
         python3 scripts/sanitize_trees.py \
             --trees {input.trees:q} \
+            --alignments {input.alignments:q} \
             --output {output.trees:q} 2>&1 | tee {log}
         """
 

--- a/workflow/snakemake_rules/treeknit.smk
+++ b/workflow/snakemake_rules/treeknit.smk
@@ -1,0 +1,91 @@
+ruleorder: refine_ARG>refine
+
+
+rule treeknit:
+    input:
+        trees = rules.sanitize_trees.output.trees,
+        metadata = build_dir + "/{build_name}/metadata.tsv"
+    output:
+        trees = expand("{build_dir}/{{build_name}}/TreeKnit/tree_common_{segment}.resolved.nwk",
+                       segment=config['segments'][:2], build_dir=[build_dir]),
+        mccs = build_dir + "/{build_name}/TreeKnit/MCCs.dat"
+    params:
+        treetime_tmpdir = build_dir + "/{build_name}/TreeTime_tmp",
+        tmp_trees = expand("{build_dir}/{{build_name}}/TreeKnit/tree_{segment}.nwk",
+                            segment=config['segments'][:2], build_dir=[build_dir]),
+        treeknit_tmpdir = build_dir + "/{build_name}/TreeKnit",
+        clock_filter=4
+    shell:
+        """
+        treeknit {input.trees[0]} {input.trees[1]} --outdir {params.treeknit_tmpdir}
+        """
+
+rule treetime_arg:
+    message:
+        """
+        Refining tree
+          - estimate timetree
+        """
+    input:
+        trees = rules.treeknit.output.trees,
+        mccs = rules.treeknit.output.mccs,
+        alignments = expand("{build_dir}/{{build_name}}/{segment}/aligned.fasta",
+                            segment=config['segments'][:2], build_dir=[build_dir]),
+        metadata = build_dir + "/{build_name}/metadata.tsv"
+    output:
+        directory(build_dir + "/{build_name}/treetime_arg")
+    params:
+        coalescent = "const",
+        date_inference = "always"
+    resources:
+        mem_mb=16000
+    shell:
+        """
+        treetime arg --trees {input.trees} \
+                      --mccs {input.mccs} \
+                      --alignments {input.alignments} \
+                      --confidence --clock-std-dev 0.001 \
+                      --clock-filter 0 \
+                      --outdir  {output} \
+                      --time-marginal {params.date_inference} \
+                      --dates {input.metadata} --keep-root --keep-polytomies
+        """
+
+
+rule refine_ARG:
+    message:
+        """
+        Refining tree
+          - estimate timetree
+        """
+    input:
+        treetime_arg = rules.treetime_arg.output,
+        mccs = rules.treeknit.output.mccs,
+        metadata = build_dir + "/{build_name}/metadata.tsv",
+    output:
+        trees = expand("{build_dir}/{{build_name}}/{segment}/tree.nwk",
+                        segment=config['segments'][:2], build_dir=[build_dir]),
+        node_data = expand("{build_dir}/{{build_name}}/{segment}/branch-lengths.json",
+                            segment=config['segments'][:2], build_dir=[build_dir]),
+    conda: "../envs/nextstrain.yaml"
+    benchmark:
+        "benchmarks/refine_{build_name}.txt"
+    log:
+        "logs/refine_{build_name}.txt"
+    resources:
+        mem_mb=16000
+    shell:
+        """
+        python scripts/make-branch-length-json.py --timetree {input.treetime_arg}/timetree_1.nexus \
+                --divtree {input.treetime_arg}/divergence_tree_1.nexus \
+                --molecular-clock {input.treetime_arg}/molecular_clock_1.txt \
+                --dates {input.treetime_arg}/dates_1.tsv --mccs {input.mccs} \
+                --output-tree {output.trees[0]} --output-node-data {output.node_data[0]}
+
+        python scripts/make-branch-length-json.py --timetree {input.treetime_arg}/timetree_2.nexus \
+                --divtree {input.treetime_arg}/divergence_tree_2.nexus \
+                --molecular-clock {input.treetime_arg}/molecular_clock_2.txt \
+                --dates {input.treetime_arg}/dates_2.tsv  --mccs {input.mccs}  \
+                --output-tree {output.trees[1]} --output-node-data {output.node_data[1]}
+        """
+


### PR DESCRIPTION
This PR adds a set of rules that replace the refine rule in a way that uses the output of TreeKnit and TreeTime to provide better resolved trees and label MCCs to identify reassortment events. 

There additional steps are currently only used in the Europe profile. 