### PR TITLE
Update builds to use `--env` options

### DIFF
--- a/.github/workflows/run-private-nextflu-builds.yaml
+++ b/.github/workflows/run-private-nextflu-builds.yaml
@@ -23,6 +23,8 @@ jobs:
           --detach \
           --cpus 36 \
           --memory 72gib \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
           . \
           all_who \
           -p \

--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -23,6 +23,8 @@ jobs:
           --detach \
           --cpus 36 \
           --memory 72gib \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
           . \
           deploy_all \
           -p \

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -31,6 +31,10 @@ jobs:
       runtime: docker
       run: |
         nextstrain build \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
+          --env RETHINK_AUTH_KEY \
+          --env RETHINK_HOST \
           . \
           -j 4 \
           upload_all_titers \


### PR DESCRIPTION
### Description of proposed changes

Better to be explicit about which envvars are being passed to runtimes rather than rely on the automatic variables passed through.

The upload workflow requires the rethinkdb secrets to access Fauna and the AWS secrets to upload files to S3.

The public and private builds just need the AWS secrets to launch jobs on AWS Batch and to download files from S3.

These are all GitHub Action secrets that are being inherited by the reusable workflow and available as envvars in the GitHub Action job.

### Related issue(s)

Follow up on https://github.com/nextstrain/seasonal-flu/pull/111, following @tsibley's [recommendation](https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1692833620772029?thread_ts=1690498985.056099&cid=C01LCTT7JNN) to be explicit about envvars.

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] ~I meant to run this as today's workflow but oh well. Will test next week.~ Yesterday's [upload job failed](https://github.com/nextstrain/seasonal-flu/actions/runs/5969355108), so testing this [upload workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/5978175659) today.  
- [x] [test run of public builds](https://github.com/nextstrain/seasonal-flu/actions/runs/5978751220)
- [x] [test run of private builds](https://github.com/nextstrain/seasonal-flu/actions/runs/5978753034) 

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
