### PR TITLE
Remove AUGUR_RECURSION_LIMIT

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -2,10 +2,6 @@ import datetime
 import pandas as pd
 from treetime.utils import numeric_date
 
-# Set the maximum recursion limit globally for all shell commands, to avoid
-# issues with large trees crashing the workflow. Preserve Snakemake's default
-# use of Bash's "strict mode", as we rely on that behaviour.
-shell.prefix("set -euo pipefail; export AUGUR_RECURSION_LIMIT=10000; ")
 
 wildcard_constraints:
     segment = r'pb2|pb1|pa|ha|np|na|ma',

--- a/profiles/scicore/submit.sh
+++ b/profiles/scicore/submit.sh
@@ -8,8 +8,5 @@ source ~/miniconda3/etc/profile.d/conda.sh
 conda activate nextstrain
 #Test
 export AUGUR_MINIFY_JSON=1
-export AUGUR_RECURSION_LIMIT=10000
 
 {exec_job}
-
-


### PR DESCRIPTION
The AUGUR_RECURSION_LIMIT is set to 10,000 by default since Augur 22.0.0 and the workflow's minimum required Augur version is now 22.0.2¹

¹ https://github.com/nextstrain/seasonal-flu/blob/65df51732abcad6480239fb0c7e76e47ae5c9723/workflow/envs/nextstrain.yaml#L7

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
