### PR TITLE
use stochastic polytomy resolution

### DIFF
--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -226,6 +226,7 @@ rule refine:
             --output-tree {output.tree} \
             --output-node-data {output.node_data} \
             --keep-root \
+            --stochastic-resolve \
             --timetree \
             --use-fft \
             --no-covariance \


### PR DESCRIPTION
Use stochastic polytomy resolution instead of greedy to avoid caterpillar like trees. 