### PR TITLE
Add rules to upload parsed sequences and metadata

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -21,7 +21,9 @@ jobs:
             . \
             -j 4 \
             upload_all_titers \
+            upload_all_raw_sequences \
             upload_all_sequences \
+            upload_all_metadata \
             --configfile profiles/upload.yaml
         env:
           RETHINK_HOST: ${{ secrets.RETHINK_HOST }}


### PR DESCRIPTION
### Description of proposed changes

Updates the "upload" profile's custom rules to support uploading parsed sequences (per lineage and segment) and metadata (per lineage) and updates the "upload" GitHub Action to request these new targets for the workflow.

### Related issue(s)

Resolves #107

### Testing

- [x] Checks pass
- [x] Manually run "upload" action to confirm it works as expected