### PR TITLE
Automate builds

### DIFF
--- a/.github/workflows/run-private-nextflu-builds.yaml
+++ b/.github/workflows/run-private-nextflu-builds.yaml
@@ -1,6 +1,12 @@
 name: Run the private Nextflu builds
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      dockerImage:
+        description: "Specific container image to use for build (will override the default of `nextstrain build`)"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -24,3 +30,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.dockerImage }}

--- a/.github/workflows/run-private-nextflu-builds.yaml
+++ b/.github/workflows/run-private-nextflu-builds.yaml
@@ -1,0 +1,26 @@
+name: Run the private Nextflu builds
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+      - name: Launch build on AWS Batch
+        run: |
+          set -x
+
+          nextstrain build \
+            --aws-batch \
+            --detach \
+            --cpus 36 \
+            --memory 72gib \
+            . \
+            all_who \
+            -p \
+            --configfile profiles/private.nextflu.org.yaml
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -1,6 +1,12 @@
 name: Run the Nextstrain public builds
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      dockerImage:
+        description: "Specific container image to use for build (will override the default of `nextstrain build`)"
+        required: false
+        type: string
 
 jobs:
   build:
@@ -24,3 +30,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.dockerImage }}

--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -1,0 +1,26 @@
+name: Run the Nextstrain public builds
+
+on: workflow_dispatch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+      - name: Launch build on AWS Batch
+        run: |
+          set -x
+
+          nextstrain build \
+            --aws-batch \
+            --detach \
+            --cpus 36 \
+            --memory 72gib \
+            . \
+            all_public \
+            -p \
+            --configfile profiles/nextstrain-public.yaml
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -1,7 +1,17 @@
 name: Upload data from fauna to S3
 
 # Only support manual trigger of this workflow.
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      triggerPublic:
+        description: "Trigger Nextstrain public builds"
+        required: true
+        type: boolean
+      triggerPrivateNextflu:
+        description: "Trigger private Nextflu builds"
+        required: true
+        type: boolean
 
 jobs:
   upload:
@@ -28,3 +38,23 @@ jobs:
           RETHINK_AUTH_KEY: ${{ secrets.RETHINK_AUTH_KEY }}
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+  trigger-public-builds:
+    needs: [upload]
+    if: ${{ inputs.triggerPublic }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger Nextstrain public builds
+        run: gh workflow run run-public-builds.yaml --repo nextstrain/seasonal-flu
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+  trigger-private-nextflu-builds:
+    needs: [upload]
+    if: ${{ inputs.triggerPrivateNextflu }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger private Nextflu builds
+        run: gh workflow run run-private-nextflu-builds.yaml --repo nextstrain/seasonal-flu
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -8,10 +8,18 @@ on:
         description: "Trigger Nextstrain public builds"
         required: true
         type: boolean
+      publicDockerImage:
+        description: "Specific container image to use for Nextstrain public builds"
+        required: false
+        type: string
       triggerPrivateNextflu:
         description: "Trigger private Nextflu builds"
         required: true
         type: boolean
+      privateNextfluDockerImage:
+        description: "Specific container image to use for private Nextflu builds"
+        required: false
+        type: string
 
 jobs:
   upload:
@@ -45,7 +53,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Nextstrain public builds
-        run: gh workflow run run-public-builds.yaml --repo nextstrain/seasonal-flu
+        run: |
+          gh workflow run \
+            run-public-builds.yaml \
+            --repo nextstrain/seasonal-flu \
+            -f dockerImage=${{ github.event.inputs.publicDockerImage }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
@@ -55,6 +67,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Trigger private Nextflu builds
-        run: gh workflow run run-private-nextflu-builds.yaml --repo nextstrain/seasonal-flu
+        run: |
+          gh workflow run \
+            run-private-nextflu-builds.yaml \
+            --repo nextstrain/seasonal-flu \
+            -f dockerImage=${{ github.event.inputs.privateNextfluDockerImage }}
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
### Description of proposed changes

Add option to trigger builds after the uploads to S3 have completed.
The downstream triggers are optional, so we can still run upload jobs without starting builds. 
I kept the builds as separate GH workflows so that they can also be run independently of the upload job. 

There's a lot of overlap in the public and private build workflows (as well as with all the other AWS Batch workflows across all of our pathogen repos). Hopefully will be able to trim them down after we set up a reusable workflow for these jobs. 

Still need to manually download the builds from AWS Batch and deploy them. I haven't set up any auto-deployments or Slack messages (yet). 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Worked well for today's builds. [upload](https://github.com/nextstrain/seasonal-flu/actions/runs/4886287107) triggered the downstream [public build](https://github.com/nextstrain/seasonal-flu/actions/runs/4886621659) and [private build](https://github.com/nextstrain/seasonal-flu/actions/runs/4886621735). 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
