### PR TITLE
Use pathogen-repo-build workflow for builds

### DIFF
--- a/.github/workflows/run-private-nextflu-builds.yaml
+++ b/.github/workflows/run-private-nextflu-builds.yaml
@@ -9,25 +9,19 @@ on:
         type: string
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      - name: Launch build on AWS Batch
-        run: |
-          set -x
-
-          nextstrain build \
-            --aws-batch \
-            --detach \
-            --cpus 36 \
-            --memory 72gib \
-            . \
-            all_who \
-            -p \
-            --configfile profiles/private.nextflu.org.yaml
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.dockerImage }}
+  run-build:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: aws-batch
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
+      run: |
+        nextstrain build \
+          --detach \
+          --cpus 36 \
+          --memory 72gib \
+          . \
+          all_who \
+          -p \
+          --configfile profiles/private.nextflu.org.yaml

--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -9,25 +9,19 @@ on:
         type: string
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      - name: Launch build on AWS Batch
-        run: |
-          set -x
-
-          nextstrain build \
-            --aws-batch \
-            --detach \
-            --cpus 36 \
-            --memory 72gib \
-            . \
-            all_public \
-            -p \
-            --configfile profiles/nextstrain-public.yaml
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          NEXTSTRAIN_DOCKER_IMAGE: ${{ github.event.inputs.dockerImage }}
+  run-build:
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: aws-batch
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
+      run: |
+        nextstrain build \
+          --detach \
+          --cpus 36 \
+          --memory 72gib \
+          . \
+          all_public \
+          -p \
+          --configfile profiles/nextstrain-public.yaml

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -23,31 +23,19 @@ on:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      # Install Nextstrain CLI, so we can run the flu workflow.
-      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
-      # Run the flu workflow that downloads titers and sequences from fauna and
-      # uploads to S3.
-      - name: Download from fauna and upload to S3
-        run: |
-          set -x
-
-          nextstrain build \
-            --docker \
-            . \
-            -j 4 \
-            upload_all_titers \
-            upload_all_raw_sequences \
-            upload_all_sequences \
-            upload_all_metadata \
-            --configfile profiles/upload.yaml
-        env:
-          RETHINK_HOST: ${{ secrets.RETHINK_HOST }}
-          RETHINK_AUTH_KEY: ${{ secrets.RETHINK_AUTH_KEY }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: docker
+      run: |
+        nextstrain build \
+          . \
+          -j 4 \
+          upload_all_titers \
+          upload_all_raw_sequences \
+          upload_all_sequences \
+          upload_all_metadata \
+          --configfile profiles/upload.yaml
 
   trigger-public-builds:
     needs: [upload]


### PR DESCRIPTION
Simplify build workflows by using the reusable Nextstrain pathogen-repo-build workflow.


### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] [Test upload workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/5625952076)
- [x] [Test public builds workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/5625975282) (cancelled job on AWS Batch)
- [x] [Test private builds workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/5625993347) (cancelled job on AWS Batch)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
