### PR TITLE
Deploy private nextflu builds to Netlify

### DIFF
--- a/.github/workflows/deploy-private-nextflu.yaml
+++ b/.github/workflows/deploy-private-nextflu.yaml
@@ -1,0 +1,56 @@
+name: Deploy private.nextflu.org
+
+on:
+  workflow_dispatch:
+
+env:
+  # Everything should run from within the nextflu/auspice directory
+  # https://github.com/blab/nextflu/tree/e672eba6d2e0ad5e10b0775f94fc87ffc75d6005/auspice
+  WORKING_DIR: auspice
+
+defaults:
+  run:
+    # Cannot use contexts or expressions for this top level defaults, so must
+    # hard-code the path instead of using env.WORKING_DIR
+    # https://docs.github.com/en/actions/using-jobs/setting-default-values-for-jobs#setting-default-shell-and-working-directory
+    working-directory: auspice
+
+jobs:
+  deploy_to_netlify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: blab/nextflu
+          sparse-checkout: |
+            ${{ env.WORKING_DIR }}
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.3.7'
+          bundler-cache: true
+          # `uses` does not respect the default working-directory
+          # Luckily, the setup-ruby action has a `working-directory` input
+          # https://github.com/ruby/setup-ruby#working-directory
+          #
+          # Must be set to access the Gemfile.lock file in the auspice directory
+          # https://github.com/blab/nextflu/blob/12c5645d990f53c553d6f04e293e2f12b4ad3575/auspice/Gemfile.lock
+          working-directory: ${{ env.WORKING_DIR }}
+
+      - name: Build site
+        run: bundle exec jekyll build
+
+      - uses: actions/setup-node@v3
+        with:
+          # Minimum node version to install Netlify CLI
+          # https://docs.netlify.com/cli/get-started/#installation
+          node-version: 16
+
+      - name: Install Netlify CLI
+        run: npm install netlify-cli -g
+
+      - name: Deploy to Netlify
+        run: netlify deploy --build --prod
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STAGING }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/deploy-private-nextflu.yaml
+++ b/.github/workflows/deploy-private-nextflu.yaml
@@ -2,11 +2,17 @@ name: Deploy private.nextflu.org
 
 on:
   workflow_dispatch:
+    inputs:
+      aws_batch_job_id:
+        description: The AWS Batch Job ID for the private nextflu seasonal flu builds.
+        type: string
+        required: true
 
 env:
   # Everything should run from within the nextflu/auspice directory
   # https://github.com/blab/nextflu/tree/e672eba6d2e0ad5e10b0775f94fc87ffc75d6005/auspice
   WORKING_DIR: auspice
+  AUSPICE_DIR: auspice-who
 
 defaults:
   run:
@@ -36,6 +42,30 @@ jobs:
           # Must be set to access the Gemfile.lock file in the auspice directory
           # https://github.com/blab/nextflu/blob/12c5645d990f53c553d6f04e293e2f12b4ad3575/auspice/Gemfile.lock
           working-directory: ${{ env.WORKING_DIR }}
+
+      - uses: nextstrain/.github/actions/setup-nextstrain-cli@master
+
+      - name: Download builds from AWS Batch
+        run: |
+          nextstrain build \
+          --aws-batch \
+          --attach "$AWS_BATCH_JOB_ID" \
+          --download "$AUSPICE_DIR/*.json" \
+          --no-logs \
+          .
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_BATCH_JOB_ID: ${{ inputs.aws_batch_job_id }}
+
+      - name: Move Auspice JSONs
+        run: |
+          mkdir data
+          mv "$AUSPICE_DIR"/*.json data/
+          rm -r "$AUSPICE_DIR"
+
+      - name: Create index files
+        run: python provision_directories.py
 
       - name: Build site
         run: bundle exec jekyll build

--- a/.github/workflows/deploy-private-nextflu.yaml
+++ b/.github/workflows/deploy-private-nextflu.yaml
@@ -7,6 +7,10 @@ on:
         description: The AWS Batch Job ID for the private nextflu seasonal flu builds.
         type: string
         required: true
+      deploy_to_staging:
+        description: Deploy to the staging website at https://staging-private-nextflu.netlify.app
+        type: boolean
+        required: true
 
 env:
   # Everything should run from within the nextflu/auspice directory
@@ -82,5 +86,5 @@ jobs:
       - name: Deploy to Netlify
         run: netlify deploy --build --prod
         env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID_STAGING }}
+          NETLIFY_SITE_ID: ${{ inputs.deploy_to_staging && secrets.NETLIFY_SITE_ID_STAGING || secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}


### PR DESCRIPTION
## Description of proposed changes

The private.nextflu.org site is still built using the old Auspice
version in https://github.com/blab/nextflu and deployed to Netlify.
This requires an older version of Ruby (2.3.7) and dependencies that
others have had trouble installing on the new M1 macs. Instead of
depending on my old mac to deploy the private builds, use a GitHub
Action workflow  to deploy the site that anyone on the Nextstrain team
can run.

I've opted for this route instead of trying to update the dependencies
for the old Auspice because the ultimate goal is to sunset the private
site. This seemed like less work than fiddling with dependencies.

> [!NOTE]  
> For this new workflow, I had to add [ruby/setup-ruby@v1](https://github.com/ruby/setup-ruby) to the Nextstrain's list of allowed actions.


## Next steps 

This can be run manually for now, but would be best to connect with the private builds to auto-deploy to the private site when the build succeeds. 

The easiest route would be to keep the private builds attached to the AWS Batch job and then trigger this new workflow 
when the job is complete. The private builds are running up to ~4hrs, which is within GH's 6hr job limit. However, I'm not doing this now since we still have limited concurrency for GH Actions. 
