### PR TITLE
Auto deploy public builds

### DIFF
--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -24,6 +24,6 @@ jobs:
           --cpus 36 \
           --memory 72gib \
           . \
-          all_deploy \
+          deploy_all \
           -p \
           --configfile profiles/nextstrain-public.yaml

--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -24,6 +24,6 @@ jobs:
           --cpus 36 \
           --memory 72gib \
           . \
-          all_public \
+          all_deploy \
           -p \
           --configfile profiles/nextstrain-public.yaml

--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -1,6 +1,10 @@
 custom_rules:
   - workflow/snakemake_rules/download_from_s3.smk
   - profiles/nextstrain-public/rename.smk
+  - profiles/nextstrain-public/deploy.smk
+
+# URL for auto-deploying builds
+deploy_url: s3://nextstrain-data
 
 fasta_fields:
   - strain

--- a/profiles/nextstrain-public/deploy.smk
+++ b/profiles/nextstrain-public/deploy.smk
@@ -1,0 +1,15 @@
+"""
+This part of the workflow handles automatic deployments of public builds.
+Depends on the `all_public` rule from rename.smk
+"""
+
+rule all_deploy:
+    input: rules.all_public.input
+    log:
+        "logs/all_deploy.txt"
+    params:
+        s3_dst = config["deploy_url"]
+    shell:
+        """
+        nextstrain remote upload {params.s3_dst} {input} 2>&1 | tee {log}
+        """

--- a/profiles/nextstrain-public/deploy.smk
+++ b/profiles/nextstrain-public/deploy.smk
@@ -5,11 +5,9 @@ Depends on the `all_public` rule from rename.smk
 
 rule all_deploy:
     input: rules.all_public.input
-    log:
-        "logs/all_deploy.txt"
     params:
         s3_dst = config["deploy_url"]
     shell:
         """
-        nextstrain remote upload {params.s3_dst} {input} 2>&1 | tee {log}
+        nextstrain remote upload {params.s3_dst} {input}
         """

--- a/profiles/nextstrain-public/deploy.smk
+++ b/profiles/nextstrain-public/deploy.smk
@@ -3,7 +3,7 @@ This part of the workflow handles automatic deployments of public builds.
 Depends on the `all_public` rule from rename.smk
 """
 
-rule all_deploy:
+rule deploy_all:
     input: rules.all_public.input
     params:
         s3_dst = config["deploy_url"]


### PR DESCRIPTION
### Description of proposed changes

Deploy the public builds to s3://nextstrain-data as part of the automated public workflow. 
The public builds should no longer have to be manually inspected since outliers are now automatically removed as of #110. 

### Related issue(s)
Follow up to #106 

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] To test w/ @j23414 as part of our weekly builds

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
