### PR TITLE
Version nextclade binary for transition, i.e. nextclade -> nextclade2

### DIFF
--- a/workflow/snakemake_rules/report.smk
+++ b/workflow/snakemake_rules/report.smk
@@ -16,7 +16,7 @@ rule get_nextclade_dataset:
         dataset = "flu_{lineage}_ha"
     shell:
         """
-        nextclade dataset get --name {params.dataset} --output-dir {params.nextclade_dir} 2>&1 | tee {log}
+        nextclade2 dataset get --name {params.dataset} --output-dir {params.nextclade_dir} 2>&1 | tee {log}
         """
 
 rule nextclade_all:
@@ -36,7 +36,7 @@ rule nextclade_all:
     threads: 8
     shell:
         """
-        nextclade run \
+        nextclade2 run \
             --verbosity=error \
             --input-dataset {params.nextclade_dataset} \
             -j {threads} \


### PR DESCRIPTION
Soon we will release nextclade v3. Once nextclade v3 hits bioconda, workflows that rely on v2 syntax will break. To prevent this, this PR makes it explicit that the syntax used is for v2 and that the v2 binary nextclade2 should be used.

This binary is in both the nextstrain-base docker image and in the conda-base managed conda environment.

Users who don't use either will have to add nextclade2 to the path.

Over the next few weeks, we will transition repos to use nextclade3. The reason to add nextclade2 now is so that workflows don't break if they haven't yet transitioned to nextclade3 at the time of v3 release. It also makes it easy to search which workflows need to be changed.
