### PR TITLE
Add h3n2/na segment length to GFF

### DIFF
--- a/config/h3n2/na/genemap.gff
+++ b/config/h3n2/na/genemap.gff
@@ -1,2 +1,3 @@
 ##gff-version 3
+##sequence-region CY114383 1 1436
 CY114383	feature	gene	4	1413	.	+	.	gene_name="NA"


### PR DESCRIPTION
Including such information will become mandatory in Augur following <https://github.com/nextstrain/augur/pull/1351>.

Segment length from <https://www.ncbi.nlm.nih.gov/nuccore/CY114383>

This absence was noticed by [this failing CI action](https://github.com/nextstrain/augur/actions/runs/7107634336/job/19349457899) on the [above augur PR](https://github.com/nextstrain/augur/pull/1351) 