### PR TITLE
Make Markdown output for reports

### DIFF
--- a/profiles/nextflu-private/README.md
+++ b/profiles/nextflu-private/README.md
@@ -27,6 +27,8 @@ nextstrain build \
   --memory 48Gib \
   . \
     -p \
+    all \
+    all_counts_of_recent_tips_by_clade \
     --configfile profiles/nextflu-private.yaml \
     --set-threads tree=7
 ```
@@ -39,6 +41,8 @@ Alternately, run the jobs on the Hutch's SLURM cluster with the following comman
 ```bash
 snakemake \
   -j 10 \
+  all \
+  all_counts_of_recent_tips_by_clade \
   --configfile profiles/nextflu-private.yaml \
   --profile profiles/hutch
 ```

--- a/profiles/nextflu-private/antigenic_distances.smk
+++ b/profiles/nextflu-private/antigenic_distances.smk
@@ -76,6 +76,7 @@ rule summarize_haplotype_titer_coverage:
     output:
         table="builds/{build_name}/{segment}/haplotype_summary/{titer_collection}.tsv",
         node_data="builds/{build_name}/{segment}/haplotypes_without_references/{titer_collection}.json",
+        markdown_table="builds/{build_name}/{segment}/haplotype_summary/{titer_collection}.md",
     benchmark:
         "benchmarks/summarize_haplotype_titer_coverage_{build_name}_{segment}_{titer_collection}.txt"
     log:
@@ -89,6 +90,7 @@ rule summarize_haplotype_titer_coverage:
             --frequencies {input.frequencies} \
             --attribute-name-for-haplotype-without-reference "haplotype_missing_reference_virus_in_{wildcards.titer_collection}" \
             --output-table {output.table} \
+            --output-markdown-table {output.markdown_table} \
             --output-node-data {output.node_data} 2>&1 | tee {log}
         """
 

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -12,3 +12,22 @@ rule plot_lineage_counts:
     log:
         "logs/plot-counts-per-lineage.ipynb"
     notebook: "../../notebooks/plot-counts-per-lineage.py.ipynb"
+
+rule all_counts_of_recent_tips_by_clade:
+    input:
+        counts=expand("builds/{build_name}/counts_of_recent_tips_by_clade.md", build_name=list(config["builds"].keys()))
+
+rule count_recent_tips_by_clade:
+    input:
+        recency="builds/{build_name}/recency.json",
+        clades="builds/{build_name}/ha/clades.json",
+    output:
+        counts="builds/{build_name}/counts_of_recent_tips_by_clade.md",
+    conda: "../../workflow/envs/nextstrain.yaml"
+    shell:
+        """
+        python3 scripts/count_recent_tips_by_clade.py \
+            --recency {input.recency} \
+            --clades {input.clades} \
+            --output {output.counts}
+        """

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -20,7 +20,7 @@ rule all_counts_of_recent_tips_by_clade:
 rule count_recent_tips_by_clade:
     input:
         recency="builds/{build_name}/recency.json",
-        clades="builds/{build_name}/ha/clades.json",
+        clades="builds/{build_name}/ha/subclades.json",
     output:
         counts="builds/{build_name}/counts_of_recent_tips_by_clade.md",
     conda: "../../workflow/envs/nextstrain.yaml"

--- a/scripts/count_recent_tips_by_clade.py
+++ b/scripts/count_recent_tips_by_clade.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
     # Count the clade membership for each recent tip.
     count_by_clade = pd.DataFrame.from_dict(
         Counter([
-            node_data["clade_membership"]
+            node_data["subclade"]
             for node_name, node_data in clades["nodes"].items()
             if node_name in recent_tips
         ]),

--- a/scripts/count_recent_tips_by_clade.py
+++ b/scripts/count_recent_tips_by_clade.py
@@ -1,0 +1,59 @@
+"""
+Count recent tips by clade for reporting.
+"""
+import argparse
+from augur.utils import read_node_data
+from collections import Counter
+import pandas as pd
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Annotate derived haplotypes per node from annotated clades and store as node data JSON",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("--recency", help="recency annotations in node data JSON format based on submission date of sequences", required=True)
+    parser.add_argument("--clades", help="clade annotations in node data JSON format", required=True)
+    parser.add_argument("--recency-values", nargs="+", default=["last week", "last month"], help="values in the 'recency' annotation to use for counting recent sequences")
+    parser.add_argument("--output", help="Markdown file with list of recent sequence counts per clade", required=True)
+    args = parser.parse_args()
+
+    # Load recency annotations.
+    recency = read_node_data(args.recency)
+
+    # Load clades.
+    clades = read_node_data(args.clades)
+
+    # Find all nodes with recency values that match the requested values.
+    recent_tips = {
+        node_name
+        for node_name, node_data in recency["nodes"].items()
+        if node_data.get("recency") in args.recency_values
+    }
+
+    # Count the clade membership for each recent tip.
+    count_by_clade = pd.DataFrame.from_dict(
+        Counter([
+            node_data["clade_membership"]
+            for node_name, node_data in clades["nodes"].items()
+            if node_name in recent_tips
+        ]),
+        orient="index",
+        columns=["count"],
+    )
+
+    count_by_clade.index.name = "clade"
+
+    # Annotate the total number of tips.
+    count_by_clade.loc["total", "count"] = count_by_clade["count"].sum()
+    count_by_clade["count"] = count_by_clade["count"].astype(int)
+
+    # Sort by count in descending order.
+    count_by_clade = count_by_clade.sort_values(
+        "count",
+        ascending=False,
+    )
+
+    # Save Markdown table.
+    with open(args.output, "w", encoding="utf-8") as oh:
+        print(count_by_clade.to_markdown(), file=oh)

--- a/scripts/summarize_haplotype_titer_coverage.py
+++ b/scripts/summarize_haplotype_titer_coverage.py
@@ -114,15 +114,15 @@ if __name__ == '__main__':
     # Fill missing distinct references with empty string.
     annotated_haplotypes["distinct_references"] = annotated_haplotypes["distinct_references"].fillna("")
 
-    # Round deminal values of frequencies.
-    annotated_haplotypes["current_frequency"] = annotated_haplotypes["current_frequency"].round(2)
-
-    # Keep non-zero frequencies.
-    annotated_haplotypes = annotated_haplotypes.query("current_frequency > 0").copy()
-
-    # Round change in frequency.
-    annotated_haplotypes["delta_frequency"] = annotated_haplotypes["delta_frequency"].round(2)
+    # Keep haplotypes with at least 1% frequency.
+    annotated_haplotypes = annotated_haplotypes.query("current_frequency >= 0.01").copy()
 
     # Save Markdown table.
     with open(args.output_markdown_table, "w", encoding="utf-8") as oh:
-        print(annotated_haplotypes.to_markdown(index=False), file=oh)
+        print(
+            annotated_haplotypes.to_markdown(
+                index=False,
+                floatfmt=".2f",
+            ),
+            file=oh,
+        )

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -16,6 +16,8 @@ dependencies:
   - seqkit=2.2.0
   - csvtk=0.23.0
   - tsv-utils=2.2.0
+  - tabulate=0.8.10
   - xlrd=1.*
+  - pip=23.0.1
   - pip:
     - rethinkdb==2.3.0.post6

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -4,7 +4,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - augur=23.1.0
+  - augur=23.1.1
   - biopython=1.80
   - awscli=1.27.9
   - epiweeks=2.1.2
@@ -16,7 +16,7 @@ dependencies:
   - seqkit=2.2.0
   - csvtk=0.23.0
   - tsv-utils=2.2.0
-  - tabulate=0.8.10
+  - tabulate=0.9.0
   - xlrd=1.*
   - pip=23.0.1
   - pip:


### PR DESCRIPTION
## Description of proposed changes

Adds Snakemake rules and scripts to make Markdown tables as part of the nextflu-private workflow, so we can add these tables to our monthly reports.

## Related issue(s)

The functionality from this PR depends on [the tabulate package](https://pypi.org/project/tabulate/). This package gets installed implicitly in Nextstrain Docker and Conda runtimes as a dependency of Snakemake, however we will want to eventually install tabulate in those runtimes explicitly to document that we depend on it directly. [See this Slack thread for more details](https://bedfordlab.slack.com/archives/C03KWNCLK/p1686327885597899?thread_ts=1686324517.672459&cid=C03KWNCLK).

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
