### PR TITLE
Add Auspice JSON colorings for HA/NA accessions

### DIFF
--- a/config/h1n1pdm/auspice_config.json
+++ b/config/h1n1pdm/auspice_config.json
@@ -88,6 +88,16 @@
       "type": "categorical"
     },
     {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
       "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"

--- a/config/h3n2/auspice_config.json
+++ b/config/h3n2/auspice_config.json
@@ -98,6 +98,16 @@
       "type": "categorical"
     },
     {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
       "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"

--- a/config/vic/auspice_config.json
+++ b/config/vic/auspice_config.json
@@ -73,6 +73,16 @@
       "type": "categorical"
     },
     {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
       "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"

--- a/config/yam/auspice_config.json
+++ b/config/yam/auspice_config.json
@@ -68,6 +68,16 @@
       "type": "categorical"
     },
     {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
       "key": "submitting_lab",
       "title": "Submitting lab",
       "type": "categorical"


### PR DESCRIPTION
## Description of proposed changes

Adds coloring entries for the HA and NA accessions associated with each sequence in a build, so this information appears in the public trees and allows users to determine the sequences that correspond with each strain name.

## Related issue(s)

Closes #137

## Checklist

- [x] Checks pass