### PR TITLE
Fix deploy private

### DIFF
--- a/.github/workflows/deploy-private-nextflu.yaml
+++ b/.github/workflows/deploy-private-nextflu.yaml
@@ -81,7 +81,7 @@ jobs:
           node-version: 18
 
       - name: Install Netlify CLI
-        run: npm install netlify-cli -g
+        run: npm install netlify-cli@17.2.2 -g
 
       - name: Deploy to Netlify
         run: netlify deploy --build --prod

--- a/.github/workflows/deploy-private-nextflu.yaml
+++ b/.github/workflows/deploy-private-nextflu.yaml
@@ -78,7 +78,7 @@ jobs:
         with:
           # Minimum node version to install Netlify CLI
           # https://docs.netlify.com/cli/get-started/#installation
-          node-version: 16
+          node-version: 18
 
       - name: Install Netlify CLI
         run: npm install netlify-cli -g


### PR DESCRIPTION
## Description of proposed changes

Pin Netlify CLI version for now to get the deployment of the private nextflu site working. 

When I went to login to the private site after deployment today, the username and password did not work as expected. 
I compared [this weeks deployment](https://github.com/nextstrain/seasonal-flu/actions/runs/6907038759/job/18793376743#step:10:11) to [last week's deployment](https://github.com/nextstrain/seasonal-flu/actions/runs/6853790956/job/18635385696#step:10:11) and saw a change in the Netlify CLI version from 17.2.2 to 17.5.1. 


I did [a test run with the Netlify CLI pinned to 17.2.2](https://github.com/nextstrain/seasonal-flu/actions/runs/6908500166) and the staging site was working as expected. 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
