### PR TITLE
Add measurements panel for Welsh et al. escape scores

### DIFF
--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/150C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/150C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '150C' in cohort '40-45_years'",
   "serum": "150C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/150C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/150C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/150C.json
@@ -1,0 +1,3371 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '150C' in cohort '40-45_years'",
+  "serum": "150C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0163
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0032
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1293
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0189
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0208
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1053
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0413
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0278
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.0406
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0706
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0139
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0386
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.032
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0797
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0706
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0069
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0883
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.1399
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0624
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0751
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0175
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1403
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0393
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0411
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0166
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0786
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0103
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0398
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0858
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0601
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.1275
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0254
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "C",
+          "weight": 0.0547
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0129
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.177
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.1686
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0628
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.1577
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0619
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0011
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0372
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.056
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1117
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0432
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0253
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1208
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1219
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0531
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.2018
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.039
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.1259
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0113
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1313
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0554
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0719
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.083
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0063
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0125
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.1825
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0073
+        }
+      ],
+      "16": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0551
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0729
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0497
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0771
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0241
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0846
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0641
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.1413
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0576
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0976
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0323
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0534
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0244
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0087
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0165
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0221
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0281
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0973
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0575
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0415
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.126
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.035
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0646
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1419
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0334
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0312
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0166
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0445
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0245
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0478
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0942
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0054
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0442
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0407
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1387
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0033
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0783
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.032
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0082
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0552
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0402
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1295
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0711
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0487
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0106
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0023
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0235
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0153
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.022
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0086
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0134
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0696
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0036
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0805
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0098
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0195
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0008
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0237
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.029
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0536
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0129
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.023
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0618
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.002
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0321
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0155
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1179
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0062
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0384
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0329
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0399
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0195
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.01
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0584
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1261
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0733
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1282
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.004
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1994
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0343
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0463
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0316
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0439
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.057
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0049
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0382
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.029
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0859
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.037
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0517
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0385
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.1169
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0731
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0485
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0051
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0248
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0047
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0044
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0825
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.1212
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0493
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0056
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0071
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0278
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.0124
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0249
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0202
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0025
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0015
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0623
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1611
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0395
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0327
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0625
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1118
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0884
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0615
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0817
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0218
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0388
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0234
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.004
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.002
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0212
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0365
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0247
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.027
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0091
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0018
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1705
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.084
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0419
+        }
+      ],
+      "73": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0359
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0057
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0549
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0022
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.036
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0395
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0782
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0457
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0045
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0929
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0609
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1318
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0101
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0838
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0929
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0189
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0471
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0336
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0605
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.156
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0057
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.019
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0014
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0645
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0543
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0111
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.048
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0853
+        }
+      ],
+      "84": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0262
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0555
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0944
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0029
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0985
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.2004
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0209
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0644
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0027
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0086
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0361
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0829
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0876
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1229
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0401
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0247
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0306
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.046
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0104
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.015
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0394
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0725
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0319
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0122
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0782
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0271
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0014
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0156
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.1276
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0109
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0099
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.022
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.021
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.085
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0836
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0286
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0279
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0193
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0881
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0193
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0608
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0549
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.056
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0554
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0344
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0131
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0354
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0199
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0085
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0176
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0297
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0903
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0305
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0558
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.1761
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.065
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0276
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1151
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0576
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0171
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0665
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0608
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0218
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0369
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1015
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0386
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0396
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0673
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0709
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0109
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.046
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0482
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0563
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1829
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.1138
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.2631
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0875
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0988
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0371
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0334
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1648
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0639
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1521
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1315
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.045
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1188
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0708
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1688
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1211
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0319
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0176
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0392
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2274
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0648
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0767
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1129
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.019
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.4634
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0931
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0037
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0978
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0217
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0483
+        },
+        {
+          "from": "L",
+          "to": "T",
+          "weight": 0.106
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.027
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0216
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0969
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0186
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0953
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0958
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1406
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0116
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0998
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0006
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0929
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0022
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0223
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.066
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0121
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0268
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0013
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0087
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0924
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0488
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0412
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.037
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0337
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0306
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0441
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1187
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.052
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0097
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0647
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0232
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "N",
+          "weight": 0.0183
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.1932
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1128
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0061
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0489
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0303
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.091
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.074
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.2642
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2128
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.1805
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.122
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.4947
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.6459
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.6864
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.3978
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.3621
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.4795
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.4039
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.5335
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.4193
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.5587
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.5137
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.3486
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3656
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3809
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.5978
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.3511
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0178
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.055
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0171
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0319
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1108
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0458
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0122
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0046
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0352
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0159
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0569
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5557
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.3904
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.1879
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1413
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.2183
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1504
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1637
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1805
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1711
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0919
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.044
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.053
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0267
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1092
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0219
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0438
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1133
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0132
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0438
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0229
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0647
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0408
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0043
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0608
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0783
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1107
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1704
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0845
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1377
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0539
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0328
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0095
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0229
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0206
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0706
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0389
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0057
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0914
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.008
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0228
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.011
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.105
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0996
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0449
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0599
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0275
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0269
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0497
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1253
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0709
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0024
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0614
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0035
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0232
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.1294
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0503
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0612
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.005
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0332
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.016
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0047
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0437
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.09
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0215
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0408
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0944
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0589
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0758
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0006
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0188
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0628
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0311
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0206
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0479
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0446
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0179
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0297
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0022
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.033
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0269
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1022
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1032
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.006
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.245
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1585
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0292
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.119
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0077
+        }
+      ],
+      "229": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0193
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0887
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0453
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0037
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0243
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0036
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.106
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.018
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0852
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1109
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1258
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0362
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0756
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.0549
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.106
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0577
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0618
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0375
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.041
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0305
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0229
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0586
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0014
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0016
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0891
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0796
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0163
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0326
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0265
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0157
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.06
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0868
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1337
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0162
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0352
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0413
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0328
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0353
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0312
+        }
+      ],
+      "273": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0702
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0229
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0347
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0369
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0342
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0155
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0096
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0777
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0613
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0461
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0963
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0052
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0448
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0112
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0132
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0995
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0639
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0312
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0285
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0632
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1414
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0642
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.1477
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.076
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0577
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0062
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.062
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0575
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0308
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.104
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1225
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0405
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0068
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0733
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0878
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0012
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0095
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1002
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0196
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0406
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0238
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0248
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.1068
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0332
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0368
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0215
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0549
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.031
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0242
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1024
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0652
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0434
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.1203
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.2526
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0788
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0493
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1107
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0822
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0529
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0214
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1489
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.2045
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0891
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0244
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.144
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0675
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0393
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0256
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0959
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0614
+        },
+        {
+          "from": "V",
+          "to": "Y",
+          "weight": 0.0011
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0519
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.09
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0057
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0052
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0373
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0283
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0408
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.032
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0243
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0417
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0166
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1476
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0415
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0136
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.051
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0437
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/18C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/18C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '18C' in cohort '40-45_years'",
   "serum": "18C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/18C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/18C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/18C.json
@@ -1,0 +1,3717 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '18C' in cohort '40-45_years'",
+  "serum": "18C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": -0.0
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.053
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0424
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0626
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.001
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0808
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0441
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0166
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0151
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0258
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0918
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0416
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0485
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0867
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0129
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0005
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0325
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0766
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0805
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0212
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0352
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0841
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0063
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0766
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0675
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0021
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0338
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0908
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1038
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0186
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0342
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.1006
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0521
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.265
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0832
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0952
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0064
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0465
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0421
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0713
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0456
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0094
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0611
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0531
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0518
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0397
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0169
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0095
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0333
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0597
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.043
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0301
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0906
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0336
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0612
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.041
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0162
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0221
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.023
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.004
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0028
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0056
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1399
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.001
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0277
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.045
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0189
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.001
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0247
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0284
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.1745
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0343
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0296
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0666
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.014
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0007
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0999
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0882
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0328
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0356
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.007
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0334
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0477
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0495
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0194
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.012
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0717
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0267
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0196
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0115
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1696
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0331
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0014
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0543
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1758
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0058
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0026
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0256
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0063
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0336
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0609
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0449
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0001
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0273
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0318
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0271
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.085
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0048
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0646
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0195
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0345
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0738
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.1239
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0359
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0164
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0676
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0776
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0724
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0176
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0009
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0391
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.043
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.026
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0373
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0972
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1376
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0404
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0325
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0768
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0054
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0085
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0188
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0082
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.013
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0967
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1103
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0179
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1246
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.1294
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0233
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.159
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0166
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0181
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0931
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0036
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0249
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1321
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0378
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0318
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0336
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0356
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0106
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1112
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1017
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.2102
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.001
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.2111
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0849
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0518
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.0529
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.027
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0247
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0373
+        }
+      ],
+      "51": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0597
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0922
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.042
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.09
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0233
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0181
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0442
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.1173
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.005
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.2351
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0597
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0411
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0117
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0625
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0366
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0552
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0566
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0242
+        }
+      ],
+      "70": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.059
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0242
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0032
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.061
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0042
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0067
+        }
+      ],
+      "77": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0231
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0706
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0045
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.077
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1319
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0737
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0643
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1139
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.051
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1069
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0413
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0187
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.032
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0506
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0327
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0025
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0139
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.081
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0237
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0514
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0881
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0066
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0588
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0042
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1002
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0414
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0653
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0719
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0606
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.09
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.032
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.076
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0091
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.033
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0461
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.023
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1145
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0712
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0718
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0612
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.045
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0079
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.04
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0394
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0783
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0554
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.1143
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0886
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0322
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0926
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0783
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0737
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0694
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0128
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0483
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0117
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0073
+        }
+      ],
+      "102": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0925
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0515
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.1231
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0877
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0766
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0773
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0329
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0999
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0032
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0188
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.0051
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.078
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0276
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0023
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0116
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0075
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0829
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0032
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0767
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0382
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0519
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0471
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0369
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0076
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.02
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0099
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0048
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0607
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0208
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0715
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.052
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0106
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0247
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0442
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0205
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0034
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1143
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0111
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0684
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0129
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0499
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0189
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1288
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1785
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0138
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0934
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0221
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.2465
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0506
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0647
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1973
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0427
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0729
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.037
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0564
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0005
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0281
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0019
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1345
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0082
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1008
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0189
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1087
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0478
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0131
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0101
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0638
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0748
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0745
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0753
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0459
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.049
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0138
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1043
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0705
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0292
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0209
+        }
+      ],
+      "155": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0235
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.0256
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0525
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.089
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.113
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.1635
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0073
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0343
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0083
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0496
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0402
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.1721
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0536
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0586
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.047
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0016
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0563
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0427
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.036
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1017
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0269
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0448
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.026
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0743
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0443
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.149
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0291
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0058
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0074
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0172
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0554
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0187
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.007
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1094
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0522
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.111
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0228
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0161
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "N",
+          "weight": 0.0033
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1335
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1521
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0488
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0906
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1669
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0858
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0555
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0516
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0136
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2947
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.2611
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.5431
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1731
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1385
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1879
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1094
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1316
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.382
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.2033
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.2527
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.243
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2906
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3066
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1924
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1663
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0546
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0661
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0124
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0086
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.3211
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.3824
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0122
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0585
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.145
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.1589
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0268
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0695
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0933
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0043
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1152
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0498
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0176
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0341
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0097
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.022
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0197
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0553
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0559
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0227
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0155
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0728
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0583
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0222
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0457
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0055
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0128
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1205
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0138
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0161
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0344
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0542
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0983
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0175
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0451
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.1172
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.3267
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0102
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1049
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1583
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.1479
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0324
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0385
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0117
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0338
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0815
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.079
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0738
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0404
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0466
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0408
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0233
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0209
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0845
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0194
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0925
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0146
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0948
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1448
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0395
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0269
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0652
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1184
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0452
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0068
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0311
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0061
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0368
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0321
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.1724
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0569
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.061
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.2355
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0342
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0924
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0095
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0307
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0523
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0575
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0508
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0767
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0464
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0094
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0884
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0504
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1083
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0638
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0019
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0073
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0162
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0002
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0813
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0181
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.1545
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0628
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1553
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1056
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.045
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1591
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0558
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0654
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0121
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0363
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0583
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0053
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.012
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.019
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.009
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.1331
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1084
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0081
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0372
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1262
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0593
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0398
+        }
+      ],
+      "223": [
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0212
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0869
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0203
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.005
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0131
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0119
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.05
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0637
+        },
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.1505
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0296
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1268
+        },
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0472
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0131
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1224
+        },
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0619
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0676
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0223
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0208
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1458
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.1146
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0786
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0278
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0324
+        },
+        {
+          "from": "L",
+          "to": "C",
+          "weight": 0.0791
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1314
+        },
+        {
+          "from": "L",
+          "to": "H",
+          "weight": 0.0595
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1051
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.2373
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.151
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0382
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.2362
+        }
+      ],
+      "246": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0001
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0014
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0792
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0071
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1058
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.022
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1672
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0137
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0662
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0763
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0356
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0144
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0464
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0071
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0253
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0724
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0141
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.102
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1468
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0224
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0674
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0099
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0392
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0314
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0625
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0614
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1021
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0187
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0321
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1016
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0119
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.0024
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.2584
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0144
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0936
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0997
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0179
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0612
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.035
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0259
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0803
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0852
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0166
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0141
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.099
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0018
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1123
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0337
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.136
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1594
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0197
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.023
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0737
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0875
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0047
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.076
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0716
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0308
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0527
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1167
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0282
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0229
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0272
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0197
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0004
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0512
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0199
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.047
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.022
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0679
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0005
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0106
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0171
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1458
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0134
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0015
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0966
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0645
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0249
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0845
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0333
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0006
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0162
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.1248
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0279
+        }
+      ],
+      "302": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0127
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0156
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0018
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0147
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0382
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0028
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0412
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0153
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1089
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0021
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0479
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.087
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0121
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1589
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0797
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0297
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0558
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0351
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.021
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0106
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0028
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0049
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0052
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0672
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0382
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0712
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0216
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.017
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0211
+        },
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0496
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0662
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0243
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0243
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0612
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0038
+        },
+        {
+          "from": "V",
+          "to": "Y",
+          "weight": 0.0227
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.045
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0815
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0088
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0372
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": -0.0
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0215
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0498
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0628
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0253
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1306
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0092
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0385
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0558
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0652
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/197C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/197C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '197C' in cohort '40-45_years'",
   "serum": "197C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/197C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/197C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/197C.json
@@ -1,0 +1,3364 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '197C' in cohort '40-45_years'",
+  "serum": "197C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1795
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0107
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0282
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0009
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0593
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1515
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0487
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0355
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.1661
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0673
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0149
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0375
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0058
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0028
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0665
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0477
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0065
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1129
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0349
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.022
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1031
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0364
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1494
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0572
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0222
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0032
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1297
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.003
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0255
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0361
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0359
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0247
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0725
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0336
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.055
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0626
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.1263
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1867
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0609
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0278
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0257
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0516
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0451
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0019
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.012
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0938
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0585
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0192
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1014
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0619
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.072
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0371
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0534
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.057
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0376
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0345
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0022
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0064
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.3667
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1488
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0638
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0238
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0542
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.005
+        }
+      ],
+      "16": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0225
+        }
+      ],
+      "17": [
+        {
+          "from": "H",
+          "to": "R",
+          "weight": 0.0313
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0508
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0269
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0299
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0009
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0306
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.3123
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.221
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0098
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.1117
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0463
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0318
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0127
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.02
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0293
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0009
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0532
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1095
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0524
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0573
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0136
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0863
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0678
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1951
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0184
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1551
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0306
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.162
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0199
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0526
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0135
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0462
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0265
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0155
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0312
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0182
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.045
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0961
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0467
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0292
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0372
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0846
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1379
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1021
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0031
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0396
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.093
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0606
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1099
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1708
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0493
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0493
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0737
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0671
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0727
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0203
+        }
+      ],
+      "39": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0457
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0506
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0629
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1077
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0133
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0481
+        }
+      ],
+      "41": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0216
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0601
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0118
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0722
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0359
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0125
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0614
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0548
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0119
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1557
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0845
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0755
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0196
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0856
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0424
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0385
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0176
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0129
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.119
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0088
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0607
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.1024
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0495
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.019
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0401
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1463
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0838
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0432
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0242
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.1498
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.074
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0444
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0877
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1022
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1878
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.1206
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0837
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0182
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0431
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0082
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0156
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.1127
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.215
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0079
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.2046
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0414
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0854
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0899
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.071
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.1016
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0381
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0313
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0301
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.061
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0555
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0844
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0315
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0399
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0782
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0371
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0944
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.1216
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.0377
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0002
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0648
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.007
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0291
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0513
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0373
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0319
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0628
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0602
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1016
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1003
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0015
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0674
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0068
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0541
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0057
+        }
+      ],
+      "67": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0295
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1161
+        }
+      ],
+      "77": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0589
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0536
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0147
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0515
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0131
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0058
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0363
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0566
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.165
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0066
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0506
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0143
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1445
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1151
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0016
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0646
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1194
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0407
+        }
+      ],
+      "84": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0636
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0235
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1023
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0965
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0317
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0393
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0183
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0365
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0772
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0062
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0518
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.011
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0369
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0686
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0173
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0274
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0313
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.072
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.1008
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0014
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0361
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0502
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0187
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0455
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0166
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0428
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0183
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0342
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0158
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.1587
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0457
+        },
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.0082
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0356
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.1171
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0002
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0727
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0016
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0249
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0302
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0264
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1192
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2463
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.044
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0535
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0341
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1328
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0442
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0114
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0749
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0148
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.1266
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0617
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1692
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1132
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0258
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1979
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0063
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1136
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0029
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0089
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1577
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1088
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0297
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.003
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1334
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.069
+        }
+      ],
+      "136": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0036
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.0221
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0291
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0067
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0744
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0079
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.144
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.067
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.2517
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0456
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1862
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1277
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0621
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0771
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1211
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1064
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0722
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.081
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1725
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0312
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.107
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.236
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0327
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.025
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0365
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0551
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0558
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0144
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3845
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0535
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0132
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.2137
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0039
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 1.0194
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0034
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.3638
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.0003
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0205
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0289
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0412
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0185
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0122
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.02
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0267
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.1951
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.1097
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1782
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0139
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0306
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0396
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1041
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0109
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0334
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0729
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0356
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0107
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.023
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1116
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0528
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0462
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0013
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0313
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.034
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0727
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0453
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0263
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0292
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0297
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0496
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0002
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0251
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.416
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.4699
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.5359
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1815
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.2489
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0239
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1115
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1819
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.3478
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.317
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.3165
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0145
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3642
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.2373
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2432
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.2675
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.011
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5683
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.309
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0831
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0164
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0287
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1231
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1039
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0908
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0903
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.044
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0554
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0518
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0237
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0685
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0473
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1051
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0828
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0243
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0523
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0606
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0444
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0849
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0315
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0655
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1055
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0442
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0012
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0612
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.004
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0296
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0334
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0437
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0271
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1447
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1591
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0408
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0077
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0897
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0622
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0566
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.044
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0295
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0085
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0595
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0043
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0035
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0123
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0558
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0594
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0141
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0394
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0556
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0943
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0664
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.024
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1974
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0375
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.099
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0137
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0265
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0265
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0185
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1353
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0417
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0205
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0133
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0778
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0272
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0308
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0824
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0212
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0122
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0037
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0053
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1537
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.1657
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0211
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.002
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0173
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.018
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0019
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0922
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0094
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.1326
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0125
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0234
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0676
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.062
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0882
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0155
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0612
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0129
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0077
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0459
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0448
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0657
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0302
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0102
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0438
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0509
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0214
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0382
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0233
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0042
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0052
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0195
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0002
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0355
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0775
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0113
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.0273
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0521
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0219
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.013
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.086
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0437
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.003
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0892
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0414
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0727
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1319
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.3412
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.2033
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0601
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.1043
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0278
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0425
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1966
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0569
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0801
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0843
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0036
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0682
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0355
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0491
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0293
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0462
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0608
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0436
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0201
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0423
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0093
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0056
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0484
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0926
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1086
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0262
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1043
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.107
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0091
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.2039
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.1039
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0766
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0119
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0325
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0995
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0007
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0741
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0421
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0654
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1065
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0341
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0702
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.1473
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0897
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.1142
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0869
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.076
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.005
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0474
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0145
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1206
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0167
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1282
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0058
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0363
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0124
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0171
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.003
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0177
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0497
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0008
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0597
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.042
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0409
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0099
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0537
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0936
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0128
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0527
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.033
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.089
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0004
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0172
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1505
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0514
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0009
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0204
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0356
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0524
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0381
+        }
+      ],
+      "320": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0155
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0122
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0065
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0872
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0328
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0407
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.1326
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0221
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.1162
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0827
+        },
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.1104
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0596
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1169
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0778
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0914
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0179
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0629
+        },
+        {
+          "from": "T",
+          "to": "P",
+          "weight": 0.007
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.114
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/199C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/199C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '199C' in cohort '40-45_years'",
   "serum": "199C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/199C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/199C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/199C.json
@@ -1,0 +1,2954 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '199C' in cohort '40-45_years'",
+  "serum": "199C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0257
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0695
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0158
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0493
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0399
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.032
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0529
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.1197
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0262
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.1024
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0985
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0051
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0053
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0539
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0295
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.042
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0119
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0408
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0303
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0449
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0392
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0345
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0415
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0148
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1173
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1046
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1191
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1412
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0176
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0281
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0891
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0214
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.062
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.006
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0446
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0064
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0387
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0039
+        },
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0737
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.1314
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0189
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0058
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.1041
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.1652
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1884
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.207
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0777
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0317
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0041
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1969
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0401
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0656
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0794
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0758
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0109
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0266
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0231
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0103
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0446
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0278
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1524
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.012
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0077
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0307
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0253
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0804
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0254
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.004
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0388
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0497
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.007
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.082
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0832
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.063
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.048
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.2063
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0844
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0764
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0892
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0416
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1881
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.2563
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.1876
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1426
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0033
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0058
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0329
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1543
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0178
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0045
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0268
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0337
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1325
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1776
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1198
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0676
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1177
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1232
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0645
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0764
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0411
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0173
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0068
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0345
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0763
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0356
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.1914
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.088
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0579
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0735
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0137
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0329
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0409
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.061
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1109
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0107
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1672
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0168
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1048
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0935
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.1441
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0475
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0956
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0054
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0012
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0622
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0205
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0104
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.2043
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0061
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1113
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0126
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0244
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.007
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1606
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0876
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.1295
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0831
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0399
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0664
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0064
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0076
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0259
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1717
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0552
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0802
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0825
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1223
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0123
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0733
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0119
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0795
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.2454
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0812
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0578
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0853
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0032
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0692
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0054
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0946
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0013
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0655
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0052
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0557
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0206
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0274
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0836
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0232
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.2135
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1338
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0423
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1433
+        }
+      ],
+      "73": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0145
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0029
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0306
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0721
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0069
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0472
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.012
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0099
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0378
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0625
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0017
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0536
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0595
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0853
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0273
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0742
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0865
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0166
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0788
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0285
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1062
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0147
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0486
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1051
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0268
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.112
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0126
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0125
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.1078
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.021
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0509
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1665
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0772
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0791
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0899
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0391
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.059
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1491
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0496
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0057
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0094
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1831
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0408
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.1743
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0341
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0652
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1242
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.049
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0286
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0567
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.1385
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.2205
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0966
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0192
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": -0.0
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.026
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.026
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.1829
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0913
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.012
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0306
+        }
+      ],
+      "109": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0319
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.082
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0273
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0053
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0118
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0329
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0154
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0347
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.052
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0607
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0142
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.03
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0404
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0468
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0323
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0266
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0089
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.012
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0282
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0636
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0701
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0201
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1814
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0609
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.2209
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.4631
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.099
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1044
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0333
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.312
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0616
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3994
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3734
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2553
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.5579
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.2483
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.4996
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0391
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.1318
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0983
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0334
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0015
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0811
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0071
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.015
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0945
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0087
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0041
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0695
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1906
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0771
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0462
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1243
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1355
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0102
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0884
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0226
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0439
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.2738
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0088
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.1472
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0822
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0808
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0538
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1509
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.1678
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0238
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1498
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0372
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0093
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0021
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0527
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0794
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0969
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0019
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0282
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1128
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.1219
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0194
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.1115
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0595
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0664
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0728
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0481
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0073
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0559
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0431
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0063
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0021
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1569
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.5707
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1425
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.1502
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0417
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0147
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0574
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0063
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0245
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.173
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1478
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0398
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0186
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1784
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.3108
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.1246
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.081
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.2497
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0097
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0934
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0708
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.2514
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1384
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5223
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.5596
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.2762
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1928
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.3485
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.3366
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.5124
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.7021
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1756
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0033
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.1102
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0581
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0172
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.1027
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0344
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0886
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0266
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1484
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.2959
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0535
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0105
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0168
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.268
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.115
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0897
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0851
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1625
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0603
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0366
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1013
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.115
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0293
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1374
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0573
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0961
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0318
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0951
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0094
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0148
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0409
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1001
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0446
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0191
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0717
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0291
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.246
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.04
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.042
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0699
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0796
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0843
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0817
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1225
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.2173
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1013
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0403
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0869
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0706
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.2181
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0755
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0821
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.016
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0471
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.18
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.2486
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0809
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0947
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.003
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0438
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0013
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0023
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0385
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0189
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0386
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0333
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0994
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0114
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0147
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0059
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0615
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0384
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0806
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1045
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.4307
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.099
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.032
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0157
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.026
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0093
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0655
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0141
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0003
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.009
+        }
+      ],
+      "273": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0524
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.1063
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0408
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1122
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.02
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0579
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0435
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0002
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0482
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0701
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0143
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.075
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1876
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0185
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0033
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0988
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.095
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.1257
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.087
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0437
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.102
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.1137
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0198
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0176
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.023
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0464
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1551
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0437
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.1298
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0591
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0722
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.193
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0124
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0086
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0434
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.2054
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0004
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0582
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0574
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0549
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0578
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0609
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0388
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0217
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0296
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1256
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0057
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1077
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0963
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0404
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0143
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.092
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0097
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0694
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0335
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.08
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0223
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0473
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1506
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.116
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0975
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0194
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1395
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.061
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0241
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0125
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0742
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0497
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.1088
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0102
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0268
+        },
+        {
+          "from": "V",
+          "to": "Y",
+          "weight": 0.0378
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0217
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0524
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0455
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0168
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0534
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0273
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1003
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0293
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0068
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0382
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1019
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0418
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0004
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0518
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0542
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0597
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/210C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/210C.json
@@ -1,0 +1,3080 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '210C' in cohort '40-45_years'",
+  "serum": "210C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0931
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0425
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0184
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0098
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0086
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0186
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0198
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0079
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0204
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.1052
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0341
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.107
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0016
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.022
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0227
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0256
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0315
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0512
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0878
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.2418
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.1061
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.1196
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0399
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0043
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0013
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0054
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1099
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0058
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0592
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0508
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.026
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.031
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0049
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1345
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0173
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0357
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0471
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.036
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0093
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0523
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0058
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0111
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.1057
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0591
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0229
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.061
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.029
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.116
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0541
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0378
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0292
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0166
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.1069
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.031
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0524
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1623
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0383
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0076
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0338
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0121
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0675
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0093
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1231
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.012
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0046
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0084
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0106
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0587
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0107
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0053
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0715
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0043
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1334
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0364
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0805
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0178
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0553
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0129
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.004
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0256
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0112
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0495
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0225
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0365
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0489
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0082
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0577
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1457
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0153
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0254
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0157
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0965
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.001
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0305
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0208
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0712
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0459
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1527
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0578
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0723
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1157
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0519
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0055
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0586
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1121
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0053
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0202
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1128
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0122
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0915
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0551
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0591
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0092
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0353
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0332
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.1246
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0454
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0003
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0563
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0185
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0025
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.2884
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.009
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0669
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0277
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0414
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.03
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.0446
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0319
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0513
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0008
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0258
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0936
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0144
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.162
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.004
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.016
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0418
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.076
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0021
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0628
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0039
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.032
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0439
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0529
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.048
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0946
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0496
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0767
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0228
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0063
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1764
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0367
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.1337
+        }
+      ],
+      "70": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0209
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0111
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0948
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0041
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0144
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0944
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1392
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0641
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1477
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0026
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0428
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0107
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0154
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0218
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0538
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.089
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0588
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1047
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1397
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0909
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0529
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.034
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0029
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1188
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1255
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0317
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0184
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0493
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0981
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.038
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0297
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1126
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0202
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0271
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.079
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0165
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0758
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0839
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0225
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0153
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0382
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0083
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0592
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0023
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0641
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0085
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0312
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0777
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0433
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0147
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0537
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0682
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0169
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.013
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0211
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0208
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0035
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0052
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0075
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0383
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0128
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0858
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0863
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0155
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1088
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0152
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0424
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0288
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0386
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0199
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0858
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0327
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0138
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0236
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0261
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1952
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.059
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0574
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0072
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0676
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.105
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0019
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0195
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0001
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1394
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0099
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0661
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1772
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.2605
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0862
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.0933
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.1285
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.255
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1777
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0696
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.006
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1014
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0823
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0718
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0998
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.013
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0352
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1589
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0013
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0074
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0059
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.2617
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.42
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0536
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2771
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0418
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0109
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0355
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.2232
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1453
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0035
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0859
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2152
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0513
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.062
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.0528
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0022
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0201
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0164
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.014
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0963
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0527
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0117
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0104
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0818
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0891
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0668
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0767
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.016
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1217
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0596
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1324
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0312
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0026
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0391
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0418
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0576
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.071
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0328
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.1692
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0651
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0174
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0413
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1382
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0157
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0014
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0416
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0764
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1116
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1216
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.2229
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0691
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1582
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1247
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0628
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.034
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1911
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.159
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1018
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0123
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0922
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0559
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0603
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0423
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0021
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.13
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0962
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.098
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0038
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0568
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0697
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0005
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0088
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0719
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0513
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.081
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0067
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.009
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1139
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0054
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0851
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0353
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0441
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0063
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.015
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1015
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.01
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0283
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0367
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0119
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0508
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0322
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0375
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0384
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0578
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0256
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0859
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0703
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0262
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0113
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0711
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1332
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0266
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0189
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0165
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0837
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0166
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0928
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1852
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0688
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1505
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0291
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0281
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0008
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0428
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0354
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1246
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.028
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0296
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0179
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0201
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.073
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0198
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0248
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0158
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1041
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.025
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1769
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0154
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1282
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0153
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0239
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.078
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0245
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.076
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0271
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1479
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0231
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0424
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0499
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0244
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.1788
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.033
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0868
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0498
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0697
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0102
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0043
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0239
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0209
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0149
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.2056
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0926
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0195
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0038
+        }
+      ],
+      "228": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0145
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0088
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0123
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0116
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0496
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0028
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0708
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0013
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0064
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0195
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0094
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1345
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0177
+        }
+      ],
+      "246": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0278
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1697
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0069
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0429
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0116
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0437
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1203
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0003
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0877
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0189
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0926
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0019
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0068
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0473
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1381
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0031
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0658
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0287
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0154
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1467
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0758
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0448
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1419
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0346
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0323
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0232
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0149
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.034
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.093
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0527
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0226
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0499
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0131
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0541
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0892
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0424
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0145
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0197
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0349
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0662
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.039
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0361
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0105
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0277
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0576
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0176
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0611
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0465
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1021
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.008
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0712
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0038
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0586
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0236
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0096
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0148
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0339
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0187
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0145
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0203
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0143
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0369
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.001
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.1712
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0499
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0278
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0571
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0556
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0173
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0434
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1149
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0092
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0256
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0063
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0477
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1311
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0087
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0164
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0652
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0648
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0419
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0625
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.1189
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0981
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.2014
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0119
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0474
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0369
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0926
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1489
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0711
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0376
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0172
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0158
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.048
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.097
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0007
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0564
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0421
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0604
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0844
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0866
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0063
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0612
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0133
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.1427
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.014
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0789
+        },
+        {
+          "from": "V",
+          "to": "Y",
+          "weight": 0.0001
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0912
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0845
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0505
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0045
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0044
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0657
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0035
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0253
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1172
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0982
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0061
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.1216
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0125
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/210C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/210C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '210C' in cohort '40-45_years'",
   "serum": "210C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/210C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/215C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/215C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '215C' in cohort '40-45_years'",
   "serum": "215C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/215C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/215C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/215C.json
@@ -1,0 +1,3109 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '215C' in cohort '40-45_years'",
+  "serum": "215C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1418
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.046
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0546
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0247
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.025
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0469
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0089
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0179
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0049
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0055
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0287
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0135
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.001
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.1097
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0047
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0337
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0052
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0081
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.057
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0322
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0971
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0322
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0203
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0144
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0326
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.1582
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0268
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0454
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0215
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0009
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.1681
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1589
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0208
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0296
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0181
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0563
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1124
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.04
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0019
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0705
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.1533
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.034
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0143
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0964
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0264
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0045
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1541
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0244
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0119
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0347
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0793
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0383
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0434
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.016
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0821
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1227
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0946
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0129
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0563
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0526
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0012
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0463
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0133
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.014
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0307
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.017
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0086
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0037
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0276
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0325
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0454
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0872
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0512
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0038
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0023
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0976
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0036
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0685
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0117
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0307
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.2481
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0021
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0041
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.031
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0175
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0053
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0017
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.163
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0276
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0131
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0098
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0275
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0805
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0886
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0552
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0082
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0588
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0452
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0002
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0665
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0298
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0231
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0197
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0031
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.015
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0117
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.148
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.126
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0038
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0289
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0202
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0963
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0203
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0316
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0971
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0428
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1169
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0848
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0072
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0383
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0228
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0213
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.034
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0317
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.014
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0565
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0206
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0193
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0413
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0376
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0935
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0134
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0158
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1585
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0312
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1997
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0352
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0237
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0462
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0375
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.016
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0452
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.058
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0118
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0745
+        }
+      ],
+      "51": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0015
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.1655
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0122
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0058
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0915
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0179
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0582
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0406
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0007
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0118
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0367
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0106
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0366
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0205
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0381
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0757
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0232
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.01
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0315
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0094
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.094
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0188
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0273
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0563
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0266
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1677
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1028
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0379
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0025
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0524
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0109
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0148
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0833
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1112
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0041
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1375
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0263
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0177
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.022
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0109
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0777
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0163
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0772
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0326
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0232
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0148
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0278
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1167
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0202
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.1212
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0045
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.2165
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0612
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0012
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.014
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0333
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.159
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0276
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0911
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.0173
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0997
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.1053
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0461
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.128
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0095
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0079
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0562
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0048
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0102
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0087
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0034
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1294
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0047
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0254
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0407
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0137
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.032
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.048
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0072
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0037
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0217
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0102
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1191
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0354
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.07
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0785
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0266
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0092
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.083
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0134
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0842
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0607
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0429
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1127
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0481
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0854
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0073
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0972
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0053
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0656
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0298
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0993
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0256
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0983
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0383
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0064
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0301
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0589
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0249
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0567
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0687
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1537
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0487
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1995
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1087
+        },
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.3068
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1763
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.7117
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1009
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0945
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.6965
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1816
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0669
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.2907
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1007
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2095
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.366
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1554
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.4268
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.2296
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.419
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.5721
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.046
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0094
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0451
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0244
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1599
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0239
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0546
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.3714
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.4077
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.2681
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0378
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3561
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0018
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.367
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2913
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0073
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.016
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.7779
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0153
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.4976
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 1.1453
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0241
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0689
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.061
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.4185
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.3187
+        }
+      ],
+      "155": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0612
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.3573
+        },
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.0202
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0819
+        },
+        {
+          "from": "L",
+          "to": "T",
+          "weight": 0.0166
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.3896
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 1.0684
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.9916
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.2761
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.9919
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.3404
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.3659
+        },
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.0661
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.3823
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.7373
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.3933
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.074
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.3971
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.2981
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0007
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0258
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0193
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0287
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0133
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0054
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0093
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1805
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1834
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0547
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0706
+        },
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0097
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0306
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0322
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0162
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0125
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0192
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0436
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0201
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0928
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0339
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0208
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0163
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0104
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0284
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0435
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0075
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0287
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0267
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.005
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0289
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.2199
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0007
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.2152
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1544
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0301
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1907
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1238
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1017
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0041
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.6381
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 1.07
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 1.2296
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.2839
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.5349
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.3712
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.3747
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.4352
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.3969
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.4568
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.5814
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.5718
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.5694
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.5528
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.3162
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0354
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0395
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.3889
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0374
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0651
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.3421
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0001
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 1.1208
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 1.2099
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0242
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0057
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0216
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.1265
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0969
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.3641
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0529
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0277
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0295
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0574
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0992
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0368
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0264
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0715
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0281
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0574
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0077
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0026
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0168
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1962
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0368
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0155
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0675
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.068
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0219
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1289
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0147
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0047
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0465
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0145
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0626
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0514
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.161
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0165
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.043
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0072
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.024
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0838
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0602
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0241
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0692
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0581
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0309
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0183
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0314
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0161
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0173
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0068
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0089
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0114
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1406
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0262
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0753
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0117
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0352
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0341
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0059
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0266
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0123
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0185
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1555
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0401
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0829
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.013
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0049
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0874
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0213
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0241
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1385
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0367
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.025
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1849
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.2912
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.2385
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0383
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0307
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0395
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0064
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0289
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.047
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0342
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0078
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1045
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.1512
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1108
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1742
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0992
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0435
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1142
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.053
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0635
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0033
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0087
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0029
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0322
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0863
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0222
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0062
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.015
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.043
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0392
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1201
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0036
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0659
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.028
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0341
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0412
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0104
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0815
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0436
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0167
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0887
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0117
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0039
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0231
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0193
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0296
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0201
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.027
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0017
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0065
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0386
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0884
+        },
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0496
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0361
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0035
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0611
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.014
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0119
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0204
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.1243
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.135
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.1097
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0262
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1188
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.078
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0001
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0113
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1068
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0611
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0027
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0209
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0078
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0972
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0034
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0407
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0098
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.069
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0057
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0537
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.1367
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0132
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0161
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0116
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0035
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0057
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0024
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0359
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.225
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1328
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0065
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1269
+        }
+      ],
+      "320": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0229
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0147
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0487
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0121
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0428
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0056
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.039
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1686
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0127
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2323.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2323.json
@@ -1,0 +1,3649 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2323' in cohort '2-5_years'",
+  "serum": "2323",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0949
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0785
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0312
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.007
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0152
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1432
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.0461
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0325
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0907
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0174
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0604
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0566
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0327
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0066
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0501
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.054
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0539
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0006
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0359
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0603
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0313
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0357
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0339
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0124
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "C",
+          "weight": 0.1074
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0048
+        },
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0428
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.005
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0374
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0347
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.1111
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0313
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1178
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0661
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0529
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.1002
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0294
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.073
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0153
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0542
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0322
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0269
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0969
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0355
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.022
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0292
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0427
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1121
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0332
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0361
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1186
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0464
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0857
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0525
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1204
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0101
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0755
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0078
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0094
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0769
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0258
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0332
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0303
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0093
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0429
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1475
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0097
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0731
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.081
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0147
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.003
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0396
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.056
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.2002
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0595
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.1984
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0221
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0433
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0607
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0224
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0069
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0057
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0762
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0069
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0594
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0497
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0875
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0255
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0583
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0259
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0757
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1408
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0876
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0649
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.195
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0086
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0095
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0518
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0414
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0235
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0355
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0605
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.1201
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0155
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0396
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0652
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0153
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0452
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0238
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0128
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0873
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0047
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0094
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0264
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0881
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1092
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0188
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0542
+        }
+      ],
+      "39": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0722
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0151
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0956
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0315
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0132
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0529
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1081
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0107
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0361
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0096
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1061
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.088
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0108
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0153
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0353
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0595
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.056
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0693
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0141
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0082
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1771
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0211
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1132
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1764
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0539
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.042
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.183
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.125
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1211
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1025
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0877
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0104
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.1184
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0822
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1572
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1558
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0125
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0909
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0592
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0168
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0545
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0204
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0311
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.1284
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.2672
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.2325
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.057
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.1296
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.2925
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.1488
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.2182
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.0887
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.189
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.1511
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.2508
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.12
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.1249
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.085
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.267
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.1093
+        }
+      ],
+      "51": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0181
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0625
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0171
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.2207
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.108
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1664
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0128
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0504
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.1333
+        },
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0134
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0643
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0231
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0091
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0055
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0384
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.064
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0277
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0038
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0419
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0121
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1342
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0167
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.059
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0468
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1263
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.1189
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0426
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0767
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0626
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0046
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.1404
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0513
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0126
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0107
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1474
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.114
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0855
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1057
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0306
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1002
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.143
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0654
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1257
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0337
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0676
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0536
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0455
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.021
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0303
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0129
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0592
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0052
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0504
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0789
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0457
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1184
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0488
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0077
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0831
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0399
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0726
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0666
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0764
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.1034
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0643
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0295
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0023
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0823
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.1883
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0483
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0152
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0117
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0049
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0876
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0464
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0187
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0047
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0225
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0182
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1084
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.0936
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0115
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1561
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.006
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0464
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0642
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0095
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0026
+        }
+      ],
+      "109": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1988
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0069
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0139
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0524
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0532
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1199
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0026
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0263
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0559
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0171
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0354
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0285
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0758
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.018
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0039
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0291
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1075
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.074
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0099
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0078
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0133
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0081
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0065
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.6353
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0714
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.073
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.7388
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0756
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0384
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0284
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0139
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0197
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0726
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0553
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0665
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1703
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1145
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1084
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0227
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0063
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0261
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0273
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.0251
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0118
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0197
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0949
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0643
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0009
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0038
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0243
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0027
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1299
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0138
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0708
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.101
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0305
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.146
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2077
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0355
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1061
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1357
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2842
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0325
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0031
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0213
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.123
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0905
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.8171
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1991
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.2423
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0435
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.114
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.1186
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.1319
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.022
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1574
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.1605
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0407
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0671
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0879
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.4461
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.1313
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0625
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.2259
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.2642
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1643
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.3994
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1347
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.2488
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.2122
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.4306
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0267
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1962
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.2558
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0526
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0584
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0586
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1938
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0581
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0131
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.035
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0379
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1064
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.2029
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.091
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0487
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0399
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1211
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0225
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1036
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0193
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1195
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0038
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0283
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0384
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0743
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0086
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0107
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0498
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0137
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0216
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0586
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0998
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1378
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0364
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.1706
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.038
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0308
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0579
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0086
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "N",
+          "weight": 0.0254
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0119
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0477
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0693
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0676
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0909
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0712
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.2743
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2739
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0366
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.2076
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.7303
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.6938
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.784
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.4172
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.7125
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.2771
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.6813
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.704
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.8169
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.6849
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.7714
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.3996
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.7025
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.5996
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.6225
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.375
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1273
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1247
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0127
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0763
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.511
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.4586
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.2736
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0334
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1191
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0153
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0022
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0339
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.089
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0237
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0365
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0301
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0101
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0051
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0033
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0468
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0698
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.01
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0474
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0488
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0538
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0241
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1206
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.156
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.022
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0122
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0044
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.04
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0134
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.013
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0058
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0592
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.004
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0384
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0339
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0176
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0529
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0584
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0055
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.1367
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0233
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0467
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0318
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0672
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0472
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0246
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0523
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0023
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0502
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0588
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0418
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0555
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.016
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.009
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1026
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.118
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.017
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.028
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0932
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0898
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0702
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.012
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0229
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0225
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0691
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0223
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0881
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1113
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0042
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.085
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.246
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.1049
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0451
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1043
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0099
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0674
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0635
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0574
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0131
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1129
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0917
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0677
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0901
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0586
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.065
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0389
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0886
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0045
+        }
+      ],
+      "228": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0203
+        }
+      ],
+      "229": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0549
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0317
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0872
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1328
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0466
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0543
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1118
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "C",
+          "weight": 0.1012
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1122
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.2077
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0635
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0008
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0728
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1203
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0838
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0006
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.019
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1134
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0215
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0118
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0191
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0185
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0055
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0217
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0752
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0401
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.102
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0152
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0044
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0105
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1739
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0498
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0047
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0067
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0023
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0021
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.026
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0888
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0072
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.039
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0723
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0389
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1982
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0398
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0913
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0581
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.046
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1004
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0709
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.122
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0399
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1928
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1622
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0264
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1293
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0652
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0358
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0171
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0004
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1121
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.04
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0599
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0425
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0643
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0435
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0444
+        },
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0711
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0372
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0031
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.062
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0276
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0633
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0403
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0819
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0231
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0365
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0385
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.1779
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0439
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0077
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.1045
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0682
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0704
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0323
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0261
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0165
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0463
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0198
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0368
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0756
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0343
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0867
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0455
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0567
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0128
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0297
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0354
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0031
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0365
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.077
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0227
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0379
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0226
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0712
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0631
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0089
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0186
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0093
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0436
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0039
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0585
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0071
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0166
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0239
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0255
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.1009
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0325
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0033
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0682
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0453
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.055
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0801
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0517
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0078
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0009
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0738
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.1968
+        },
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.1147
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0535
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0184
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0294
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0001
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0913
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.026
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.1798
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0414
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0172
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0718
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0138
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0157
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0456
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0353
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0488
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2323.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2323.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2323' in cohort '2-5_years'",
   "serum": "2323",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/2323",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2350.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2350.json
@@ -1,0 +1,2809 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2350' in cohort '15-20_years'",
+  "serum": "2350",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "3": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0273
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0622
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0096
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.056
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0226
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0262
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0552
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0309
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0376
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0883
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0703
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0266
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.056
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0335
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0227
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0145
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0192
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0437
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0982
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0659
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0679
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0404
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0069
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.1353
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0973
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0128
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0436
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0623
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0524
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0184
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0058
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0104
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0809
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0369
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0155
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.056
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.023
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0055
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0567
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1945
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0048
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0952
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0083
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0556
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0902
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0064
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0555
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.007
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0709
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0882
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0845
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0288
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0212
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0015
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0633
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0016
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0479
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.016
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0998
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0239
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0311
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0323
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0195
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0351
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1346
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0382
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0678
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0927
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0814
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0188
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0901
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0541
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0251
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0001
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0534
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0191
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0434
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0614
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0429
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0178
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0129
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0325
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0105
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.03
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0816
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0837
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.096
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0678
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0884
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0531
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0993
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0732
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0483
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.012
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0233
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0552
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0615
+        }
+      ],
+      "41": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0466
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.018
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0024
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0391
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.065
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0181
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0193
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0226
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0128
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0533
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0133
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.017
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0465
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0124
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0188
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0789
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0442
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0132
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1415
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.066
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0128
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0252
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1014
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0281
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0864
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0307
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.1367
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0221
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0843
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0258
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0611
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.006
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0097
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0822
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0604
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.135
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0247
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.001
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0123
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0894
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0085
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0253
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0791
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0412
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0764
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0077
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0976
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.1168
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1142
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0242
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.019
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1095
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0737
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1073
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.012
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0365
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.1248
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0015
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0621
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0213
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1226
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0047
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0756
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0202
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0266
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0498
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0109
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0279
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0577
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0124
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0047
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0853
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0849
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0018
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0107
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0131
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0609
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0338
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0268
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.032
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0258
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0065
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0088
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1301
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0142
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0244
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0577
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0752
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.1037
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1324
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.1346
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0005
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0075
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0385
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.1117
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0119
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0148
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.1001
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0899
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0184
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0177
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0017
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.005
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0378
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1323
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0499
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0443
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0085
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0956
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0232
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0371
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0218
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0147
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0153
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.1104
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0487
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.046
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0073
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0153
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0081
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0007
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0127
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.3546
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0942
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.2907
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0147
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1339
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1047
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.2766
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.3172
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0563
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1257
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.2048
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0944
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0157
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.179
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1378
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1811
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.2565
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2257
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0177
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.3136
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0862
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0605
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0987
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0494
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0382
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0919
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1455
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0163
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0385
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1691
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2063
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0574
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3654
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0685
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0106
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0727
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.2227
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.3883
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1686
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1198
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.3051
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.4067
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0243
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.7071
+        },
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.1587
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0864
+        },
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.5121
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "D",
+          "weight": 0.2193
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0068
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.054
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.5479
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.5056
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.5068
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1951
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.2653
+        },
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.1333
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.238
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.4454
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.2662
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.2702
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.182
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0537
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0763
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0612
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0354
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1062
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0013
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.04
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1468
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0658
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0206
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0887
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0457
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0126
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0548
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0528
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1031
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0305
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0602
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0688
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1092
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1027
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.3695
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2126
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1306
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.7061
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.8433
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.9007
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.3227
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.6144
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.5377
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.4812
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.5886
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.6073
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.5711
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.6393
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.2102
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.7092
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.558
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.5976
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.4932
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1003
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.2168
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.2225
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.2037
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.2098
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0555
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1034
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0906
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.1032
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1437
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.115
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0772
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1883
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.2372
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0104
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.7787
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.7416
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.052
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0022
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2748
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0473
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.271
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.1946
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0308
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0364
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0193
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0515
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.116
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.03
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0809
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0057
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0636
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0685
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0005
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0474
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0884
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.01
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0356
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0506
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0317
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0288
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0076
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0178
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0368
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.1064
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0623
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1408
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0061
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0681
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0541
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0164
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1045
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0347
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0254
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0953
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0268
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.081
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0557
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0372
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0428
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0312
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0446
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0762
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0242
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0208
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0163
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0003
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1367
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.214
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0382
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1266
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0669
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0728
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0864
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0941
+        }
+      ],
+      "217": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0021
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0061
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0999
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0053
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.06
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.014
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0121
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0161
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0665
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0313
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0257
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0025
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0331
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1068
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1134
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0569
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0702
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0231
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.017
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.043
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0187
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0405
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0262
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0235
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0648
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0395
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0092
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0471
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0246
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0054
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0138
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0373
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0542
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0183
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0113
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0609
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.105
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1187
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.002
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0569
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.033
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0224
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0286
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0307
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0424
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0649
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0171
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0338
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1039
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0595
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0403
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0088
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0653
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0192
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0263
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1184
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1036
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0067
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.057
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0269
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0161
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0293
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0454
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.025
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0504
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1206
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0143
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0467
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1065
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0279
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0587
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0236
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0005
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.091
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0192
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.022
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0634
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0294
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0044
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0274
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0502
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0634
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0357
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0448
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0231
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0531
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0657
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0451
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0299
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0283
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0175
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0809
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0478
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.014
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0109
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.066
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0308
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0009
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0242
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0106
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.017
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.039
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0247
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0119
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.1024
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0035
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0106
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0535
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0078
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0683
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2350.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2350.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2350' in cohort '15-20_years'",
   "serum": "2350",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/2350",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2365.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2365.json
@@ -1,0 +1,3219 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2365' in cohort '15-20_years'",
+  "serum": "2365",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0061
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0287
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0016
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0756
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0837
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0189
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0098
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0106
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0084
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0654
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0353
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0136
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1296
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0581
+        },
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.0345
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0418
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0351
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.021
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0489
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0127
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0077
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0673
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0138
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.004
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.1177
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.053
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0313
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0115
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0581
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0282
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0197
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0229
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.064
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0538
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0231
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0086
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0899
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0124
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0631
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.024
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0194
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0629
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0121
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0046
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0248
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0273
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0193
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0696
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0493
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0488
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0336
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0849
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0288
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0635
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0229
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.2101
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0537
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0111
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0348
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1098
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.1051
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0197
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0836
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1151
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.1327
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0218
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.2089
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.048
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0115
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0295
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0632
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0486
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0716
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0348
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0051
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0082
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0955
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.03
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0379
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0311
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.033
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1429
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0495
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1126
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0162
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.021
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0269
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.035
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0553
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0763
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0556
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0911
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0755
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.045
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0079
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0055
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0851
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0048
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0312
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0344
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0059
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0362
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0045
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0685
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0418
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0773
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0235
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0217
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0072
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0912
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0204
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.027
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0129
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.028
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1411
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0014
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0407
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0293
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0189
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0259
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1675
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0615
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.035
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0778
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0845
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0608
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.012
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0293
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0512
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0059
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1309
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0132
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0099
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1692
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0128
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0022
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0183
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0507
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0391
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1613
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.075
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0086
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.063
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0661
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0454
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0426
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0948
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.03
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0821
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0012
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0302
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0729
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0201
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.1193
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0085
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0752
+        }
+      ],
+      "51": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.272
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0085
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0277
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1223
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0262
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0692
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0473
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0933
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0256
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0312
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0262
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0076
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0028
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0263
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0446
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1146
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0051
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0061
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0368
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0241
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0164
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0047
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.04
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0416
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0387
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0788
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0476
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0152
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0783
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0392
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0449
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0721
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0216
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0079
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0275
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0595
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0343
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0633
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0733
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0639
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.2298
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0932
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0406
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0486
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0235
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0594
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0088
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0357
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0762
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0131
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0526
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0022
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0017
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0275
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0092
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0275
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0296
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.009
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0455
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0346
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0463
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0679
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0228
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.058
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0234
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0362
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1131
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.0413
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0266
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0279
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0332
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0083
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0193
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0029
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0861
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0169
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0763
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0726
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0394
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.043
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.025
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0134
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0379
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0201
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0298
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0264
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0489
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0094
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0114
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0434
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0157
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0225
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0255
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0937
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0087
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0193
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0523
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0351
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0068
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.4238
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0153
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.4245
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0315
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0126
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1337
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0596
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0132
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0409
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0199
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0471
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0194
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.1544
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.108
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0053
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0747
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0165
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0291
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0782
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0388
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0222
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.027
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0123
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1505
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.1903
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1339
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0623
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0203
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0077
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0079
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0322
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0271
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0076
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0633
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0591
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0746
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0632
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0267
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0943
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3995
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0357
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0382
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0819
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0447
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.5619
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1071
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.0337
+        },
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.0249
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0571
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.3363
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.4412
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0183
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.2935
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1795
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.1577
+        },
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.0532
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.1093
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.3106
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0041
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0113
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.2488
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0787
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0047
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0088
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0352
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1269
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0066
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0183
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0589
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0006
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.104
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0167
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0241
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0467
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0074
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0828
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.083
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0408
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0399
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0236
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0055
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.039
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0075
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1263
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0794
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0477
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0109
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0169
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0667
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0552
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0545
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1019
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0058
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.1031
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0151
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0746
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0233
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1153
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1943
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0568
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0273
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.1109
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0548
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1755
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1239
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0302
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1034
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.4776
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.6757
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.781
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1116
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.3536
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.3154
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.3151
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.4021
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.3829
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.4133
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.503
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0311
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.4
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3453
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2718
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1729
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0154
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0471
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1372
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0139
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0993
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0443
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0306
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0215
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0866
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5509
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.5538
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1776
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0844
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.1149
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0746
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.046
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0155
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0213
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0701
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0354
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0493
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1172
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0328
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0132
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0668
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0932
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.009
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0063
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0039
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0097
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0607
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0808
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0221
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0885
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0017
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0263
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0002
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0449
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0272
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0008
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0734
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0376
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0597
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0214
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.025
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0577
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0002
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0157
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0367
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0236
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0074
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0819
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0008
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0241
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0021
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.005
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0233
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0283
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0497
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1733
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.084
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0593
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0171
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0162
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0464
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0377
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0687
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.007
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0429
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0053
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1151
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0615
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0337
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0027
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0253
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.007
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0033
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0028
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.01
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0343
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0813
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0074
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0183
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0178
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.1077
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0639
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0497
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0853
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0502
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0094
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0194
+        }
+      ],
+      "228": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0932
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0271
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0132
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0798
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.066
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0757
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.043
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.0321
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0089
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0258
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0475
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0186
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0102
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0415
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.076
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0035
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0315
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0301
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": -0.0
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0628
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0135
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1322
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1003
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.2201
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0489
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0469
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0032
+        }
+      ],
+      "273": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.1269
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0432
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0352
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0527
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0241
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0246
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0586
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0712
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0933
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0755
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1418
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1175
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1235
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1207
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0107
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0226
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0342
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.007
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0262
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.046
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0156
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0519
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0262
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0267
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0548
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0639
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1216
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0086
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0998
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0557
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0144
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0034
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0957
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0167
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0202
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0007
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0223
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0943
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0021
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0155
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.029
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0202
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0249
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0516
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0071
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0339
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.067
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0252
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0369
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0534
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1011
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0108
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0331
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0223
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0375
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0031
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0249
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0114
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0416
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0118
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.008
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0238
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0176
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0033
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0053
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0218
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0385
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0516
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0187
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0473
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0057
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0418
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0109
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0268
+        },
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0088
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0538
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.029
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0048
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0338
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0672
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0326
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0675
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0062
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2365.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2365.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2365' in cohort '15-20_years'",
   "serum": "2365",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/2365",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2367.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2367.json
@@ -1,0 +1,3906 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2367' in cohort '2-5_years'",
+  "serum": "2367",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0303
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0382
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.065
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1329
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0715
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0626
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.2121
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.1365
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0807
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.1059
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0761
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0194
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0267
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.01
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0083
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0809
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.1259
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0216
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0445
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0111
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0764
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.028
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0837
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0297
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0195
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0025
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0059
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.001
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "C",
+          "weight": 0.0136
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0212
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.01
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.2583
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0421
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.093
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0457
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0722
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1252
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0415
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0003
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0107
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0516
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0073
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0003
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0347
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0696
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.2618
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.088
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0113
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0414
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.053
+        },
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.1739
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0089
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1113
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0953
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1029
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.088
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0106
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0112
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0248
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0566
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.005
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0797
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0245
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.1204
+        }
+      ],
+      "17": [
+        {
+          "from": "H",
+          "to": "R",
+          "weight": 0.0359
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0199
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0241
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.016
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1971
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0154
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0914
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0243
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0455
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0163
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0462
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0693
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.1769
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0036
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0178
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0995
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0737
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.2295
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0276
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.064
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0435
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0161
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0868
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.2077
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0722
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.2133
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0661
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1886
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0292
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0095
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0243
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0094
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0962
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.023
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0083
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0444
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0028
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1264
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1159
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.3065
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0555
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0842
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.1346
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0939
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0903
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0076
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0841
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0867
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0657
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0944
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0156
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1296
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0777
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0186
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0433
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.1211
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.1217
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.041
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0371
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0256
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0783
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0046
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0676
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0213
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0221
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0353
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0176
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0324
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0668
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0708
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1848
+        }
+      ],
+      "39": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1234
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0839
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1572
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0029
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0229
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0188
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0158
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0991
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.3707
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0092
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0147
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.091
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0477
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0383
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1129
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0555
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0084
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0443
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0693
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0051
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0465
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0845
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1053
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0147
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1434
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0197
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1157
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0627
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0984
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1667
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0574
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0165
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1328
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1474
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.069
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0705
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1231
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.044
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0086
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.1734
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0994
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0253
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.1172
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.1664
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.0438
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.1191
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.075
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.078
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.2228
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.001
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.1104
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0968
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0971
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0919
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1245
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0389
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0111
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0109
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0095
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0334
+        },
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0282
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.1056
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0887
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0774
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0975
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0892
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1118
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0647
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.2142
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0479
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0766
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.1055
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1709
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0694
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0128
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0021
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0217
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0788
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.106
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0169
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0039
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1499
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.1018
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0563
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0516
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0703
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0105
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0154
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0149
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0653
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0102
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0281
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.126
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0404
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0622
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0675
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0088
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0154
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.095
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.016
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0298
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0395
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0232
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1748
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.071
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0033
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0096
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1428
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0426
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0679
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1735
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0321
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0242
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0148
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0181
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0113
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0038
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0725
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.1655
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0431
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.0697
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.03
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.1696
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0433
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0248
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0159
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0225
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0306
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0397
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0403
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.041
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0217
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0025
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.011
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0313
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0981
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0243
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0862
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0726
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0049
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.007
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0163
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0737
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.004
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0153
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.2029
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.1837
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0138
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0951
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0044
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1287
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.016
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0632
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0367
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0012
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0794
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.024
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0069
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0343
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0803
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.068
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0401
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0202
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0178
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0251
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.051
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0031
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.004
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.2387
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0773
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0092
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0403
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0767
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.1295
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0949
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0491
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0085
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.2182
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0777
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.7392
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0145
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.7798
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0127
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0739
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.034
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.1442
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0376
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0405
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.082
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0174
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1509
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0562
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.3154
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0061
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.2068
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0257
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1528
+        },
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.1585
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1046
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0831
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.198
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0831
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.2979
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.4129
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0632
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1525
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1758
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.115
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0254
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.7046
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.9777
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.2141
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.2922
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.3816
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0726
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.078
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0504
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0997
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0993
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1193
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0743
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0579
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0272
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0022
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0035
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0107
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.5815
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5337
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.5998
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.2934
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.186
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.147
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0463
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.2728
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1055
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.8702
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.354
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0279
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.2331
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.2622
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.2557
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.2862
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 1.7728
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.6412
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.5895
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0069
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.002
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.0676
+        },
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.0467
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.1784
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.1183
+        }
+      ],
+      "158": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.2113
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.1207
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.2918
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0905
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0264
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0255
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.3208
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.1877
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0283
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0306
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.234
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.4927
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.2525
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.7268
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1793
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.1769
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.3037
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.575
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.2961
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.1862
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0388
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0753
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.108
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1589
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0262
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0169
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0029
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0535
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.1059
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.1269
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0251
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0356
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1548
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.1019
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.015
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.137
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0517
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0464
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0625
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0276
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0412
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1268
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0579
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1185
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0682
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0697
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0941
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.2104
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.007
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.088
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.1757
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0299
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0226
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0127
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0235
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0658
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1035
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1584
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0915
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.1462
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.008
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0055
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0789
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0366
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.069
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0355
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "N",
+          "weight": 0.1044
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0335
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0315
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0102
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.1588
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.435
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.323
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.14
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.2813
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0017
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0341
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 1.8919
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 1.3946
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 1.7055
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 1.075
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 1.4191
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 1.0259
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 1.702
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 1.606
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 1.6943
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 1.5448
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 1.7738
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 1.1067
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 1.7077
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 1.5371
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 1.6002
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 1.0842
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.1875
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.4041
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0804
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0649
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 1.1646
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 1.2652
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.3112
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0697
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1882
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0479
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0207
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0123
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1423
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0351
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0621
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0116
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0986
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0143
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1218
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0592
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0151
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0021
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0279
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1844
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0309
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0904
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1194
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0578
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.058
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0435
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.2191
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0437
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0194
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.2002
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0057
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0191
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0683
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.076
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0813
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.2511
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1621
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1304
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1505
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0472
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0572
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0159
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.05
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0253
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0314
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1035
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.018
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1385
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0765
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0527
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0259
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0659
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0108
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1005
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1215
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0683
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0378
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0166
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0444
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0687
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.1009
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.066
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1644
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0049
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1252
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0911
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0913
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0942
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0601
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0758
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0348
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0011
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.054
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0345
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0278
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0545
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0019
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1111
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.305
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0491
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0322
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0794
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0734
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0232
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0304
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1302
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.019
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1357
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0172
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0323
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0146
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0822
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.3712
+        }
+      ],
+      "225": [
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0292
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0018
+        },
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0755
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0082
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1091
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0528
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.064
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0374
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1487
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.09
+        },
+        {
+          "from": "L",
+          "to": "C",
+          "weight": 0.1344
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1924
+        },
+        {
+          "from": "L",
+          "to": "H",
+          "weight": 0.0216
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0763
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.1064
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0595
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1793
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0644
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.009
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0573
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0876
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0773
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0701
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.01
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0839
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0288
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0526
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0421
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1848
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.002
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0152
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0915
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1055
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0995
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0335
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0185
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0045
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0426
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0958
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0148
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0431
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0175
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.2012
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0437
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0073
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1593
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0019
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1766
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0734
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0484
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0326
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0133
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0011
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0025
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0506
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1627
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0552
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0492
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0702
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0022
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1236
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0946
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1483
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0287
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0976
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1098
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0435
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.012
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0633
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0066
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0256
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0111
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0797
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0191
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0329
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0407
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0681
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0401
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0362
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0068
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.003
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0276
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0824
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0865
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0976
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.2029
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1301
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.1951
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.1858
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0854
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0262
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0116
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.002
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0353
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0143
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0144
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.2602
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0487
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0475
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0533
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0298
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0208
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0561
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0367
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0533
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1312
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1009
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0408
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.087
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0343
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.011
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0111
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.027
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0149
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0356
+        },
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.1193
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0122
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0352
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.2603
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0434
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.2261
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.1618
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0656
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0427
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0303
+        },
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0021
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.002
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0316
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0557
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.048
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0436
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0854
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.1017
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2367.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2367.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2367' in cohort '2-5_years'",
   "serum": "2367",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/2367",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2380.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2380.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2380' in cohort '15-20_years'",
   "serum": "2380",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/2380",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2380.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2380.json
@@ -1,0 +1,3730 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2380' in cohort '15-20_years'",
+  "serum": "2380",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1421
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.051
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1515
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0067
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0409
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.023
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0236
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0718
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.1146
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0338
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0261
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.064
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0563
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0339
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0508
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0394
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0564
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0568
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0185
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0463
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0745
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0279
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0039
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0171
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0216
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0473
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0757
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0754
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0481
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0605
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "C",
+          "weight": 0.0343
+        },
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0019
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0161
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0464
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0732
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0181
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0754
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0297
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0202
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.025
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0283
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0617
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0374
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.122
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0326
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0647
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0347
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1744
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0256
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.1478
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0585
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0051
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0673
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0211
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1257
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.1299
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0153
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0037
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0613
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0081
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0967
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0714
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0169
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0633
+        }
+      ],
+      "17": [
+        {
+          "from": "H",
+          "to": "R",
+          "weight": 0.0021
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0261
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0891
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1512
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0831
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0283
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0095
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.1029
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.1134
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0004
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0041
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0011
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0066
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.1955
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0312
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0327
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0626
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0207
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.096
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1077
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0532
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.102
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.017
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0476
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.049
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0582
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0646
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.022
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0021
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0131
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1058
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0005
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0645
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0719
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0032
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0451
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0143
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0408
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.125
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1048
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0149
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.1596
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0141
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0188
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0244
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1213
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0257
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0379
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0483
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0397
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0854
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0148
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1014
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0156
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0197
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.031
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0559
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0225
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1164
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0971
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.2179
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0112
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0534
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0481
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0625
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0004
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0044
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.1121
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0635
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0267
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0027
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0861
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0372
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.1521
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.059
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0144
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0467
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.2461
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0711
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1677
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0874
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0895
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0306
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1289
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0038
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0361
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0359
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0706
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.1123
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0339
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0576
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1199
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.1018
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.1362
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0674
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.049
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0447
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0499
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.039
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0281
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0195
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.1019
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.015
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0661
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0384
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0068
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0581
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1299
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1519
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1077
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0171
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0438
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0594
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1089
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.044
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0537
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0076
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0822
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0284
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0124
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0399
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0047
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1481
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1014
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0566
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0246
+        }
+      ],
+      "73": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.013
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0714
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0789
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0537
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0208
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0091
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0757
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0498
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0423
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0386
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1747
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1526
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0133
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0001
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0639
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.01
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0309
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0704
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0077
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0073
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0058
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0191
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0355
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.013
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.019
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.044
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0728
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0399
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0708
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0223
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.09
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0412
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0003
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.2123
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0605
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0788
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0392
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0305
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0579
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0382
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0432
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0173
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0347
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0177
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0175
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0291
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0697
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0415
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0372
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0265
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0656
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0969
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0618
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0486
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.1359
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0229
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.1037
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0443
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0115
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.026
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0559
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0323
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0733
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0289
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0191
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0912
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.023
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0224
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0151
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0414
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.2861
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0025
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0872
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0274
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0058
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0476
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.1796
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0005
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1514
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.082
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2167
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 1.0577
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0193
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.5444
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.6839
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 1.1765
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0222
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1113
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0991
+        }
+      ],
+      "138": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0405
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1913
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0268
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0709
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1785
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0543
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0328
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0207
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0028
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.111
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0413
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0279
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0261
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0512
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0016
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1181
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0364
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0144
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0801
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1131
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.4272
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0383
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0678
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1588
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.6427
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.6902
+        },
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.3627
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.5559
+        },
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.6696
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.9954
+        },
+        {
+          "from": "L",
+          "to": "D",
+          "weight": 0.4043
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.7448
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.5391
+        },
+        {
+          "from": "L",
+          "to": "K",
+          "weight": 0.5213
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.1915
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.1677
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.5411
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.7394
+        },
+        {
+          "from": "L",
+          "to": "T",
+          "weight": 0.1299
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0307
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.4213
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.3698
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.3908
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.3153
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.1002
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.2405
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.1517
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.1683
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0277
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0727
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0033
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0367
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0243
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0175
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.031
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1138
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0197
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.1471
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1224
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.079
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0039
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.2537
+        },
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0331
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.1027
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0178
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0298
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0821
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0045
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0435
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0364
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0978
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0277
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0434
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0294
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0244
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0014
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.1075
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0129
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0617
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0051
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0884
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.1229
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.047
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.2195
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.262
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.1843
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0011
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0681
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0297
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0724
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.4547
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2334
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.1421
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0892
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0795
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.7974
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.9575
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.9784
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.5049
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.604
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.5069
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.4945
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.6329
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.6297
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.6055
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.7268
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.6729
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.5123
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.5007
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.3697
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.3588
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.4394
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1404
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0739
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0261
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0278
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.1836
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1154
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.1038
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.2914
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1294
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0249
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1921
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.4691
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.7641
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.7299
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2072
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.3504
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.3287
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1371
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0375
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1397
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0367
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1135
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0116
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1088
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0141
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.151
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.021
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1014
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1375
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0509
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0194
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0148
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1532
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.008
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0193
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1042
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0186
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0846
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0827
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0434
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0639
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0826
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0943
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0111
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.2566
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0152
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.2343
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0487
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0554
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0615
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0518
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.159
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0288
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1326
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0161
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1972
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0874
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0134
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0183
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0415
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0014
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0786
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0457
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0373
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.109
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0459
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0783
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0349
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1041
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0539
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0514
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0133
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.031
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0699
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0717
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0454
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1188
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0484
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0131
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1116
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0198
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.107
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0371
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0004
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0081
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.001
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0873
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0051
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0297
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0607
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0194
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0496
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0203
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1034
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.1523
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0577
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.09
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1354
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.101
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0361
+        }
+      ],
+      "217": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.015
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0986
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0657
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.2483
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0807
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0078
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1567
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.124
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.008
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.117
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0449
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0203
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0097
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0835
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0261
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0136
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0097
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0367
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0607
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.3745
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.1726
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0469
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0259
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0409
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1119
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0364
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.039
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0373
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0898
+        }
+      ],
+      "229": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.1778
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0287
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0373
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0359
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0068
+        },
+        {
+          "from": "W",
+          "to": "H",
+          "weight": 0.0145
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0135
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0151
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0138
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0462
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0868
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1976
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0643
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0003
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0006
+        },
+        {
+          "from": "L",
+          "to": "C",
+          "weight": 0.0903
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0441
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1029
+        },
+        {
+          "from": "L",
+          "to": "H",
+          "weight": 0.0549
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1884
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0939
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0933
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0263
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1994
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0092
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0751
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0446
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0415
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0593
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0304
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0449
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0967
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0292
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0491
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.046
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0041
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0466
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1257
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0022
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0249
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0088
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0462
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0426
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1026
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0193
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1128
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0897
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0368
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0531
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0055
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0079
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.102
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0387
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0355
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0693
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0318
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0605
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0112
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0347
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1089
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0194
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0072
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0569
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.005
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0073
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1221
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0386
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0322
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0382
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0586
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0317
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0607
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0161
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0128
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0833
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0043
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0032
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.013
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0456
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0281
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.1633
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.06
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0101
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0572
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0566
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0171
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0137
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0026
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.1849
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.1567
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0136
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.1257
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0139
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0489
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0168
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0493
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.034
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.075
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0026
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0681
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0505
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0188
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0095
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0036
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0618
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0783
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0082
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.038
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0221
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0573
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0545
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0823
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0775
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.045
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0257
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0671
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0015
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0463
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0274
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0396
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0614
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0232
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0288
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0452
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0383
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0316
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1146
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0738
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1064
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0246
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1202
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0644
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0247
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0151
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.1057
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0317
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.1208
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0357
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0032
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0359
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0135
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0735
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.038
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0156
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0195
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0087
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0661
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0072
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0182
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0091
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0123
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0419
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0669
+        },
+        {
+          "from": "T",
+          "to": "P",
+          "weight": 0.0044
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0292
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0364
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2382.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2382.json
@@ -1,0 +1,3136 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2382' in cohort '15-20_years'",
+  "serum": "2382",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0016
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0802
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0652
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0495
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.004
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.021
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0014
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0325
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.055
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0003
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.1
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0329
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0623
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.1557
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.02
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.004
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0333
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0667
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0996
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0106
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0453
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0752
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.027
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0397
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0437
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0413
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0139
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0081
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0223
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0274
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0091
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0099
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0197
+        },
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0347
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0419
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0155
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1168
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0055
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0182
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0096
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0157
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0522
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1465
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0057
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0225
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0341
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0235
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0486
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0272
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0118
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0509
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1105
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0954
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0041
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0198
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0309
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0112
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0188
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1242
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0881
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.1524
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0085
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0075
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0024
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0371
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0842
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0254
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0034
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1686
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1015
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0065
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0493
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.097
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1619
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0786
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0552
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0326
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0525
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0223
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0296
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0204
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0331
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.1131
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0507
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0251
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0886
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0008
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0413
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0635
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0487
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0114
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0222
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0796
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0223
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.029
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0091
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0248
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0356
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0335
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0555
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0274
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.104
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0009
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0072
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0447
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0276
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0145
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0269
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0472
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0226
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2096
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0557
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0806
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0112
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.049
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0317
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0804
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0011
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0267
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0193
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.1083
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0201
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0582
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.021
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0832
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1027
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0034
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0776
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0973
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0018
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0479
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0167
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0612
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0207
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0597
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0212
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0425
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0031
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0572
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0186
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0156
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0716
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1247
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0454
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0245
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.036
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0141
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.003
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0676
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0496
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0893
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2158
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0164
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0208
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.003
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.1021
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.0225
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0467
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.1267
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0295
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0448
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0294
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0595
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0532
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0242
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0217
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0186
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0692
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.035
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0541
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0056
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0037
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0289
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1382
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0317
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0201
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0462
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0839
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.061
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0506
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0348
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2019
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.2116
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0258
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0651
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1004
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0981
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0196
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0008
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1704
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.052
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0215
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0588
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0242
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0341
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0708
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0222
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.055
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0248
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1225
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0638
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0205
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0574
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0956
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0595
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0257
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.014
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.0111
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0531
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0262
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0423
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.2227
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.1617
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0562
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.1372
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0454
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0968
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0038
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0321
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0482
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0356
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0265
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0457
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0052
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0039
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0007
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1126
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0372
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0041
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.106
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0521
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0412
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0474
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0339
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0219
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0203
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1444
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.2766
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0259
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0574
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0063
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0841
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.042
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0232
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0094
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0712
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0639
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0617
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0183
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0839
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0517
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0286
+        },
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.1057
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0004
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.189
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0817
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0097
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0295
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0429
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0432
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1004
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1199
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0661
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0232
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1929
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.1064
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.1602
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0108
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0827
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0277
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1281
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0552
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0046
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0366
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.017
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1313
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1186
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1733
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0432
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1299
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0183
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0328
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1454
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0124
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0865
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1302
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2228
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0365
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0899
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.4572
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0627
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.2107
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.3181
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0809
+        },
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.1864
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "D",
+          "weight": 0.0168
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0033
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.2574
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.1963
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0864
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0548
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0646
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0481
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0071
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.036
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0374
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0358
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1028
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.05
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0114
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0272
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.1027
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0007
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0232
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.05
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0233
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0016
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0428
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1107
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.1409
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0226
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0264
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.2082
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0355
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0099
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0047
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0362
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.092
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0462
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0181
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0169
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1231
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0232
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0731
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0279
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1784
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0442
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0107
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0082
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0425
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.3741
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.4843
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.5788
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0966
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.3944
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.2662
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.2363
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.3141
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.3133
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.306
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.3723
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2665
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1543
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2063
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0823
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0881
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.3595
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0767
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.119
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0567
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1681
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0393
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0655
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1035
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.2376
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.4923
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.4397
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0629
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0077
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0619
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.1405
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.105
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0351
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1252
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0146
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1512
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0774
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0926
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1022
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0172
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1069
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0369
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0388
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0837
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0578
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0162
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0608
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0752
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0574
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0077
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0264
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0179
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0529
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0185
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1369
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0894
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0249
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0349
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0341
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.007
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0302
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0431
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0209
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0782
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0432
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0134
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0182
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0021
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0243
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0487
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0183
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0136
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.021
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0234
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0084
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0115
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0232
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0137
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0429
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0122
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.006
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0494
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0617
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0653
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0077
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0896
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0832
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0978
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0381
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.05
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0338
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.042
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0189
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0818
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0133
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0319
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0833
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0058
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1089
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0062
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.1047
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0027
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.0171
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0706
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0588
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0026
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0816
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0943
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0626
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0494
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.0219
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.065
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0584
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0563
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0621
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0386
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0893
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1071
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0433
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.029
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0336
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.002
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.042
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0143
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0024
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0006
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0521
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0419
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0653
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.086
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.065
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0043
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0809
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0151
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0018
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0017
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0045
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0036
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0338
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0251
+        }
+      ],
+      "273": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0312
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0338
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0077
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.063
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.2423
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.3645
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1926
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1784
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1276
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.3063
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.2887
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.3072
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2807
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0929
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0622
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1166
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0363
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0402
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0082
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0396
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0094
+        },
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0203
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0202
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1228
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0262
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0009
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0366
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0623
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0735
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.067
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0181
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0185
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.002
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0681
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0168
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0369
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0034
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.03
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0276
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0313
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0101
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0538
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0649
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0025
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0249
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0297
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0482
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0256
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0518
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.045
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0419
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0701
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0309
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0169
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.065
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0457
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0024
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0379
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0284
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.016
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0724
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.053
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0183
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0912
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1279
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0349
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0076
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0354
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0777
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0483
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0346
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0153
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0887
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0343
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0067
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0333
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0366
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0354
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0361
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0288
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0344
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0221
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2382.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2382.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2382' in cohort '15-20_years'",
   "serum": "2382",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/2382",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2388.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2388.json
@@ -1,0 +1,3911 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2388' in cohort '2-5_years'",
+  "serum": "2388",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0334
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.012
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0513
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0042
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.09
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.1193
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0686
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0521
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0117
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0641
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0225
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0185
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0186
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0003
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0779
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.016
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.024
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1071
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0313
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0557
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0882
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0136
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0332
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0259
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0313
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0053
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0461
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0359
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0016
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0511
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0033
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0064
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.018
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0806
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0221
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0365
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.08
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.033
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1275
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0229
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0196
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.076
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0086
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.1131
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0133
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0025
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0834
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0792
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0284
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0066
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0292
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1966
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0014
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.09
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0793
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1165
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0063
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0396
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1145
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0987
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0468
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0191
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0844
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0045
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0568
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0646
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0018
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0471
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0041
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0314
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0272
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0887
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0379
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.1491
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.027
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0445
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0252
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0745
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0298
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0271
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0022
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0635
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0022
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0463
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0064
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0657
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0344
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0306
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0661
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0131
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0085
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0872
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.018
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0191
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0056
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0426
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0731
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0451
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0619
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0138
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1626
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0282
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0366
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.1429
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0142
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0272
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.1001
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0226
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0724
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0095
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0134
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0446
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0206
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0319
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0662
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0787
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0461
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.048
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0005
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0555
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0297
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0756
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.053
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0223
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0965
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0169
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.006
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.056
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0229
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0032
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0032
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0374
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0097
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.005
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0134
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0607
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.062
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0203
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.021
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0649
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0165
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0019
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.1004
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0376
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0341
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0211
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0234
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.039
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0659
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0339
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.056
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.084
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0189
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0461
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0041
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0102
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0497
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0016
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0137
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0137
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0122
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.029
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0157
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0372
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0273
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0488
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0243
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0159
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.019
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.044
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0311
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1351
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0234
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0235
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.016
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.1308
+        }
+      ],
+      "67": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0242
+        }
+      ],
+      "70": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0007
+        }
+      ],
+      "73": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0162
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0053
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0301
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0261
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0309
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0292
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0134
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0262
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0655
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0195
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1085
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0492
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.133
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0126
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0537
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0881
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.035
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0282
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0118
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0768
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0477
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.002
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0656
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1035
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0082
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0385
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0547
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0149
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0008
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0567
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0486
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1206
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0087
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.01
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0302
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0783
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.038
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0315
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0556
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0957
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0859
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0267
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0075
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0052
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0651
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0602
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.0881
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0251
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0281
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0479
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0309
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.005
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.039
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0354
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0621
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0008
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0703
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0049
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0969
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0461
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0234
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0799
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0301
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0242
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.027
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.1067
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0881
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.1054
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0484
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0155
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0162
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0785
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0349
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0098
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0313
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0011
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0301
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0814
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0395
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0198
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0053
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.035
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0487
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0726
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0059
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0059
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0473
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0445
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1119
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.2712
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0407
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0292
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0084
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0638
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0758
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1001
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0233
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0122
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0337
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0363
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0107
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0127
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0375
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0619
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0267
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0558
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0683
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0439
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.058
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0363
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0389
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0755
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.001
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.027
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0381
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0416
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.1034
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0905
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0296
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0547
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.3166
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.1616
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0976
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1584
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0225
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.2033
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0746
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0393
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.2081
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0566
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0198
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1197
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0087
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0414
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0575
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0196
+        }
+      ],
+      "138": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0665
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0093
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1577
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.012
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0047
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0367
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0537
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0115
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.019
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1229
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.139
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0318
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0169
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1874
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0747
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.2108
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.3056
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0202
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0207
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2792
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0055
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0077
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1248
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.3227
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1541
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.3718
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0799
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.5695
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1778
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1605
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.3214
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0245
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.0117
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0626
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.1043
+        },
+        {
+          "from": "L",
+          "to": "T",
+          "weight": 0.0049
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0861
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0792
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0381
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0952
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0042
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.1205
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.1407
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0977
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0626
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1324
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.094
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.1157
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0417
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0885
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0061
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0624
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.1167
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0965
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0215
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1324
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0029
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.1163
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0072
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0289
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1574
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0031
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0493
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0401
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0435
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1386
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.074
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0124
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0348
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0266
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0582
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.082
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0132
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0949
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.011
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0326
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0397
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0371
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0413
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0449
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0014
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0171
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "N",
+          "weight": 0.0019
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.305
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0296
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.104
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0943
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0415
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.05
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.3018
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1125
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.124
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1428
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0673
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0569
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.3769
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.6029
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.6697
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1149
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1461
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.2999
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1529
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0143
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1259
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.3769
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.3823
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.4004
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3826
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.3175
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0886
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0052
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0067
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.1372
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1325
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0446
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0232
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0109
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0271
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.4198
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.3784
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0119
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0001
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0143
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0283
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0349
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0425
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0366
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1423
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0615
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0428
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0126
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0245
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0661
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.051
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0173
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0709
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0396
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0151
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0413
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1124
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0639
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0642
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0217
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0568
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0786
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0373
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1591
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0187
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.064
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0318
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0686
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0866
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0671
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1032
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0771
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.1516
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0314
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0681
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0492
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.158
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0963
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1087
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1611
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0321
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.1739
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.1274
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0572
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0839
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1295
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0188
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0868
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0362
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0182
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0128
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0273
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0394
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0052
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0608
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1299
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0859
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0322
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0523
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.023
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0914
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0172
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0443
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0893
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.029
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0131
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.1524
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0612
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.132
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0185
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.1607
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0166
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.2403
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1419
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0208
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0431
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0105
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0109
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0243
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0108
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1348
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.1024
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0904
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0444
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1008
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.005
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.058
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0659
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0784
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0373
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0279
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0589
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0084
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0032
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0015
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0579
+        }
+      ],
+      "217": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0682
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0369
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0817
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.1356
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.1583
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0896
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0436
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0918
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0345
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0438
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1353
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2107
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0198
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.009
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0421
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0348
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0362
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0109
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0051
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0065
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0528
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0978
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1403
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0706
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1996
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0525
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1906
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0819
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1675
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.2491
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0295
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.1314
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0215
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0172
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.1152
+        }
+      ],
+      "224": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.1262
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0213
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0372
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0742
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1187
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0624
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0415
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.097
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0895
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.116
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0737
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.014
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.083
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0072
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0188
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0185
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0395
+        }
+      ],
+      "229": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0222
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0253
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0055
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0046
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0336
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0227
+        },
+        {
+          "from": "W",
+          "to": "H",
+          "weight": 0.0059
+        },
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.0959
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0199
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.077
+        },
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.1112
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0895
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1827
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0635
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0569
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0795
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.08
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0596
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0907
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0339
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.2671
+        },
+        {
+          "from": "L",
+          "to": "H",
+          "weight": 0.0696
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1943
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.2215
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0666
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.2724
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0948
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.3235
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0008
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0159
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0503
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0108
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0802
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0072
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0037
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0171
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0732
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0117
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0183
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0296
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0032
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0094
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0282
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1032
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0587
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0008
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.0084
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0158
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0014
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0054
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.025
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0042
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0808
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0442
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0044
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0184
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0262
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0497
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0685
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0256
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0713
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0661
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0083
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0523
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0757
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0333
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0429
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0014
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0035
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0519
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0727
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0531
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0514
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0017
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0088
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0288
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.086
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": -0.0
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0148
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0268
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0003
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.008
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0057
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0663
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0321
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0315
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0019
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0924
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0025
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0217
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0205
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0385
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0109
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0165
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0339
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0169
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0452
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.043
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0293
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.03
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1478
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0063
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.002
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.2819
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0652
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0105
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0821
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0362
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.1137
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0677
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0356
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0505
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0857
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0308
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0113
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.049
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.006
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0143
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.037
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0443
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.032
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0251
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0469
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0561
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0142
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0653
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2388.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2388.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2388' in cohort '2-5_years'",
   "serum": "2388",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/2388",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2389.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2389.json
@@ -1,0 +1,3373 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2389' in cohort '2-5_years'",
+  "serum": "2389",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1055
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0502
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0759
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0471
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.1
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0956
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0504
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0736
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0433
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0143
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0203
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0675
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0324
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0597
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1179
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0048
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0208
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0559
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0084
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0165
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0414
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1814
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0111
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0822
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.07
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0539
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.059
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0075
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.1494
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0074
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0328
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0182
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0657
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0123
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0415
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0126
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.1107
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.2168
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0502
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0249
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0418
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0361
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0806
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1979
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0987
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0453
+        },
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0007
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1379
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0249
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1096
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0151
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1239
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0316
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0367
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.2077
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.1623
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0043
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0693
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0166
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0358
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0503
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0227
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1349
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0866
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.009
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0333
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0051
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0276
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0489
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0789
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0135
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0618
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0783
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0008
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0378
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0216
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1432
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0777
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1126
+        }
+      ],
+      "26": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1169
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1171
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.011
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0066
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0557
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0023
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0416
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0033
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0909
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0548
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1538
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0043
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0277
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0128
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0689
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0788
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0594
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0149
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0164
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0118
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.029
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.1011
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0067
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0534
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0673
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0147
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0788
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0291
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0553
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0358
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0106
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.037
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0707
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0267
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0465
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.009
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0439
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0264
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0523
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0004
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0279
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0038
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1351
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0104
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.031
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0146
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0054
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0207
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0624
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0641
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0649
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0501
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0632
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0282
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.2456
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0602
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0416
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.1279
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0216
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1838
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.097
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.1078
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0978
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1396
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0581
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0781
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.1116
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.2116
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.2321
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.2384
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.288
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.1197
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.3337
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.2957
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.2442
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.047
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.1696
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.3182
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.2674
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.2364
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.2891
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.2814
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.1967
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.2664
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.1021
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0268
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0308
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.1696
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0496
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1716
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0473
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0509
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0594
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0417
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.0457
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0703
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0582
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0191
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0567
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0161
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0042
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0897
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0277
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0224
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0886
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0003
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0457
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.018
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0084
+        }
+      ],
+      "73": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0465
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.019
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.086
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0514
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0162
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0486
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0257
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0002
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0367
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0428
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0071
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0035
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0323
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0485
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0207
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0038
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0277
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0774
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0181
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0536
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0696
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0456
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0398
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0446
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.029
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0988
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.041
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0285
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.078
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0663
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0068
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0127
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0531
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0477
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0041
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0141
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0346
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.024
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0467
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0673
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.026
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.1014
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0897
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0374
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.1247
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.061
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0582
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0153
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.044
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0433
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0178
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0831
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0215
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0082
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0681
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0109
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0233
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0365
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0314
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0463
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.038
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0452
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0354
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0056
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0115
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.2971
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0778
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0338
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0145
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.103
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0171
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0055
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0871
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.02
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0453
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.4036
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.4434
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.027
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0131
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0226
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0088
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0323
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0551
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0801
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.036
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0346
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0353
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0251
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0018
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0117
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0917
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1132
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0104
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0378
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0411
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0291
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1268
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0735
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0541
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0107
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0911
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0131
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.127
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0576
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1391
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0094
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0979
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0135
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0422
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1258
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0111
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0655
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0805
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.112
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1883
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0167
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0309
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0242
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0287
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0178
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0209
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0663
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.3896
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0105
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0719
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0197
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.0363
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "T",
+          "weight": 0.0217
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0656
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0608
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.1294
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0218
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0297
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0494
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1002
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0144
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0403
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0201
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0708
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0168
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0637
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0285
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0055
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0746
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0109
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.017
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0252
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0233
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0402
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0251
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0359
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0247
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0358
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0245
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0164
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0174
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.077
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0065
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.106
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0703
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0801
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0161
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1048
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "N",
+          "weight": 0.0513
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0385
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0802
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0076
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0312
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.062
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.075
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1091
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0721
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0036
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0182
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1012
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.031
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.4167
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.3587
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.4731
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.17
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.2264
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1767
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.3023
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.3922
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.4539
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.3151
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.4149
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.2336
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3913
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3149
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.236
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1766
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.09
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0551
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.2656
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1784
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0441
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0428
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0054
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0088
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0313
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0329
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.103
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0789
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0737
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.063
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0674
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0352
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0096
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0406
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0277
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0073
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0664
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0021
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0309
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.001
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.069
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0958
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.102
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1426
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.033
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0426
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.045
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.06
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0022
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0045
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0184
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0441
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1205
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0348
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0596
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0349
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0115
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0441
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0348
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0139
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1276
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0083
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0225
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0329
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0005
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0163
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.006
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0674
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0009
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0004
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0122
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0374
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0112
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0441
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0387
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0179
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0009
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0412
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0349
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.097
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0364
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0017
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0709
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.005
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0302
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0085
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1825
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0814
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.021
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0715
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0936
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0122
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.074
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0225
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0282
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0274
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0034
+        }
+      ],
+      "228": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0935
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.054
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0134
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0867
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0259
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0218
+        },
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0166
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0838
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0739
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0398
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0131
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.052
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0062
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0506
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1022
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0541
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1031
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.0725
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0861
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0045
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0071
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0627
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0766
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0126
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0495
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0074
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0111
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0039
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0607
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1045
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0248
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0165
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0143
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0428
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0637
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.068
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1294
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.024
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0002
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0633
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0215
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.004
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0922
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0034
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.2312
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.152
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.1501
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0931
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.2409
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0801
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.1422
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.2659
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1404
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0094
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1417
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0628
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0785
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0697
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0248
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1399
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0047
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.06
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0122
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0372
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0281
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0074
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0049
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0155
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0871
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0961
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1101
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.04
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1666
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0824
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.1357
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0427
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0108
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0068
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0121
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.1272
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.012
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0241
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0124
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0287
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0359
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.058
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0149
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0076
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1441
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0156
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0656
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0599
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0046
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0994
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0157
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.043
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.069
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0038
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.1202
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.079
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.1188
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0632
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.026
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0518
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0261
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0144
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0263
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0118
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0755
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0206
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0308
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0397
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0174
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0166
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0154
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0517
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1049
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0505
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.1478
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0626
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0315
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.046
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.036
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0059
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0765
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.1105
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0532
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0458
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0776
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0998
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0301
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0518
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0878
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.2361
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0793
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0639
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1391
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0422
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0379
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0921
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0332
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0608
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0602
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0438
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0891
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0738
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2389.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2389.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2389' in cohort '2-5_years'",
   "serum": "2389",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/2389",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2462.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2462.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '2462' in cohort 'infant'",
   "serum": "2462",
   "cohort": "infant",
+  "cohort_serum": "infant/2462",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2462.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/2462.json
@@ -1,0 +1,3164 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '2462' in cohort 'infant'",
+  "serum": "2462",
+  "cohort": "infant",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1011
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1561
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0626
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0174
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.2054
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0121
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0975
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0551
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.0084
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.1723
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0063
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0423
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0343
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0393
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0455
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0497
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0323
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.129
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0126
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.036
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0218
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0601
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0013
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0715
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0581
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0038
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0088
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0189
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0517
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.1166
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0822
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.1942
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0117
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0985
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0489
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0151
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0149
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.2
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0136
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0485
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0794
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0788
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1259
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0685
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0024
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0625
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.036
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.2104
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.3311
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0177
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0975
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0419
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.039
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0618
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0724
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1288
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0074
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0174
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1123
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1406
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0643
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0842
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.1515
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0023
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0504
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0542
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0412
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0938
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0133
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0318
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0327
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.1585
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0403
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0458
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.006
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0633
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0094
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0698
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0384
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0253
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0051
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0568
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0954
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0117
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0624
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0655
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0263
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0535
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1115
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0048
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0467
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.071
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0478
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0055
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1835
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0182
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0723
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1386
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0938
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0876
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0371
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.1086
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0316
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0705
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1137
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1504
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.1646
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.004
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0346
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0509
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0226
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0582
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0918
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0143
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0649
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0098
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0057
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0916
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0426
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1396
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0284
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0339
+        }
+      ],
+      "39": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.067
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0741
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0483
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0184
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0499
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1032
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0578
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0405
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0011
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0849
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0484
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0557
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0147
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0152
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0279
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1661
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0081
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1575
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0315
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0014
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0438
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0746
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.1551
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0291
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1521
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0217
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1102
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0093
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0248
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0383
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0526
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.1442
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0596
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0368
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0296
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0682
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0321
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0895
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0073
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.022
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.1471
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.0198
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.0352
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0488
+        }
+      ],
+      "51": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0724
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0151
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1369
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0283
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0249
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.1094
+        },
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0313
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.0351
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0623
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0167
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0518
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.015
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0646
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0439
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0199
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0126
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1142
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0996
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0685
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0361
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0875
+        }
+      ],
+      "77": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0908
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.1045
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0755
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1424
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0067
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.184
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.1526
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0588
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0295
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.012
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0405
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1146
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0797
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0953
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0353
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0737
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.02
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1403
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0046
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0933
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0024
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1507
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0132
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1106
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.203
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0152
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0323
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.021
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0356
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0038
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0301
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0055
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0335
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.064
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0481
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.025
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0778
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0324
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0523
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0129
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0252
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0464
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.1236
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0849
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0441
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0089
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0654
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0461
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.1438
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0509
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0128
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0164
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0191
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0401
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0552
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.2361
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0652
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0157
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0347
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0123
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0202
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0391
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0069
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0376
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0273
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0159
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0733
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.2598
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.124
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.061
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.2796
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1344
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0239
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0662
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.091
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0222
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0648
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0306
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.064
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0473
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2449
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0839
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0361
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0611
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0013
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1368
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0667
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1163
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1204
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.003
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.2335
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0458
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.2147
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.016
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0146
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0688
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0329
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0371
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.2491
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0304
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0692
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0627
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1344
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3276
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0679
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.3662
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1499
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0045
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0038
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.151
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0999
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0291
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1285
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.2724
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.8071
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2383
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.2107
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.4754
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1355
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0424
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0458
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0702
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1656
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0036
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0662
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0121
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0432
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1057
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0286
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0131
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.041
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0184
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0971
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0838
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.03
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0812
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0323
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2606
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0444
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1752
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0055
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0499
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.055
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0134
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0092
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0251
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0205
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0595
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0022
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0634
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0947
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0046
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0364
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0555
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.1355
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0816
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0737
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0685
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0435
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0983
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0094
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0876
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0873
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0434
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.2051
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0283
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0777
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0081
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2935
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.5084
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.7322
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0319
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.2796
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1087
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.3446
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.2744
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.3997
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.3856
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.4003
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.368
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3333
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2655
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.074
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0122
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0308
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0171
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0337
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0383
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0028
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.009
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5513
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.4408
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.1102
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0759
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0768
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0025
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0608
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0306
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.001
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0845
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0664
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1352
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.1147
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0518
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0338
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0202
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0347
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.025
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0361
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0438
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0543
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.069
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.117
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0295
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0772
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1666
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0613
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0234
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0764
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0047
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0012
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.154
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0432
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0852
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0499
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0323
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0312
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.1257
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0989
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0139
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0017
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.012
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0463
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0072
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0639
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0701
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0204
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0727
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0148
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0772
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0336
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0426
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0677
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0178
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1981
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1594
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0414
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.004
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0872
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0866
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1152
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0104
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0129
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0916
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.058
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.2071
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0154
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0241
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0169
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0121
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.3076
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0253
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0048
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0141
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0009
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.007
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0076
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0007
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0079
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0614
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.065
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0323
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0585
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.054
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0501
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0047
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.0007
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0154
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0197
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0822
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0107
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0074
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0224
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1356
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0668
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.1268
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0567
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0924
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0455
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.075
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0125
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0099
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.074
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0079
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0764
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.1269
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0586
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0578
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0086
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0911
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0619
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.1062
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0154
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0944
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0204
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0623
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0205
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0301
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.2452
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0296
+        }
+      ],
+      "284": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0315
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0152
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.106
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0129
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0249
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.114
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.2
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.116
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.1796
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0416
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0728
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0766
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1465
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.1104
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0906
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0187
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0243
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0071
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0267
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0761
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0407
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1058
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0326
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.039
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0899
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0387
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1073
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0013
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0429
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0106
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.205
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0413
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0173
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0762
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0511
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.09
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.1901
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1047
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0075
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0122
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0151
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0373
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1921
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0784
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0628
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0532
+        },
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.2017
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0634
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1623
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0431
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0858
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0974
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0499
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0091
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0961
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0241
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.1248
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.1888
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.1449
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0248
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0434
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0074
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0421
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0075
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0024
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0152
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1103
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0888
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.078
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/33C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/33C.json
@@ -1,0 +1,3194 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '33C' in cohort '40-45_years'",
+  "serum": "33C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0718
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1145
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0037
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0721
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0242
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0289
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0335
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0458
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0955
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0362
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0144
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.054
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.067
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0557
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0203
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0053
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0542
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0839
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0438
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0175
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0971
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0162
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0052
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1634
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0465
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0005
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0165
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0024
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0202
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.067
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0201
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0424
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0297
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0069
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0904
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0457
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.133
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0546
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0329
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0234
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0565
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0564
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.219
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1139
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1282
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0059
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0275
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0025
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.007
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0097
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.1491
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0387
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0892
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0186
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.02
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0754
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0228
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0033
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0715
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0136
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0542
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.014
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0947
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.083
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0112
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.1804
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0322
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0234
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.1226
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0149
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.1432
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0152
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0215
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0204
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0318
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0195
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.019
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0083
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0472
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0256
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0147
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0219
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0522
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0022
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0277
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0386
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1161
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.068
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0175
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0094
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0644
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0703
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.1068
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0336
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0034
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.109
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.03
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0452
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.1266
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1873
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0317
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.212
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0046
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0625
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0275
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0591
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0336
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0316
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0304
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0482
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0462
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0148
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.074
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0851
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0008
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0216
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1897
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0012
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.057
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0569
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.025
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0174
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0328
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0668
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0298
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.14
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1309
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1502
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0984
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0896
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0198
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0666
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0296
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0475
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0209
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0048
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0399
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0673
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0046
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0074
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0163
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1362
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.1457
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0366
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1552
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0741
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0002
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0171
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0021
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0299
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0914
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0269
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.004
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1061
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0266
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0524
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0706
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0296
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0065
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.136
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0292
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0061
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0067
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0921
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0876
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0163
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0173
+        }
+      ],
+      "67": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0192
+        }
+      ],
+      "69": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0673
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0271
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0494
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0015
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0337
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0365
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.016
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1309
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.04
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0385
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0539
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0659
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0443
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.005
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0077
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0066
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0992
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0881
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0091
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0877
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0578
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0903
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1012
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0395
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0146
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.063
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.004
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0322
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0302
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0744
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0821
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0011
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.1988
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0491
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0689
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0184
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1159
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0579
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0019
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0364
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0321
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0882
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0013
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0853
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.1227
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0029
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0429
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0261
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0255
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.113
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0133
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0876
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.095
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0545
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0003
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.022
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0772
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0208
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0173
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.019
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0262
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0672
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0355
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0178
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0447
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1005
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1096
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0548
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1311
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0219
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0521
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.018
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0492
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0019
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0019
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1263
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0083
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0349
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0037
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0726
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.019
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.1725
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0165
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.2014
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0328
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.152
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1094
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.288
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0103
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0411
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0883
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0138
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2217
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1706
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0345
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.127
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.265
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.4086
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.3637
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0832
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0614
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0846
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0273
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1388
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0286
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1798
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0913
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.156
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3153
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0745
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.1055
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0258
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.2182
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1866
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0269
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2767
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.004
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.2537
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2931
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0329
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.2512
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.2211
+        }
+      ],
+      "155": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0123
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0571
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0061
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0096
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0412
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0308
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0744
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0049
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0188
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.033
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0083
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0365
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.121
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0832
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0197
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0238
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1058
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0824
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1226
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0913
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0432
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0552
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0651
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0046
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0465
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0486
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0921
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0443
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0568
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0946
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0019
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0162
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0053
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0343
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0077
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0553
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0611
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0108
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1635
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1529
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1033
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.2965
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1651
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0482
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1124
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.5364
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.5395
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.6653
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0904
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.4683
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1774
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.3583
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.2846
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.4804
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.3102
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.4291
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1558
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.4404
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.3507
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.3705
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0611
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.046
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0361
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1277
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0065
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0706
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0359
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0236
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1095
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0932
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5049
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.5621
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0469
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1066
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0595
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0915
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0518
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0108
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.057
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0427
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.087
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0126
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0179
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0336
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0599
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0537
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0873
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0065
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0691
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0727
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0498
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.015
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0265
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0094
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0118
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0136
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0306
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.1303
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0107
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0422
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1083
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0308
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0246
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0395
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0837
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0467
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.12
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0467
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0952
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0091
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0384
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0909
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.133
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0441
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0305
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0396
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0553
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.018
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0118
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0004
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.2763
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0317
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0373
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0614
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0188
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0065
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0141
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0561
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0731
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0089
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0754
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0332
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0196
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0423
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0949
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0188
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0398
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0387
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0411
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0399
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0544
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0192
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0767
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.075
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0437
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0205
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0287
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0843
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0297
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0169
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.078
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0941
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0409
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.079
+        }
+      ],
+      "224": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0013
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0213
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0142
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0195
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0306
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0035
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0584
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.079
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.2041
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1238
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1009
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0102
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0057
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0101
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0059
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0406
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1591
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.1295
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0657
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1147
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.115
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0197
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0002
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.02
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0187
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1291
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0116
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0152
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0285
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.001
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0185
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0064
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0265
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0004
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0385
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0529
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0246
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.007
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0726
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0304
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0044
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0016
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.015
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0864
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0363
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0317
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0644
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0477
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0074
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0046
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0909
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0198
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0045
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0021
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0012
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0187
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.01
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0312
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0719
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0257
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0711
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0724
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0934
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0281
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0484
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0652
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.014
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0794
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.1037
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.1435
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0082
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.1095
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0208
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0038
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0814
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0191
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0165
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0482
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0489
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0122
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0441
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0082
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.007
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1055
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0145
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0338
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0321
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0527
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0597
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0554
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0362
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1866
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0054
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0464
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0308
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0933
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.161
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.004
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0603
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0446
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0255
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0311
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.056
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0113
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0931
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0515
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0314
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0259
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1365
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1078
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0312
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.057
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0647
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0047
+        }
+      ],
+      "320": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.1402
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0532
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.049
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0352
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0976
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0937
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0317
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0454
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0841
+        },
+        {
+          "from": "V",
+          "to": "Y",
+          "weight": 0.0151
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0318
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0396
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0921
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0447
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0085
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0071
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/33C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/33C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '33C' in cohort '40-45_years'",
   "serum": "33C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/33C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/34C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/34C.json
@@ -1,0 +1,3009 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '34C' in cohort '40-45_years'",
+  "serum": "34C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0927
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0135
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0254
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0931
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0822
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0413
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0898
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0127
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0561
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0094
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0471
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.3174
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0374
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0053
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.089
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0274
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0054
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0192
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0819
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1267
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0442
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.062
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0563
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0719
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0171
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0097
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1229
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0592
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0643
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0003
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0424
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.2245
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.075
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0097
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.1516
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0347
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1451
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0182
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0212
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0248
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.096
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0671
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0269
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1225
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0113
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0568
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1224
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0443
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0539
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0297
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0172
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0879
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0252
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0402
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1543
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1669
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0724
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.1895
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0227
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0149
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0617
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.075
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0245
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0641
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0019
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0145
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1102
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.1527
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0281
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.1295
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0513
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0223
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0671
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.097
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0448
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0093
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0829
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0445
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0328
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0261
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1351
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0486
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0675
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0341
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0154
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0696
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0152
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0449
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0162
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1183
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.062
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1059
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0413
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0087
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0204
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1614
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0077
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1418
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": -0.0
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.1066
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0784
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.136
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0707
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0919
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0484
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0105
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0045
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.05
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0276
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0171
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.1121
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0272
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.071
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0903
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0431
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0603
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0304
+        }
+      ],
+      "39": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0514
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0271
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0745
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0445
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1007
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0991
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0389
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1391
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0935
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0538
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0392
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.043
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0392
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0329
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0157
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1023
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0144
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0044
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0766
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0023
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0347
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.036
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0787
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0646
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0129
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0878
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0131
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.078
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.1314
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.1678
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0032
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0417
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.047
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0282
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.1084
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0167
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0423
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.0034
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0124
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.1525
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0675
+        }
+      ],
+      "51": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0608
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.1082
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0219
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0672
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0494
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0567
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0514
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0099
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0273
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0045
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0107
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0644
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0047
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0224
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0253
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0532
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0225
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0001
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0336
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0278
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0945
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0973
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0049
+        }
+      ],
+      "63": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0169
+        }
+      ],
+      "73": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.1748
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.028
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0338
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0158
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.1103
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.113
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0033
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0087
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0151
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0062
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0152
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1445
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0277
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0449
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0035
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0301
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1234
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1515
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0043
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0707
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0169
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0031
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0914
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0745
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0202
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0072
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0444
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.088
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0453
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0015
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0931
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0438
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0171
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0255
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0275
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.1099
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0444
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0568
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0709
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0758
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0193
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0095
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.1108
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0276
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0509
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.2377
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0048
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0395
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0655
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0495
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0156
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0362
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0895
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0009
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0003
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.007
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0036
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0827
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.4908
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0172
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0411
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0696
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0186
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0206
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0037
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0144
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0495
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0189
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1384
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0138
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.6193
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1093
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.6666
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.012
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0859
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0662
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0469
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0254
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0487
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0306
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0818
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0702
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0166
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.137
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0025
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0296
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1083
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0275
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0196
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0827
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.2228
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1033
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.2672
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.2772
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1384
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1426
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.144
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2305
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.2391
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.08
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1461
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.0384
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.034
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.1107
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0936
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0244
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0367
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1176
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0294
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0939
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1133
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0837
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0518
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.1227
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.1523
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0948
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0945
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.2232
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1878
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3756
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1382
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0665
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.5998
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.2643
+        }
+      ],
+      "155": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1057
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.0176
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.1789
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0066
+        },
+        {
+          "from": "L",
+          "to": "T",
+          "weight": 0.0513
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0421
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0459
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.1341
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.03
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.017
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0497
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.027
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0262
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0809
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0386
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0047
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.052
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.1239
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0989
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0245
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0525
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0244
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0815
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0784
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1065
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0994
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0641
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0735
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.093
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0291
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0364
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0468
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.154
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0676
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0752
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0902
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2904
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0776
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 1.1337
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 1.1958
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 1.3044
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.7009
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 1.023
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.7682
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 1.0102
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 1.0724
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 1.139
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 1.0545
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 1.1957
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.7838
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 1.1761
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.9754
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 1.0794
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.6587
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1764
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0323
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1411
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0201
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0734
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0356
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0595
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0085
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0354
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.6556
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.6295
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.2405
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.1004
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0646
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.1044
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.044
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.066
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.1224
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0415
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1268
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0448
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0702
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0641
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0794
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0702
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0479
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0839
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0059
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0375
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0017
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.058
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.069
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0186
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0275
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0165
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1125
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0806
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0792
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0681
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0265
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0882
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0716
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0451
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0569
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0127
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0006
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0091
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1133
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1205
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0192
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.238
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.1118
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0285
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0902
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0952
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0837
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.2519
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.021
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0639
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0237
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0496
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1025
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0526
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0184
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0596
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1088
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0281
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.2771
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0519
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0051
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.1248
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0907
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0173
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1222
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0216
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1076
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0104
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.1075
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0498
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0853
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0366
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0445
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0079
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0195
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0235
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.057
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0459
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0028
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.035
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0775
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0144
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.025
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.051
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0013
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1073
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0131
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0223
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0125
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0975
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0218
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0177
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.166
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0512
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0889
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1332
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0241
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0214
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0263
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0972
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0664
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0278
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0818
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0174
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0454
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0621
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.077
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0064
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0421
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0226
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.08
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.032
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0604
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.2846
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.196
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.007
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0534
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.026
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0015
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.004
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0552
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0051
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0167
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.051
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0338
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0211
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0846
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.1015
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.037
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0028
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0221
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0164
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0893
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0346
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0138
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0908
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0903
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0612
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0722
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0081
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0795
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0064
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0068
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0167
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0898
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0745
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0355
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.3937
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.057
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0377
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0902
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0731
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0955
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0265
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.03
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0414
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1673
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.1125
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0142
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0163
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0638
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0167
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0131
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.1621
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1008
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0606
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0451
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0088
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0557
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0634
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/34C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/34C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '34C' in cohort '40-45_years'",
   "serum": "34C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/34C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3856.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3856.json
@@ -1,0 +1,2921 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '3856' in cohort '15-20_years'",
+  "serum": "3856",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0263
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.007
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0862
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0111
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0515
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0372
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0378
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.027
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0366
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0554
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0693
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0508
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.033
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0542
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0567
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0988
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.1016
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0186
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0392
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0178
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0058
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0189
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0745
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0591
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.1096
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1007
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0017
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0611
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0859
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0436
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0399
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0367
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0104
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0367
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.1211
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0667
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1546
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0019
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0075
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0086
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1519
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1726
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0015
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0588
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0185
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0637
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.11
+        },
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0221
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.036
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0235
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.1766
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.1201
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0008
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1766
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0116
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0163
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0066
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0134
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0353
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0291
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0135
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0462
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0179
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0633
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0141
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1157
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0283
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0071
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0733
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0015
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1608
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0125
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0078
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0474
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0109
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.008
+        }
+      ],
+      "26": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0035
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0022
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.2255
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0562
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1303
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1002
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0415
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0013
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0309
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0172
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0117
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0353
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0454
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0268
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0503
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0264
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0094
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.028
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0692
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0209
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0027
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0843
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0376
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0175
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0405
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0553
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1641
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.1182
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0446
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.083
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0143
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0127
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0478
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0306
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0112
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1556
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0549
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0447
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1763
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0684
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0297
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.107
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0908
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0071
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0127
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0441
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0524
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0008
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0191
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0803
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0011
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.054
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0009
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1013
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1641
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0206
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0297
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0815
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1242
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0598
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0255
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.038
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.063
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0205
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0534
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0001
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1524
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0078
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0229
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.0037
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0156
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0305
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0048
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.026
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0897
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0179
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.1032
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0775
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.045
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0785
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0843
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0199
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0167
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0148
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0056
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0745
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0648
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0555
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.077
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0194
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2588
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.3013
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0148
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1938
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1185
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2416
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1926
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2984
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0062
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0272
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2016
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1309
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0357
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0484
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0086
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0368
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0476
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0205
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0163
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0203
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0129
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0502
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0154
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0147
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0113
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.027
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0511
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0156
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0664
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1308
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0267
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0372
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0324
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0264
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0447
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0149
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0376
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0484
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.1215
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0125
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.038
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1789
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0112
+        }
+      ],
+      "102": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0274
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0155
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0432
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0289
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0561
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0047
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0429
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1299
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.076
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1984
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0031
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.052
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0016
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0525
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0104
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0178
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0077
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.2521
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.3891
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0482
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0598
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0132
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0839
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.06
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.161
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0161
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1672
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0022
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.007
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0062
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0505
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0615
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1517
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1746
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0187
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0243
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1039
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.016
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1153
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0403
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0624
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0053
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1616
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1288
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0336
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0436
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0544
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0309
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0536
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.119
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0133
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1022
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.3812
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0057
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0452
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0019
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.0059
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0004
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.02
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0768
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.057
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.1167
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1016
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0209
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0091
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0523
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0397
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0217
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0042
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.1049
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0598
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.1581
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0498
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0308
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1604
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.1284
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0608
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0348
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0317
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0593
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0475
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0758
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0609
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0901
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0014
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0092
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0602
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0457
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0473
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.003
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0612
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0261
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0089
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0016
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0679
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0276
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0186
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0451
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0272
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0632
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0233
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0484
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0229
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0595
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0432
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0588
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0119
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0489
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0503
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0831
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0262
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0127
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0105
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1832
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0356
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0055
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0986
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0169
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0268
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0037
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0163
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0198
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0046
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0369
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0476
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0928
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0012
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0026
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0515
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0666
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0951
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0383
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0219
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0273
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0089
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0477
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0081
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0003
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0015
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0421
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0206
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0181
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0668
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0724
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0296
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0071
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0016
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0055
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.074
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0304
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0235
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1391
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0969
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0589
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0343
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0465
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0527
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0418
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1125
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1315
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0021
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0451
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0604
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0469
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0037
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0361
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.125
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1069
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.01
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.1466
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0254
+        }
+      ],
+      "224": [
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0024
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0465
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.064
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0304
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0414
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0319
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0764
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0345
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0693
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1122
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0579
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0826
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1422
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0197
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0368
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0281
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0558
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0431
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0779
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0774
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0787
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0821
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0247
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0229
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0411
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0171
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0479
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.095
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.069
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0251
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0006
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0561
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.017
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0379
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0536
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0968
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0781
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0174
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0371
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0136
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0157
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0483
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0804
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.1159
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0354
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0249
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0421
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1893
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.229
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1939
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1003
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.2716
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.2924
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.2139
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.2173
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3205
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.219
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0462
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0012
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0156
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.08
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0222
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0108
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0082
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0055
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.006
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0181
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0241
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0474
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0079
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0148
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0818
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0588
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0547
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0394
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0003
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0126
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0099
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1188
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0096
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0174
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0304
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0241
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.074
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0189
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0368
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.02
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0719
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0316
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0029
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0142
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0453
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.051
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0488
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0804
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0091
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0735
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0715
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0089
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0139
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0536
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0435
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1374
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0046
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0174
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0881
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1207
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0002
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0526
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0164
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0378
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0029
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0517
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0323
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0175
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0363
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0113
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0929
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0032
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0229
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0497
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0831
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0047
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0575
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.051
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0331
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0515
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.173
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0594
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0056
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0127
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0133
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0208
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0806
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.1137
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0238
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0468
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0643
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3856.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3856.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '3856' in cohort '15-20_years'",
   "serum": "3856",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/3856",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3857.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3857.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '3857' in cohort '15-20_years'",
   "serum": "3857",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/3857",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3857.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3857.json
@@ -1,0 +1,3024 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '3857' in cohort '15-20_years'",
+  "serum": "3857",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1299
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0139
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0194
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0798
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0632
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0424
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0146
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0101
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0461
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0509
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0413
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0006
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0499
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0076
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0179
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.04
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0651
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.001
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0391
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0208
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0694
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0053
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0616
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0365
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0195
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0166
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0249
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0056
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.002
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0216
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.022
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0004
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0011
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0143
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0591
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0007
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0506
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0067
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0012
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.028
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0038
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0543
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0035
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0088
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0519
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.101
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0248
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0168
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0054
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0114
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0247
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0992
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0282
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0032
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0103
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0312
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0374
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.042
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0012
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0212
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0212
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0315
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0238
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0262
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0257
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0255
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0085
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0111
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0207
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0368
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.058
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0207
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0351
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0103
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.018
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0087
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.031
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0439
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0116
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0894
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0159
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0498
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0119
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.017
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0044
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0554
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0006
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0332
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0991
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0069
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0005
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0688
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.078
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0112
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0284
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0428
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0988
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0162
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0604
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0364
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0185
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.01
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0245
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0015
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0016
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0469
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1017
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0895
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0929
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0102
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.018
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0778
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0487
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0015
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0129
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0129
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0282
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0377
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0576
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0574
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0443
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.3337
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0409
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0205
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0489
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0687
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0098
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0169
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.059
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0805
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0175
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.096
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.184
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0763
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0086
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0667
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.1401
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0992
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.045
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.0558
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0404
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0312
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0563
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0131
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0912
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0398
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0496
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0073
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0284
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.002
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0426
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.032
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0156
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0186
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0074
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0458
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0119
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0103
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.3467
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0315
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0245
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0076
+        }
+      ],
+      "73": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0416
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0344
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1137
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.1105
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0352
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0938
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0088
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.1008
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0871
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0101
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.07
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0366
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0042
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0372
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0622
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0239
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.154
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0137
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0122
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0764
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0844
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0077
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0293
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0033
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0391
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1102
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0317
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0575
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0399
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0933
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0929
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.2466
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.2106
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0119
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0379
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1149
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0895
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.028
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0502
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0961
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0128
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0615
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0407
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0179
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0259
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.018
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0096
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0607
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0367
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0203
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0083
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0071
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0396
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0223
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0172
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0341
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0427
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0369
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0305
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0412
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.036
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.041
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.049
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0163
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0278
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0484
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0658
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0806
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0042
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0092
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0565
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0807
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0367
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0689
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0381
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.06
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0241
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0433
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0443
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0549
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0296
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0272
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0144
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0894
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0973
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0466
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0653
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0121
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0814
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.2327
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0901
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0199
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0122
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1736
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.0502
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0786
+        }
+      ],
+      "138": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0107
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1798
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0746
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0574
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1227
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1632
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.01
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1854
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1064
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3348
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0143
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1381
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1416
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2481
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1038
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1221
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0755
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0679
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0584
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1519
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.2402
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.2613
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.1002
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.1564
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0932
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0538
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.2199
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0521
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.058
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0201
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0397
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0518
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0676
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0298
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0392
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0515
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0112
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0402
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0047
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0319
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0082
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.017
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.028
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0205
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0124
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.026
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0656
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0722
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.2392
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0871
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0295
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.027
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0356
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0162
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0038
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1173
+        },
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0122
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.1677
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.2764
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0243
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0147
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0076
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0337
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0491
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.3329
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0512
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0245
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.2124
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0842
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0138
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0147
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.4572
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.6814
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.7525
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.2854
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1828
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.3564
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.3309
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.2902
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.2985
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.3474
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.5355
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.2193
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.4222
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.4892
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.351
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.3443
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0239
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.022
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.6684
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.6129
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0294
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0107
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0165
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0272
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.007
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0096
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.212
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0231
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0114
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0461
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0021
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0732
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0054
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0199
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0729
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0295
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0227
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0478
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.2617
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0442
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0654
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0273
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0072
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1149
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0287
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0717
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0862
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1268
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.043
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0065
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0939
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0101
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0077
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0059
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.033
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0081
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0647
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0016
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1871
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0927
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1037
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0227
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1243
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0254
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0441
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0869
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0184
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0536
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0229
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0576
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0329
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.1477
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0587
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0326
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.068
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0988
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0448
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0475
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1887
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.046
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0076
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0702
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0158
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0214
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0106
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0168
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0114
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.009
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0123
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.01
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0234
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0338
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0638
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0248
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0298
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.023
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1066
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0005
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0137
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0822
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0058
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0361
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0114
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0028
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0123
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0073
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0122
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0439
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0434
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1141
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1177
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.04
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0219
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0547
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.2254
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0771
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.062
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0547
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.029
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0943
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0113
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0131
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0333
+        },
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0209
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0689
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1301
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0362
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0566
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.1375
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.008
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0184
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.2749
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1637
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.2761
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.3168
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.3926
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0096
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0679
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0578
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0704
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0437
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.006
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0132
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0214
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0727
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.009
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0225
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0401
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0688
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0093
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0274
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0182
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0284
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0285
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0265
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0551
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0337
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0184
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0702
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0646
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0032
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0044
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0466
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0659
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0113
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0246
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0663
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0199
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0099
+        },
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0189
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0111
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0167
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1594
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0656
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0335
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0033
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0463
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0117
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0415
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0252
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0006
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0237
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0391
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.1488
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0034
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0791
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0586
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0368
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0727
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0332
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.2132
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0153
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0229
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0016
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0127
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0055
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0272
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.2706
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0722
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0404
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.022
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.018
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0533
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0301
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0037
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0071
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.03
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0041
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0024
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.034
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0308
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0417
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "P",
+          "weight": 0.0149
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0235
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0253
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3862.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3862.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '3862' in cohort '15-20_years'",
   "serum": "3862",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/3862",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3862.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3862.json
@@ -1,0 +1,2794 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '3862' in cohort '15-20_years'",
+  "serum": "3862",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1743
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0764
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0295
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.1139
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0125
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0195
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0157
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0657
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.093
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0644
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0033
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0055
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0576
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0133
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.04
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0082
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0319
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0103
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0421
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0163
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0573
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0341
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0245
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0087
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0085
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0925
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0044
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.075
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0494
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0014
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0016
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0092
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0009
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0195
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.008
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0392
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0165
+        },
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.0458
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.011
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0081
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0285
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0038
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0929
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.134
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0494
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0681
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0841
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0109
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.1081
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0692
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0719
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0774
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0898
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0038
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0391
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0575
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0024
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0682
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0413
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0998
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0199
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0394
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0061
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0202
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0004
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0067
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0585
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0076
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0114
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0762
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0037
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0093
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0101
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0997
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0686
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0432
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0111
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0375
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0516
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0031
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0516
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0701
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0264
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0048
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0549
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0381
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0535
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0352
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.062
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0702
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0188
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0139
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.025
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0077
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0868
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0028
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.03
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.078
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0159
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0189
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0096
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0018
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0525
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0268
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0291
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0289
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1007
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0916
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0074
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0168
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0459
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0411
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0391
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0267
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0024
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0187
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0224
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.004
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0027
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0055
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0338
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0387
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0454
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0407
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0376
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0014
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0653
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0007
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0084
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1347
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0134
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0205
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0128
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.116
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.018
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0427
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0068
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0421
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0437
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1114
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0025
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0026
+        }
+      ],
+      "77": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0089
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0257
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0109
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.1067
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0366
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0311
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0283
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1266
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0555
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0266
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0152
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0119
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1191
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1171
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.08
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0079
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0364
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0304
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0165
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0403
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0191
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0756
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.084
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0053
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0606
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1554
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0722
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0859
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.1049
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0444
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.1306
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0573
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0425
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.1557
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0972
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0699
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0079
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.1015
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0168
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0158
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0316
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0142
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.1246
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.2213
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0348
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.1239
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0695
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.013
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0577
+        }
+      ],
+      "109": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0209
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0244
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0249
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0566
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0739
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0439
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0051
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0338
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0426
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0585
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1735
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1042
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0575
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0178
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0068
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.1452
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0751
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0458
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0707
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0799
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0225
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0662
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0227
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0384
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.027
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1003
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0296
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0238
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0453
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0779
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0584
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0238
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1044
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1098
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0878
+        }
+      ],
+      "138": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0667
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.2413
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0853
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.054
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1094
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0912
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0308
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0091
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0854
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0026
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.2961
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1361
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1355
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0917
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0479
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3214
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0301
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1531
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.4101
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0575
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.2434
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.2931
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.2265
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0351
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.138
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.2371
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.2285
+        },
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.3698
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0054
+        },
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.2537
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "D",
+          "weight": 0.0336
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0268
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.1025
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.4458
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.3979
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.4332
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.25
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.4295
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.2562
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.268
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.4405
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.1771
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0151
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.086
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0644
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.123
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0593
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0067
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.003
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1055
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0741
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0072
+        },
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.1164
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0096
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.1128
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.025
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0754
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0442
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0106
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0046
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0445
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0139
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0117
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0181
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0115
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0206
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0067
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0029
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0054
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0008
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0223
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0892
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.3548
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.3374
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1601
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0338
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1314
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0871
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1796
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0732
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1205
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0139
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0227
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1321
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0637
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.3784
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0113
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0876
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1417
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0383
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0113
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0321
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.1563
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1035
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0345
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0195
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0647
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0601
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0017
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1026
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0747
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.576
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.6237
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0296
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.003
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0517
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0258
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0177
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0336
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0007
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1368
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.079
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0041
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0233
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0135
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0627
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0044
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.065
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0167
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0382
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0186
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.018
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0083
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0139
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0403
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.1074
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.037
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.1119
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0425
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0118
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0405
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0172
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.042
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0114
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0042
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0045
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0672
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0038
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0017
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0766
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0089
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0437
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0734
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0278
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0026
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0236
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.006
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0643
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1267
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0177
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0184
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1252
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0191
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0005
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0214
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.075
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0382
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0637
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0311
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0711
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.1121
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.03
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0414
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0283
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0609
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0326
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.039
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0417
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0377
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0164
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0704
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0163
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0209
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0855
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1324
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1155
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0528
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.1636
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.2248
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.1084
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0883
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0223
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0142
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0356
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0089
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0776
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0995
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.2074
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1828
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1782
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1703
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1508
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0493
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0055
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.1076
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0052
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0955
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0502
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": -0.0
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0564
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0127
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0476
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0163
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0139
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0183
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0043
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.043
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1213
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0214
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.003
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0727
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0183
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0473
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0949
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0449
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0306
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1386
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0194
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0504
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0522
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1154
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0265
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0423
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0584
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0866
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0439
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0553
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0186
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0316
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0071
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0288
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0978
+        },
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.1051
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.015
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0182
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0146
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0066
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0137
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0117
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0158
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0295
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0072
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0102
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0237
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0337
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0467
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0101
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.004
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0112
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0152
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0179
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0391
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0167
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.001
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0109
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0154
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0215
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0814
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.004
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0515
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0388
+        }
+      ],
+      "320": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0191
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.002
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0308
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0215
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.041
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0517
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0161
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0151
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0006
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0071
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0418
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3866.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3866.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '3866' in cohort '15-20_years'",
   "serum": "3866",
   "cohort": "15-20_years",
+  "cohort_serum": "15-20_years/3866",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3866.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3866.json
@@ -1,0 +1,3132 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '3866' in cohort '15-20_years'",
+  "serum": "3866",
+  "cohort": "15-20_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0832
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0004
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0172
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0735
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0528
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1051
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0619
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0199
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.0211
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0488
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0092
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.1066
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.1113
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.01
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0585
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0042
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.1316
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0929
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.011
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0538
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.024
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0542
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0453
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0975
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.181
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0765
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0574
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1107
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0082
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0327
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0005
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0985
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0606
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0635
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0377
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0948
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0275
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0451
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0518
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0495
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1038
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1586
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0514
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0165
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0121
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.207
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0306
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.3187
+        },
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0841
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0732
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0441
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0149
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0591
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1192
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0223
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0078
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.01
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1954
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0707
+        }
+      ],
+      "16": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0049
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0027
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0932
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0072
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0138
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0156
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0209
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1413
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0814
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1587
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0759
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.3145
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0438
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0408
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0349
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0262
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.1259
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0374
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0327
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0289
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1256
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0729
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0039
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0044
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0071
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0379
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0728
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0437
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0061
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0487
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0146
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0601
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.1954
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0204
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0264
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0426
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.1152
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0084
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0653
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0003
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0083
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0318
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0192
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0042
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.017
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0101
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0123
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0338
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.1503
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0301
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0045
+        }
+      ],
+      "41": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0065
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0743
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0498
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0095
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.014
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0071
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0879
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0879
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0133
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1098
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1126
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0275
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0185
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.04
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0042
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0411
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0152
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0928
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0329
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1016
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.1334
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0988
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0343
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1521
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1326
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0236
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0051
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0628
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1762
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0855
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0026
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0108
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.1612
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0502
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.1349
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.1016
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0749
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0874
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0182
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0966
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0798
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0422
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0615
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0165
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0933
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.1292
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0441
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0225
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0252
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0728
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0417
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0215
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0092
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0884
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0166
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1826
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.003
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0175
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0019
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0525
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0285
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0434
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0229
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1174
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0086
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0786
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1354
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1004
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0213
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0216
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0666
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0304
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0848
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0554
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0588
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0308
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0876
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1667
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0184
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1355
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.1408
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0104
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.116
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0147
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.3202
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0194
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0019
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0351
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0458
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0398
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.1002
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0487
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0123
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0329
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0281
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.063
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0376
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.1175
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0809
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0729
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.018
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0337
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.095
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0962
+        }
+      ],
+      "102": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0494
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0385
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.046
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0602
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0108
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0065
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0441
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0255
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0657
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0415
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0871
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.069
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.01
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0003
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0256
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0621
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0208
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.198
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0703
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.2659
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0457
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0633
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0994
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0717
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0272
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0234
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0328
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0132
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0404
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0081
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1221
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0338
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.029
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0529
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0257
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1773
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.0315
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0874
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0843
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.233
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0243
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0225
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0035
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0603
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0347
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.058
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0689
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1009
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0284
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1933
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.141
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1491
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1414
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0636
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.2126
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.5692
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0253
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0111
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0262
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.131
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1365
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0861
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.8549
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1597
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0407
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.4301
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0864
+        }
+      ],
+      "155": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.038
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.1457
+        },
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.0172
+        },
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0425
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0002
+        }
+      ],
+      "158": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0008
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0109
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.3222
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.4515
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0769
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.412
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1179
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0371
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.1313
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.2882
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.1544
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0622
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.1255
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.2881
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0246
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0541
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0139
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.2503
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.1359
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0207
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.1567
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0757
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0731
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0019
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0539
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0571
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0133
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0645
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0055
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0102
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.018
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0466
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.066
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0645
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.252
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1537
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.021
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0042
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0133
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0862
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1762
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.1117
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0695
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0777
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1631
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0008
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0698
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0114
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.11
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0022
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0264
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0754
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.2061
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0566
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0665
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0778
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.2764
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2074
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0917
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0987
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.9345
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.9486
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.9972
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.5228
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.6882
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.6784
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.7784
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.8222
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.9091
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.7638
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.9064
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.4161
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.8993
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.7436
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.7753
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.6009
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0687
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1455
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0578
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0001
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.145
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0119
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1394
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0355
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.8535
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.7916
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1935
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0871
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0491
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.096
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0002
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.1878
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.004
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0253
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.072
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1306
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0015
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0244
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0847
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0487
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0348
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0662
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0071
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0682
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0075
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0607
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.074
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.051
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.019
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0175
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0349
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0315
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0658
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.029
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0045
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0673
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0987
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0608
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.097
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0461
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0614
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0879
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0223
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0649
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0575
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0404
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0209
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0298
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0742
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1084
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0384
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.046
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0134
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0146
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1832
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0662
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0002
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0024
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1062
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0339
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0744
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0901
+        }
+      ],
+      "217": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0205
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0221
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0151
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0561
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0328
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0366
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1112
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0071
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0742
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0804
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0389
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0418
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0523
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.1145
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0303
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0385
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "H",
+          "weight": 0.0447
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0495
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.145
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0012
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0078
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.147
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1797
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.1371
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1584
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1974
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0311
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0045
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0143
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0604
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0345
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0433
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0537
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0458
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0925
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.1182
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0775
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0053
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0483
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0588
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0882
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0773
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.024
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.05
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.1108
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0074
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1263
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0001
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.084
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0468
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0956
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0117
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0372
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0124
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0532
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0072
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0467
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0089
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.1975
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1363
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0623
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0648
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0669
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0075
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0475
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0442
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0388
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0379
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0774
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.023
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0195
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0017
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0241
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0263
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0503
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1663
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0314
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0713
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0717
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1123
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0428
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0614
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.043
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0687
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0202
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0854
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0366
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0232
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0234
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1695
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.02
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0726
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0166
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0985
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0298
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0146
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0448
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0663
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0288
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0303
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0629
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.049
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0346
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1051
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0212
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0201
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0957
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0343
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0015
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0057
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0303
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0897
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0057
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0283
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0013
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0131
+        }
+      ],
+      "320": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0423
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.1183
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.1108
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0315
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0046
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0396
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0332
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0009
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0113
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0343
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0552
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0147
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.02
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0462
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1204
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0527
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3944.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3944.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '3944' in cohort '2-5_years'",
   "serum": "3944",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/3944",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3944.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3944.json
@@ -1,0 +1,3596 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '3944' in cohort '2-5_years'",
+  "serum": "3944",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0069
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0821
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0703
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.1011
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0489
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0822
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0221
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0005
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0743
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0072
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0357
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0133
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0197
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0036
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0158
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1033
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0325
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0635
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.022
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0863
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0311
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0238
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1025
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0048
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0283
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.2722
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0105
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0225
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0006
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.148
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.018
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0592
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.1348
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0001
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0541
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0279
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0717
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0351
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.007
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0243
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0691
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0773
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0241
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.043
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0217
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0236
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1725
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0196
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.097
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0673
+        },
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.1594
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.007
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0599
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0301
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0435
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0257
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0301
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0789
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1441
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0149
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0158
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0708
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0581
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0092
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0165
+        }
+      ],
+      "17": [
+        {
+          "from": "H",
+          "to": "R",
+          "weight": 0.0805
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.052
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0188
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0057
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0492
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.034
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.041
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.1397
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0641
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0165
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0745
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1001
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0035
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.026
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.064
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.234
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0237
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0306
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0242
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0311
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0494
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0294
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0872
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0116
+        }
+      ],
+      "28": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0747
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0018
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0363
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1043
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0696
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0558
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1496
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0148
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0824
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0137
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1104
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0074
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.1146
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1261
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1168
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0609
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0086
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.1309
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0323
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0481
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0082
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0528
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0796
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.033
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0071
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0179
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0242
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0228
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0166
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.05
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1106
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0306
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.056
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.1233
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.028
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0162
+        },
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.1037
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0037
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0793
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0711
+        }
+      ],
+      "39": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0711
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.044
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0283
+        }
+      ],
+      "41": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.1697
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0021
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.1096
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.069
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0105
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0911
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0698
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0439
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.014
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0266
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.07
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0045
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.001
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0072
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.05
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0953
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1888
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0548
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0402
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0219
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.2548
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.04
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0463
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0179
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.014
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0284
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.016
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0197
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0178
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0238
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0367
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1016
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0569
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0284
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0167
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0729
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0422
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.1375
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0608
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.012
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0936
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0554
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0464
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0635
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0181
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0337
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0275
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0183
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.099
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0238
+        }
+      ],
+      "51": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0301
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.1937
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0931
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1288
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1253
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0101
+        },
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.1209
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.1599
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0537
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0095
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0729
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0214
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0457
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0419
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.061
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0449
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0429
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0479
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0903
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1088
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0856
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0388
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0326
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0082
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0357
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0394
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.012
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0716
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.1121
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0223
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0317
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.073
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0263
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0134
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0068
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0133
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0034
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.016
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0532
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0004
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0466
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0183
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0716
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1227
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0396
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0298
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0193
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0234
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0186
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0314
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0741
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.094
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0927
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1246
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0319
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0037
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.007
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0268
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0276
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0256
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.1349
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0161
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0528
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0239
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.085
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0638
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0218
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0129
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0236
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0507
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0334
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0731
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0241
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0967
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.1179
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.1726
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.0103
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0423
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0376
+        }
+      ],
+      "109": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0471
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0865
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0437
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0125
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.3348
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0322
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1567
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0241
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.022
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.074
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0379
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.003
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0158
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0037
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0283
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.021
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0507
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0213
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0413
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0467
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0575
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.618
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0216
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.6927
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0437
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0881
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0077
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0158
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0877
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0124
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0112
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0038
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0468
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0726
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.094
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1754
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.01
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1357
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0191
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0039
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.148
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1808
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0644
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1245
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0964
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0285
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0338
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0364
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1372
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.009
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0101
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.027
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1175
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0598
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0242
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.043
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0711
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1194
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0067
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.105
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0642
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1954
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0488
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0878
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0999
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0586
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0482
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0001
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1168
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1509
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0005
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0547
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0525
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0658
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3748
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0902
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0129
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0702
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0332
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0801
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.6477
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1038
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0377
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0457
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.2478
+        },
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.0072
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0023
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0301
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.0286
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.2264
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.1269
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0664
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.2131
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1796
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.158
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.1714
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.1125
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0986
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.1956
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.2584
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.2471
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.2429
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.3438
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.2716
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.5014
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.17
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.2453
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.2887
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.3989
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1831
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.3743
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0376
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0115
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0854
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.1661
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0652
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0236
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0501
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0338
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.098
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0361
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0464
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0378
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0391
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.1165
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0324
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0959
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0996
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0868
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0494
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0958
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0409
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0426
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.067
+        }
+      ],
+      "184": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0476
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0826
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0533
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0425
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0363
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1217
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1458
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0516
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0722
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1366
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.8241
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.8066
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.8553
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.4059
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.6548
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.4165
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.7151
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.8016
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.7566
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.7299
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.8226
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.3631
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.7707
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.706
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.7317
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.5415
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0478
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.177
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0057
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0619
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0214
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0331
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.4992
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.4798
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.237
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.057
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0694
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0139
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0746
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0833
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0753
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.028
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0153
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0206
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0591
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0618
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0556
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0566
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0243
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0115
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0524
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.001
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0546
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0414
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.041
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0371
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0285
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0638
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1363
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0401
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0362
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0934
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0629
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0633
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.014
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0875
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0121
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0182
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0052
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.029
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0166
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0072
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0225
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0037
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0093
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0098
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0247
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0499
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0094
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0678
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0132
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1823
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.1453
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0137
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0823
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1069
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0085
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0351
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0974
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1909
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.1718
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0197
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.006
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0472
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0037
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0078
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0257
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0176
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0123
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0749
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0813
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0071
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0311
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.108
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0233
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0655
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0854
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0749
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0058
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0532
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0051
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0118
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0202
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.095
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.1077
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0009
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0329
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0007
+        },
+        {
+          "from": "L",
+          "to": "C",
+          "weight": 0.0254
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0781
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0786
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0339
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0361
+        }
+      ],
+      "246": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0505
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0186
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1192
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.043
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0106
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0671
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0555
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0155
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0458
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0354
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0215
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0184
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0079
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0556
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.019
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0571
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.019
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0449
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0334
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0407
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0534
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0323
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0318
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0614
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0703
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0828
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.1053
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0863
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0667
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0802
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0594
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0687
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0359
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0042
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0078
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.087
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0188
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.029
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0314
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0213
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0357
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0761
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0776
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0395
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0578
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0018
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0314
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0322
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0002
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0273
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.054
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.2162
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.1667
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0412
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0734
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0315
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0594
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0087
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0105
+        }
+      ],
+      "284": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0648
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0218
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0003
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0902
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0445
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0784
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0935
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.1771
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0339
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0548
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.1452
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.1154
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0104
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0258
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0222
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0246
+        }
+      ],
+      "301": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0787
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0205
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.004
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0556
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0855
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0158
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0198
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0305
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1174
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.027
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0581
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0389
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0761
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.017
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0163
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1506
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0352
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0355
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0003
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0115
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.037
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0193
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0254
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0452
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0191
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0092
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0379
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.3436
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0279
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.2266
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0098
+        }
+      ],
+      "320": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.1625
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.124
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.001
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0358
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0126
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0284
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0209
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0708
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.1416
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0422
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0438
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0036
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0073
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0041
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0103
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0494
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0407
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.1169
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.131
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0281
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.016
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0043
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0726
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0723
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3973.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3973.json
@@ -1,0 +1,3402 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '3973' in cohort '2-5_years'",
+  "serum": "3973",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0335
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0496
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0205
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0229
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0273
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.044
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1109
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0451
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.073
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.04
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.023
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0405
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0121
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0526
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0945
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.007
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0839
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0046
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0903
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0031
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0034
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0037
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0223
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0056
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0332
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.026
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0151
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "C",
+          "weight": 0.0823
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.035
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.018
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0231
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0255
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0036
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0026
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0332
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.035
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0401
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0257
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0709
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0062
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.037
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0252
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0269
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.181
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0156
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0266
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0629
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0075
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0104
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0297
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0113
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0195
+        },
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.1378
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0424
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.064
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0061
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0143
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0248
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0257
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0243
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0009
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0077
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0161
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.063
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0393
+        }
+      ],
+      "16": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0218
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0635
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0014
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0389
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0509
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0043
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0131
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0835
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0042
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0179
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0793
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0544
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.02
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0382
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0716
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0266
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0684
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0506
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0094
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0102
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0437
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0391
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0219
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0888
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.047
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0004
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0652
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0018
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0183
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0519
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.032
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0309
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0034
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.044
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.091
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.026
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0262
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0506
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.012
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0695
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0208
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0295
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.1404
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0255
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0031
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0355
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0142
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0183
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0166
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0122
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0313
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0571
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0399
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0177
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0722
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0263
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0077
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0264
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0449
+        }
+      ],
+      "39": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0072
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0074
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0163
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0087
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0239
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0403
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0372
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0245
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0529
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0329
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0175
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0687
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0667
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.024
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0375
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0732
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0011
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0026
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0109
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0336
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.05
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0204
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0004
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0493
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0248
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0266
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0145
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0247
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0017
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0105
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.0287
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0094
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.0196
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0288
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.084
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.018
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0061
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0653
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0215
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0022
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0137
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.0197
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0691
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0281
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0473
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.09
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.0257
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0111
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0301
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0046
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0669
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0291
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.034
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0491
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.065
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0212
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0887
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.04
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0028
+        }
+      ],
+      "70": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0041
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0019
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.056
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0295
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0365
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0156
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0179
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0963
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.028
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0247
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0595
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.015
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0611
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0362
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0261
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0035
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0074
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0666
+        }
+      ],
+      "84": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0056
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0484
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0565
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0154
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0936
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0589
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.018
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0134
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0134
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0198
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0355
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0486
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0152
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0038
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0151
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0204
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.029
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0162
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0615
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0038
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0896
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0326
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0463
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0088
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.1002
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.0039
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0679
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0528
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0133
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0869
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0676
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1104
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0063
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0179
+        }
+      ],
+      "102": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0109
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.04
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0272
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0092
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0698
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0293
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0897
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.062
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0062
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0094
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0172
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0192
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0058
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0756
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0182
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0137
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0928
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0285
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0116
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0374
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0081
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0125
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1079
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0162
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0344
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0454
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0243
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0263
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0051
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0055
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.378
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.6434
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0025
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0468
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0191
+        },
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0015
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0171
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.1153
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0568
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0353
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0643
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0451
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0253
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0168
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0454
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0215
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0209
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0362
+        }
+      ],
+      "136": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0079
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0387
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0497
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0001
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0621
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0259
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0749
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0606
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0154
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0711
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0373
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0261
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0841
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1211
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0363
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0105
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0056
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0974
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1835
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0244
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0791
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0289
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0336
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0066
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0053
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0485
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.031
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0195
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0472
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.041
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0531
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0498
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0808
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0224
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.009
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0813
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0168
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0631
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0587
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0899
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0442
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0146
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0202
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0236
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0298
+        },
+        {
+          "from": "E",
+          "to": "G",
+          "weight": 0.0091
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0102
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0798
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0019
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0295
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.026
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0424
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0077
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0179
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0598
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0204
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.024
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0278
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0065
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0004
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0127
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1246
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0401
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0019
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1649
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0227
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.189
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.2857
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.5307
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1053
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1235
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0837
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0981
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.062
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.127
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1002
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1323
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1399
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.014
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0409
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.3274
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1915
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0253
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.001
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0533
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0198
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0205
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0183
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0105
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0392
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0169
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.021
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0455
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0572
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0107
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0449
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0464
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0092
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0768
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0108
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0237
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0534
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.023
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0571
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0083
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0151
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0394
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0527
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0348
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0033
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0145
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0097
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0081
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0104
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0439
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0127
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0681
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0018
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1631
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0048
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0796
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0448
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0731
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0277
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.072
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.019
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0118
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0763
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0582
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0213
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0168
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0204
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0073
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0416
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0184
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0304
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0582
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0105
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.002
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0399
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0147
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0362
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0289
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0283
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0563
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0723
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0168
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0161
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0392
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.044
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0743
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0071
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.018
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.128
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0548
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0783
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0206
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0317
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.022
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0023
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.002
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0409
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0029
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0658
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0078
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0316
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0384
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0272
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0215
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.1649
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.1597
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0777
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0879
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.007
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1119
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0016
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0295
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0593
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0647
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0137
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.092
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0454
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.1356
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0035
+        }
+      ],
+      "228": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0216
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0318
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0208
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.0404
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0056
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0227
+        },
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.1006
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0066
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0124
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1172
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0197
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1076
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0062
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0701
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.044
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0448
+        },
+        {
+          "from": "L",
+          "to": "C",
+          "weight": 0.0048
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0594
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1139
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0102
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0562
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0065
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.0923
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0038
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0455
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0281
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0556
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0568
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0273
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0235
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0229
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0051
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0029
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0402
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0444
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0046
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.007
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0125
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0328
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0206
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0472
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0289
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0113
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0434
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0074
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0146
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0058
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0016
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0169
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.004
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0047
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0589
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0073
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0116
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0015
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0398
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.0067
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.009
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0122
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0378
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0566
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0143
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0155
+        }
+      ],
+      "273": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0011
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0747
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0629
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0137
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0089
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0189
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0062
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0212
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0678
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0452
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0705
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0191
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.2588
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0121
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.1055
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0147
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0171
+        }
+      ],
+      "288": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0025
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0205
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0077
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0551
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0766
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0736
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0534
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0742
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.024
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0245
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0014
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0254
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0087
+        }
+      ],
+      "302": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0108
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0022
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.004
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0358
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0098
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0209
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.079
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0236
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0219
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.016
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0163
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0635
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0724
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0485
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0751
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0053
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0206
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0037
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0332
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0111
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0493
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0239
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0444
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0144
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.1038
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.01
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0406
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0041
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.081
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.033
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0624
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0366
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0093
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0661
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0356
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0154
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0602
+        }
+      ],
+      "325": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0082
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0177
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0109
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0229
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0238
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0127
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0141
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0377
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0307
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0056
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3973.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/3973.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '3973' in cohort '2-5_years'",
   "serum": "3973",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/3973",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4299.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4299.json
@@ -1,0 +1,3368 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '4299' in cohort '2-5_years'",
+  "serum": "4299",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0379
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1425
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0151
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0304
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0236
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0208
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0223
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0039
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0073
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0272
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0537
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.1267
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0118
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0844
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.034
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0753
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0307
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0136
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0164
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0522
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0183
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0687
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1659
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0047
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0439
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.039
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0356
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.029
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0836
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0186
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0073
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0654
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0137
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0221
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0118
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0139
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0937
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0269
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0775
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0256
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1245
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0688
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0091
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0181
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0037
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0115
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0381
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0349
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.04
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0127
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.023
+        },
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0189
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0229
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0346
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.1527
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.135
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0021
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0068
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0079
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.024
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0023
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0138
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0032
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0135
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0265
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0166
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0095
+        }
+      ],
+      "20": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.1119
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0007
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.015
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.044
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0219
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.0003
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0918
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0826
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0362
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0075
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0152
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0216
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0647
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0718
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0126
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0001
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0246
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0025
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0201
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0334
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1037
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0021
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0259
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0289
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0415
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0296
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0917
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0013
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0337
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0584
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0048
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0051
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.09
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0338
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0136
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0951
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0038
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1111
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.078
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0736
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0191
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0504
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0505
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.1081
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0237
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0908
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0754
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1066
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0142
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.004
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0509
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.029
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0272
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1099
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0428
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.005
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0268
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0219
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0589
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0072
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0089
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.089
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0826
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0052
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0681
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0702
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0246
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0887
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1384
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0886
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0691
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0754
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0106
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1004
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1007
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0609
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0007
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0554
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0381
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0058
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0485
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0546
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0108
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1041
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0147
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0502
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0328
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0596
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.054
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0755
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.1904
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1872
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.0538
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0838
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0856
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0056
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0016
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0702
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.1552
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.1048
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0343
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0328
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0461
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1054
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0457
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0376
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.2056
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.1479
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.1061
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.1363
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.1153
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.1925
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.0889
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0566
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.0763
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.116
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.1252
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.1032
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.1239
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.1344
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.1705
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0033
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0634
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0838
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0299
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0304
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1267
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0354
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0801
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.1004
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.059
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1002
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0006
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0386
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0552
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.03
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0427
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0049
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.167
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1167
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0242
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0329
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0423
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0627
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0577
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.027
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0373
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0288
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.002
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0381
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0148
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0722
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1156
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0103
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.013
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0586
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1654
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0373
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.011
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0307
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0269
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0775
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0463
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0012
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0138
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0145
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0333
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0033
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0812
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0254
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0359
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0026
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0085
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.061
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0217
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0023
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0152
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0488
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.046
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0035
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0635
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "A",
+          "weight": 0.01
+        },
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0071
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0142
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.125
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.1971
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0067
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.1025
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0014
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0062
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.03
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0629
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0791
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0485
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0281
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0232
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0056
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0245
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0408
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0407
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0044
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1096
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0456
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.042
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.254
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0567
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0019
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0563
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0637
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0276
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0447
+        },
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.2714
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0105
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0418
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0227
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0253
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0324
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.5194
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.6963
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0257
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0739
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0469
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0288
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0874
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0801
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0135
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0088
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0149
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0276
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.1422
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0204
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.2087
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0635
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0083
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.015
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0289
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0747
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0308
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.0246
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0071
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0732
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1056
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0063
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0508
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0417
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0182
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0221
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.1408
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0776
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0045
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1361
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0071
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0442
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0668
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0233
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0116
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0026
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1724
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1197
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0474
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0323
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.4701
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0366
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1578
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0168
+        }
+      ],
+      "155": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0222
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.063
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.077
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0522
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0081
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0342
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.043
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0636
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0713
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0062
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0518
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.045
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.1057
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0537
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0084
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0821
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0184
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0062
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0468
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0201
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.019
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0118
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0266
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0166
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0316
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0264
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0472
+        }
+      ],
+      "175": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.2469
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0129
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1714
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0899
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0776
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0021
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.1826
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.0182
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0477
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.066
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0822
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2943
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.3372
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.3493
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.3138
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.1173
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1486
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.2609
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.2043
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.2467
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.3559
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0206
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3091
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.2028
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2097
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0907
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0349
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0267
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0284
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0112
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0251
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.14
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.068
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0068
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0294
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0425
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.1216
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0347
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.052
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0129
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0054
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0309
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0242
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0374
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0182
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0021
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.015
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0605
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0071
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0271
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0437
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.015
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0436
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0107
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0429
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0354
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0696
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.004
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0903
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.024
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0007
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0092
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0724
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0424
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0032
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.014
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0021
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0538
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0313
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0159
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0787
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0486
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0215
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0573
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0003
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0302
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0132
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0285
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0004
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0332
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0675
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0135
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.078
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0361
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.05
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.064
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0208
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1073
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0583
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0602
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0907
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0467
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0176
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0121
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0157
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0076
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0079
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0421
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0194
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0182
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1007
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.071
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0003
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0099
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0422
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0256
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0751
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0607
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0687
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0087
+        }
+      ],
+      "228": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0108
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0435
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0488
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0485
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.002
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0442
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0349
+        }
+      ],
+      "246": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0102
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0258
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0028
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0859
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0052
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0384
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0048
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0689
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0678
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0558
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1277
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0284
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0722
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0248
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.008
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.001
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0203
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0679
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0262
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0212
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0945
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.061
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0171
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0159
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.013
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.1284
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.1294
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0848
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.1741
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0203
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.034
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0788
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0704
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0687
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0595
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0006
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0863
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1297
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1045
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.107
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0322
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0287
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0532
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1023
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.024
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0748
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0711
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1349
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.042
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0114
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1818
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0746
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.026
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0231
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0299
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0803
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1121
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0253
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0054
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0814
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.1056
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0052
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0266
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0008
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0863
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.09
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0437
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.029
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0022
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.035
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0445
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0588
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0682
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0391
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.1536
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0329
+        }
+      ],
+      "292": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0402
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0167
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.045
+        }
+      ],
+      "297": [
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0055
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0342
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0046
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0477
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0108
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0359
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0153
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0309
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0793
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0193
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.1054
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0388
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0245
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0942
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0691
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0124
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0271
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0096
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0375
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0426
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.1258
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0259
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0821
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0319
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0309
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0956
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0452
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0162
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0283
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0374
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0247
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0495
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.0353
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0545
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0511
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.1445
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0782
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0235
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0253
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.1374
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0244
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0228
+        },
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0239
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0413
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0148
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0271
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0223
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0723
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0067
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0404
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0185
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4299.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4299.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '4299' in cohort '2-5_years'",
   "serum": "4299",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/4299",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4584.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4584.json
@@ -1,0 +1,3309 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '4584' in cohort '2-5_years'",
+  "serum": "4584",
+  "cohort": "2-5_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0716
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0584
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.013
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.1652
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0684
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0014
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0476
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0682
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0078
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0794
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0025
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0233
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0017
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0941
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0929
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0208
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.005
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.083
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0254
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0135
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.114
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0242
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0732
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0234
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0202
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0538
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "F",
+          "weight": 0.055
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0083
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0139
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0186
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0401
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.1224
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0137
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1098
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0786
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0011
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0114
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0439
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0228
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.1118
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0867
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0118
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0143
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0215
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0196
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1299
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0083
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0628
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0616
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.026
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0451
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.1221
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0561
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0228
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0007
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0455
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0592
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.012
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0383
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0194
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.0594
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0498
+        }
+      ],
+      "16": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.039
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0319
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.035
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0247
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0671
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0121
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0479
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0118
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0494
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0143
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0942
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0446
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0093
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0608
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0819
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0199
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1123
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0325
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0311
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0792
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0078
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0112
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0714
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0053
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0258
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0328
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0115
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0641
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0469
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0466
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.025
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0305
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0124
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.1151
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.082
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0076
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.005
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0815
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0204
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0667
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0104
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0056
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0249
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0363
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0953
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0345
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0137
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0166
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0332
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0209
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0166
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0373
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0705
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0299
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0658
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.1432
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0936
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0348
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0392
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0335
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0051
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.013
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.1713
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.3135
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.3319
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.2067
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0874
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.4156
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0196
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0192
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.1353
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.2278
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.2018
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.4029
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.2021
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0613
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0973
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0881
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0587
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0371
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0622
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0471
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1924
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.2206
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.3362
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.4601
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.5785
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.4528
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.6214
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.542
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.5321
+        },
+        {
+          "from": "E",
+          "to": "N",
+          "weight": 0.309
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.2158
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.5964
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.548
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.393
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.4212
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.4032
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.3322
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.5458
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0808
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0925
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0948
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0509
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0738
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0087
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0519
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0472
+        },
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0111
+        },
+        {
+          "from": "H",
+          "to": "L",
+          "weight": 0.0247
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0868
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0077
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0315
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0204
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0229
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0038
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1035
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0044
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0059
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0096
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0233
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0407
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1141
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0226
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0179
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0498
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.029
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "I",
+          "weight": 0.0455
+        },
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.0143
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0404
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0336
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.037
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0037
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0215
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1293
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0238
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.009
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0094
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0918
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0959
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0661
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1167
+        }
+      ],
+      "86": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.083
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0296
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0104
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0344
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0901
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0819
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0579
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0197
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0751
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0042
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0411
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0683
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0218
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0414
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0408
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0006
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.047
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0194
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0921
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0661
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0967
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0172
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0177
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0146
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.1133
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0144
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.041
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0399
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0534
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0133
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0212
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0521
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0295
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0667
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.025
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0383
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0135
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0428
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0414
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0309
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0354
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.074
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.013
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0556
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0896
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1136
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0699
+        },
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0547
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0545
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0196
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0396
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0099
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0244
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0403
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0375
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0508
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.3834
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0385
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.4989
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0117
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0143
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0651
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0632
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0115
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0011
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0076
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0443
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0443
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0706
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0051
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.0331
+        },
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0124
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0147
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0401
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0473
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0698
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0368
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0538
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0598
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0857
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0641
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0673
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0246
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0034
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0309
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.066
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1343
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0346
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.138
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0461
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0478
+        },
+        {
+          "from": "L",
+          "to": "K",
+          "weight": 0.0265
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0314
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0992
+        }
+      ],
+      "158": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.177
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0799
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0338
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0023
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0039
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0079
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.1863
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0932
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.2373
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0241
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0354
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0172
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0243
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.129
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0225
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0209
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0573
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0383
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0248
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1127
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0969
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0904
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0245
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0254
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1132
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0375
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "H",
+          "weight": 0.0226
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0132
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1252
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0017
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1082
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0089
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.053
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.1093
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0546
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0622
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.044
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0314
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.116
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0008
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0184
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0469
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0737
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0141
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0714
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0063
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0978
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0627
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0395
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0378
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1392
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0177
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0476
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0065
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0482
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0771
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0981
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0058
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0409
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0333
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0235
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0003
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0138
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0033
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0134
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0503
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.09
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0133
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.077
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0409
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0218
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0361
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0191
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0356
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1223
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0342
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.037
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0357
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0665
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0244
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0194
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0213
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0204
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0223
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0362
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0916
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.008
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0281
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0798
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0251
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0079
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0444
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.0481
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0046
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0216
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0456
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0436
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0361
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0197
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.062
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.031
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0184
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0387
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0833
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0238
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0045
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0168
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1212
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0661
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0424
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0252
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.019
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0729
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0323
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1145
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.184
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0236
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0248
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0842
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0272
+        }
+      ],
+      "217": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1666
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.1648
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0433
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.1456
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.2239
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0359
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0678
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.1783
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1551
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0234
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1821
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0451
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0626
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0768
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0769
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1054
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0268
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.2755
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0835
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.2632
+        }
+      ],
+      "224": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0127
+        }
+      ],
+      "229": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0803
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0483
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0543
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.017
+        },
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.0181
+        }
+      ],
+      "236": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0014
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0291
+        },
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0095
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0154
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.0687
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0193
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1028
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "C",
+          "weight": 0.0212
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0108
+        },
+        {
+          "from": "L",
+          "to": "H",
+          "weight": 0.0385
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0614
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0161
+        },
+        {
+          "from": "L",
+          "to": "S",
+          "weight": 0.0671
+        }
+      ],
+      "246": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.1813
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0713
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0544
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.3379
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0564
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1579
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0784
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0335
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0196
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0073
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0212
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0216
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0343
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0032
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0247
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0508
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0385
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0398
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0173
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0246
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0965
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0735
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0333
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0522
+        }
+      ],
+      "263": [
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0039
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0242
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1223
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0632
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0805
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0417
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0355
+        }
+      ],
+      "265": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.06
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1821
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0378
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0437
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0576
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0459
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0969
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0244
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0013
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.025
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.039
+        }
+      ],
+      "273": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.1836
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.2949
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.3165
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.5318
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.5701
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.3776
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.4285
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.569
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.3886
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.3258
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.5837
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.3047
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0242
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1356
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0601
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1017
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1054
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1441
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1085
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0618
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0532
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1388
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.021
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0873
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0664
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0256
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0376
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.025
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1691
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0111
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0725
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0423
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0154
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0257
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0963
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0301
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.1381
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0913
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.012
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.045
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0886
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0139
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0205
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.006
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0642
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0767
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0151
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0016
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0592
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0157
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.012
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0686
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0259
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0412
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0325
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0306
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0543
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.116
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0589
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0189
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0151
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.1304
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1501
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0737
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0564
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0168
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.2074
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.03
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.147
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0242
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0281
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.1021
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1103
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0808
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0157
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.055
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1319
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.1873
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.167
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0551
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.1132
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0903
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.0392
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0567
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0504
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.1007
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0137
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0948
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.2094
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0198
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.014
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0503
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0239
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0111
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0603
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.009
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0017
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4584.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/4584.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '4584' in cohort '2-5_years'",
   "serum": "4584",
   "cohort": "2-5_years",
+  "cohort_serum": "2-5_years/4584",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/68C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/68C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '68C' in cohort '40-45_years'",
   "serum": "68C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/68C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/68C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/68C.json
@@ -1,0 +1,3199 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '68C' in cohort '40-45_years'",
+  "serum": "68C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1773
+        }
+      ],
+      "2": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0968
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0391
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.1531
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.005
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0132
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0254
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0698
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0741
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.0148
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0197
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0011
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.1265
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0855
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0873
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0374
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0474
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0822
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.147
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0159
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0321
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0237
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.1589
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0107
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1102
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.2752
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.1094
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0936
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1151
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0738
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.006
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0201
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0973
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0167
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0006
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0394
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0145
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0074
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0798
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0652
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0564
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0042
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0617
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.503
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.061
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0245
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0109
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0898
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0315
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0346
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0312
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0027
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0116
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0579
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0276
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0627
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0049
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0043
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1757
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0816
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0046
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0225
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0998
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0484
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0931
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0141
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0467
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0046
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0442
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0243
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0687
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0258
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.046
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.1208
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0415
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0118
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0085
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0042
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0617
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.1485
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0086
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0099
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0691
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0644
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0246
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0033
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1481
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0629
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0595
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0761
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0708
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0245
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0063
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0315
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0025
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0234
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0417
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0234
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0012
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0108
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.193
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.051
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0266
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0121
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0119
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0151
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0265
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0026
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0704
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0466
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0304
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0596
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.1387
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1647
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.015
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0103
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.2746
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0575
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0768
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0035
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.1395
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0614
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0064
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0311
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0095
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.1204
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0025
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0226
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0654
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0592
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0166
+        },
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0171
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0956
+        },
+        {
+          "from": "I",
+          "to": "G",
+          "weight": 0.1031
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0369
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0184
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1169
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0717
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0881
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0628
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0528
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1212
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0306
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0522
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0205
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.1842
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0091
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0778
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0583
+        },
+        {
+          "from": "E",
+          "to": "R",
+          "weight": 0.0246
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0396
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0096
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0389
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0643
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0482
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0336
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0175
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0008
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.067
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0077
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.041
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0524
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0059
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0084
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.185
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0356
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1275
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0679
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0043
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0002
+        }
+      ],
+      "67": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0223
+        }
+      ],
+      "69": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0082
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0426
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.003
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0265
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.0101
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0675
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0498
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0875
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0099
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0793
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0796
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0233
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0437
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0143
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0284
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0784
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0477
+        }
+      ],
+      "87": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.03
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1385
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0635
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0426
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0797
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0406
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.017
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0691
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0259
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0217
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0297
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0569
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.1085
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1619
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0311
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0761
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.019
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.0035
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.0783
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.1178
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0488
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0241
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.1359
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0008
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.0689
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0269
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0238
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.1407
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0055
+        }
+      ],
+      "102": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0609
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0046
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0364
+        }
+      ],
+      "105": [
+        {
+          "from": "Y",
+          "to": "L",
+          "weight": 0.0241
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0564
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0084
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0181
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0098
+        }
+      ],
+      "109": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.054
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.012
+        }
+      ],
+      "113": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1191
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0165
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0669
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0726
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0089
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.028
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0072
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0502
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0808
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0933
+        }
+      ],
+      "126": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.062
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0688
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.024
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0401
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0185
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0119
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0056
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0126
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0833
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0073
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.0459
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0567
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0265
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0024
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1994
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1999
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.1587
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0018
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0991
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0355
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0022
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0092
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0838
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1473
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1077
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0566
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.1849
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.1399
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.0968
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.2874
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0122
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0512
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0973
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0143
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.167
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0207
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0644
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0774
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0086
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0371
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0206
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3655
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0144
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.1307
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0634
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0714
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.1876
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.067
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0509
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0175
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1632
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1394
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0311
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1154
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.038
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0698
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1362
+        }
+      ],
+      "156": [
+        {
+          "from": "H",
+          "to": "A",
+          "weight": 0.0089
+        },
+        {
+          "from": "H",
+          "to": "K",
+          "weight": 0.0132
+        },
+        {
+          "from": "H",
+          "to": "S",
+          "weight": 0.0159
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0797
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.1325
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.0149
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.229
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.0695
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0808
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.1536
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0168
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0003
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0624
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0389
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0805
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0023
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.134
+        }
+      ],
+      "167": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0599
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0517
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0536
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0442
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0032
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.029
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0266
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0296
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0007
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0097
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.053
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0093
+        }
+      ],
+      "172": [
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0598
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0215
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0218
+        },
+        {
+          "from": "Q",
+          "to": "F",
+          "weight": 0.106
+        },
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.1297
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0512
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0905
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0143
+        }
+      ],
+      "174": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0496
+        }
+      ],
+      "179": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0122
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1196
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0298
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.2076
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1616
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0781
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0388
+        },
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.1399
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0263
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0444
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0793
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0166
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2198
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.4014
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.5779
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0797
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.117
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.2312
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0331
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1285
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0939
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.2776
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.2264
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.2251
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1687
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.2811
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0043
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.1146
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0385
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1695
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1665
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0307
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.017
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.3667
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.4149
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0592
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0183
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0908
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0426
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.0526
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.1956
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0832
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0359
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0137
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0229
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0462
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0143
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0421
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0593
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1142
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0701
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.027
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.136
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0218
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1511
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1038
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1042
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0413
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.1753
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0325
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0267
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0509
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.1487
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.092
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0489
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0109
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1864
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0099
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1082
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0841
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.017
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.1615
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0236
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0259
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0725
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0146
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.1175
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0638
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0544
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.074
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0196
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1305
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0102
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1835
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0074
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0163
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0237
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0896
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.1423
+        }
+      ],
+      "213": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0061
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0129
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.3272
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0396
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0278
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0551
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0665
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0019
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0762
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0571
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.028
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0592
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.1819
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0265
+        }
+      ],
+      "217": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1174
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0553
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0561
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0274
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1403
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0068
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0714
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0119
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.106
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.1522
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0042
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1216
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0654
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.2169
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0481
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0562
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.1082
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0634
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0189
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.0488
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0272
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0642
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "C",
+          "weight": 0.019
+        },
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.085
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0407
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.021
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.008
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.0534
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.1098
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.1702
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1498
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.0579
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0654
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.017
+        }
+      ],
+      "251": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.048
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.1186
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0149
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0418
+        }
+      ],
+      "260": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.1053
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0192
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0505
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0432
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0477
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0094
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0088
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0754
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0327
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.07
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.006
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.085
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0417
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0264
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.0731
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0041
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0098
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0935
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0773
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0044
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0252
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0398
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0303
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0322
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0197
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0106
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0363
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0261
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0911
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1263
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0169
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0689
+        },
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0468
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0866
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0791
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0563
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0415
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0539
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0398
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0299
+        },
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0959
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.022
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0013
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.005
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0129
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.016
+        }
+      ],
+      "282": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0936
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0382
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0582
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0507
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0054
+        }
+      ],
+      "290": [
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0573
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0146
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0117
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0414
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0133
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0228
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0296
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.021
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0705
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0729
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.111
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.1429
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0283
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1213
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0882
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.1284
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1093
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0425
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0067
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0062
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0163
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0201
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.1089
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0127
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0104
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0399
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.1101
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0186
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0181
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0944
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.1358
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0123
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.1574
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.0021
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0563
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0178
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0321
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0372
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0809
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0515
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0833
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.1316
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0146
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0234
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.092
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0316
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0652
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.1808
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0302
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/74C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/74C.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample '74C' in cohort '40-45_years'",
   "serum": "74C",
   "cohort": "40-45_years",
+  "cohort_serum": "40-45_years/74C",
   "default": 0,
   "map": {
     "HA1": {

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/74C.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/74C.json
@@ -1,0 +1,3108 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample '74C' in cohort '40-45_years'",
+  "serum": "74C",
+  "cohort": "40-45_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "3": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.0339
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0055
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0847
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0531
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0738
+        },
+        {
+          "from": "I",
+          "to": "T",
+          "weight": 0.032
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0492
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0408
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0093
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0065
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.1111
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0109
+        },
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.127
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0609
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.128
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.017
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0491
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.041
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0269
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.0643
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0656
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0235
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0625
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0887
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0175
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.054
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0118
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1103
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0075
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0034
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0395
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0512
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.027
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0235
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0164
+        },
+        {
+          "from": "N",
+          "to": "W",
+          "weight": 0.0566
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.1851
+        },
+        {
+          "from": "D",
+          "to": "K",
+          "weight": 0.0251
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0513
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0529
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0297
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0124
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0705
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0051
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1553
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0126
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.022
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.1439
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0364
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0466
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.0035
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0304
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0819
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1903
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0008
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0636
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0819
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0901
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0466
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.016
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "C",
+          "weight": 0.0222
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0278
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0335
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0771
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0627
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1188
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0631
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0657
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0308
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0485
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0203
+        }
+      ],
+      "17": [
+        {
+          "from": "H",
+          "to": "R",
+          "weight": 0.101
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "Q",
+          "weight": 0.0117
+        },
+        {
+          "from": "H",
+          "to": "Y",
+          "weight": 0.0199
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0361
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1003
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.069
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0292
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.1419
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0027
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0049
+        },
+        {
+          "from": "P",
+          "to": "R",
+          "weight": 0.0048
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0692
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0472
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0257
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.0077
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0115
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0225
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0133
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0078
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0306
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.067
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.1502
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0355
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0049
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0229
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0563
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0998
+        }
+      ],
+      "29": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0595
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0023
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.1808
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0085
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1146
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0078
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1115
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0247
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0046
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.158
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0765
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0104
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.1189
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.1072
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0013
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0025
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0527
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0037
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0079
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0024
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0098
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0967
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0201
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0078
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.063
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0673
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0034
+        },
+        {
+          "from": "N",
+          "to": "V",
+          "weight": 0.2018
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.109
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0943
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.128
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0103
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0045
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0618
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0496
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0023
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0129
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.0369
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0234
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0998
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0032
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0672
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0042
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.1154
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.0086
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0392
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0236
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0492
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.2001
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0182
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1669
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.2032
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0327
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0199
+        },
+        {
+          "from": "Q",
+          "to": "D",
+          "weight": 0.082
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0657
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0086
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0007
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0485
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0817
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0122
+        }
+      ],
+      "58": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0016
+        }
+      ],
+      "59": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0989
+        },
+        {
+          "from": "L",
+          "to": "V",
+          "weight": 0.0473
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0065
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0627
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0105
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.028
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0303
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0779
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.1365
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.118
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.127
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0881
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0244
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.1684
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1406
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0361
+        }
+      ],
+      "81": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0291
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1249
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0179
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0121
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0391
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.1002
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0219
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0372
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1531
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.1974
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0828
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.09
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0695
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0098
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0267
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0071
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.052
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0103
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.1003
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0716
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0838
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0111
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0868
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.1106
+        }
+      ],
+      "93": [
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0594
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0256
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0052
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.0112
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.046
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0578
+        },
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0391
+        },
+        {
+          "from": "Y",
+          "to": "I",
+          "weight": 0.2057
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.1239
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0153
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.02
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0714
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.0555
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0482
+        },
+        {
+          "from": "Y",
+          "to": "T",
+          "weight": 0.1111
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.0733
+        }
+      ],
+      "96": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0316
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0796
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0008
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.022
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.006
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.0399
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0524
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0182
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.005
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0126
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0966
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0969
+        }
+      ],
+      "109": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0228
+        }
+      ],
+      "110": [
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0193
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0004
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0262
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0225
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0119
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1209
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.053
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0119
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.057
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0255
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0695
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0417
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0173
+        },
+        {
+          "from": "A",
+          "to": "Y",
+          "weight": 0.1139
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.2119
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1553
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.0022
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0251
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1137
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1207
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0783
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0509
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.4361
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0754
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0271
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0875
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.1075
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0505
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.1783
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 0.2283
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.1224
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 0.2849
+        }
+      ],
+      "138": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0116
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.2833
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0203
+        }
+      ],
+      "141": [
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.089
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.1097
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.078
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.0075
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0147
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0871
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0734
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.2442
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0587
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1583
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.2027
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.4836
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2955
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0612
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1241
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3819
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.107
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0827
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1273
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1514
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1698
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0841
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1264
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.2032
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0593
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0192
+        }
+      ],
+      "157": [
+        {
+          "from": "L",
+          "to": "D",
+          "weight": 0.1066
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0394
+        },
+        {
+          "from": "L",
+          "to": "G",
+          "weight": 0.0071
+        },
+        {
+          "from": "L",
+          "to": "N",
+          "weight": 0.0265
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "D",
+          "weight": 0.3128
+        },
+        {
+          "from": "Y",
+          "to": "E",
+          "weight": 0.2826
+        },
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0301
+        },
+        {
+          "from": "Y",
+          "to": "G",
+          "weight": 0.0791
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0432
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.2053
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.0282
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.1094
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.0262
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.072
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0016
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0802
+        },
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.0158
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0242
+        }
+      ],
+      "169": [
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0908
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0098
+        },
+        {
+          "from": "K",
+          "to": "C",
+          "weight": 0.0305
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.0351
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0413
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0095
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0038
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0599
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0804
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0247
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0405
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "G",
+          "weight": 0.0321
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.017
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.0127
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0304
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0495
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0643
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1214
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0435
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0212
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.2839
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.3388
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1411
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.3181
+        },
+        {
+          "from": "G",
+          "to": "W",
+          "weight": 0.0883
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.045
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.1293
+        },
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1699
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1717
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.0115
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0139
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.1363
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0237
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0231
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0031
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0416
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0686
+        }
+      ],
+      "190": [
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0392
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0181
+        },
+        {
+          "from": "I",
+          "to": "S",
+          "weight": 0.0161
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.2007
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0042
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0919
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.5442
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.3781
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0037
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0605
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0597
+        },
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0838
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.0139
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0577
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0783
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0012
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0438
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.1367
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0899
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0065
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.035
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0043
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0166
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0242
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0047
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0334
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.047
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0814
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.0734
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0607
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.0623
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0283
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0276
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0591
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0318
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0798
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0597
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.067
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0471
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0427
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1094
+        }
+      ],
+      "202": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0394
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.1128
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0044
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0448
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0209
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.068
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.113
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0416
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.106
+        },
+        {
+          "from": "R",
+          "to": "D",
+          "weight": 0.1069
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0208
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.074
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0273
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0318
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0262
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0299
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0039
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.011
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0501
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0163
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0138
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0247
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.1137
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.01
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0332
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0514
+        }
+      ],
+      "215": [
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.0151
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0737
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0876
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.069
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.108
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0292
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.1176
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0975
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1415
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0468
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0102
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0238
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.0173
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0169
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0541
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0604
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0068
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.009
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1636
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.005
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.1052
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.1212
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.124
+        },
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.2041
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0599
+        },
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0135
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.1016
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0894
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0154
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0332
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0077
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0233
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0097
+        }
+      ],
+      "233": [
+        {
+          "from": "Y",
+          "to": "H",
+          "weight": 0.0181
+        }
+      ],
+      "234": [
+        {
+          "from": "W",
+          "to": "Y",
+          "weight": 0.0693
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0886
+        },
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0719
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0534
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.0404
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.007
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.199
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.0685
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.1408
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0613
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0027
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0453
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0577
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0543
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0017
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0568
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0228
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0155
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0261
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0027
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0007
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0234
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0283
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0265
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0304
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0217
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0172
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0393
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.0225
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0074
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0043
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0727
+        }
+      ],
+      "270": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0049
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.092
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0671
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0655
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.074
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0377
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0476
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0103
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0254
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0332
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0931
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0181
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0167
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.081
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0013
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0361
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0197
+        },
+        {
+          "from": "E",
+          "to": "D",
+          "weight": 0.0174
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0492
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0421
+        },
+        {
+          "from": "E",
+          "to": "T",
+          "weight": 0.0675
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0481
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0283
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "A",
+          "weight": 0.0176
+        },
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0374
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.108
+        },
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.033
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0072
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.0502
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.035
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0885
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0642
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0621
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0223
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0028
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0162
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0152
+        }
+      ],
+      "302": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0244
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0294
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0801
+        },
+        {
+          "from": "A",
+          "to": "R",
+          "weight": 0.0656
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0255
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0707
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0735
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0257
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0095
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0035
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.1352
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0698
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.071
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0421
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0118
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.1521
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0175
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.0156
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1559
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.0572
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.0233
+        }
+      ],
+      "313": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0485
+        }
+      ],
+      "314": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0469
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0396
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0099
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0752
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0145
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "C",
+          "weight": 0.0028
+        },
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.077
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.1009
+        },
+        {
+          "from": "V",
+          "to": "M",
+          "weight": 0.0473
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.0934
+        },
+        {
+          "from": "V",
+          "to": "S",
+          "weight": 0.0221
+        },
+        {
+          "from": "V",
+          "to": "T",
+          "weight": 0.0092
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0081
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0166
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0467
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.038
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0215
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0267
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0252
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0024
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/AUSAB-13.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/AUSAB-13.json
@@ -1,0 +1,3402 @@
+{
+  "name": "Welsh et al. escape scores per site and amino acid for sample 'AUSAB-13' in cohort '68_years'",
+  "serum": "AUSAB-13",
+  "cohort": "68_years",
+  "default": 0,
+  "map": {
+    "HA1": {
+      "1": [
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0126
+        }
+      ],
+      "3": [
+        {
+          "from": "I",
+          "to": "A",
+          "weight": 0.0528
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0391
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0371
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0493
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0078
+        }
+      ],
+      "4": [
+        {
+          "from": "P",
+          "to": "C",
+          "weight": 0.0123
+        },
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0386
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.0024
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0613
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.2353
+        },
+        {
+          "from": "P",
+          "to": "S",
+          "weight": 0.0079
+        },
+        {
+          "from": "P",
+          "to": "Y",
+          "weight": 0.0205
+        }
+      ],
+      "5": [
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0871
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.1394
+        },
+        {
+          "from": "G",
+          "to": "R",
+          "weight": 0.0381
+        },
+        {
+          "from": "G",
+          "to": "V",
+          "weight": 0.0048
+        }
+      ],
+      "6": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0255
+        },
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.1945
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.2953
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0509
+        },
+        {
+          "from": "N",
+          "to": "L",
+          "weight": 0.0732
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0304
+        }
+      ],
+      "7": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0037
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.2224
+        },
+        {
+          "from": "D",
+          "to": "P",
+          "weight": 0.0143
+        }
+      ],
+      "8": [
+        {
+          "from": "N",
+          "to": "C",
+          "weight": 0.0048
+        },
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.1026
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.1947
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.0265
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.1002
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0106
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0189
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.279
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1074
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0446
+        }
+      ],
+      "9": [
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0375
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0159
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0044
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0005
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0071
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0185
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0208
+        }
+      ],
+      "10": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0067
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0323
+        },
+        {
+          "from": "T",
+          "to": "G",
+          "weight": 0.0091
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0056
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0286
+        }
+      ],
+      "11": [
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0277
+        }
+      ],
+      "12": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.0108
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1145
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0341
+        },
+        {
+          "from": "T",
+          "to": "W",
+          "weight": 0.4636
+        }
+      ],
+      "13": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0322
+        }
+      ],
+      "15": [
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.0463
+        }
+      ],
+      "18": [
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0412
+        }
+      ],
+      "19": [
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0367
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0932
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.1542
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0219
+        }
+      ],
+      "21": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0866
+        },
+        {
+          "from": "P",
+          "to": "F",
+          "weight": 0.0635
+        },
+        {
+          "from": "P",
+          "to": "G",
+          "weight": 0.0448
+        },
+        {
+          "from": "P",
+          "to": "L",
+          "weight": 0.0047
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.091
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.2149
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0444
+        },
+        {
+          "from": "P",
+          "to": "W",
+          "weight": 0.5079
+        }
+      ],
+      "22": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0001
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0793
+        }
+      ],
+      "24": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0027
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0053
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0282
+        }
+      ],
+      "25": [
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.1718
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.051
+        },
+        {
+          "from": "I",
+          "to": "R",
+          "weight": 0.0157
+        }
+      ],
+      "26": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0632
+        }
+      ],
+      "27": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.019
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0136
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0793
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0918
+        }
+      ],
+      "30": [
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0179
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.0852
+        },
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0402
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0204
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.272
+        }
+      ],
+      "31": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0818
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0474
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.2635
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0156
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.1301
+        },
+        {
+          "from": "N",
+          "to": "Y",
+          "weight": 0.004
+        }
+      ],
+      "32": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0051
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0403
+        },
+        {
+          "from": "D",
+          "to": "L",
+          "weight": 0.0076
+        },
+        {
+          "from": "D",
+          "to": "M",
+          "weight": 0.0228
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.0008
+        }
+      ],
+      "33": [
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.0314
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0122
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0018
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0979
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0358
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1044
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0403
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0423
+        }
+      ],
+      "34": [
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.0287
+        }
+      ],
+      "35": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0216
+        },
+        {
+          "from": "E",
+          "to": "S",
+          "weight": 0.0093
+        }
+      ],
+      "37": [
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0104
+        }
+      ],
+      "38": [
+        {
+          "from": "N",
+          "to": "E",
+          "weight": 0.007
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.2211
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0298
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0559
+        }
+      ],
+      "40": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.0195
+        },
+        {
+          "from": "T",
+          "to": "I",
+          "weight": 0.0765
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.2342
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.1632
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0086
+        }
+      ],
+      "44": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1047
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0399
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0641
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0537
+        }
+      ],
+      "45": [
+        {
+          "from": "N",
+          "to": "A",
+          "weight": 0.0363
+        },
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0075
+        },
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.1418
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.1143
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0206
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0578
+        }
+      ],
+      "46": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.0014
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0039
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0466
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1396
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.1899
+        },
+        {
+          "from": "S",
+          "to": "W",
+          "weight": 0.0593
+        }
+      ],
+      "47": [
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0958
+        }
+      ],
+      "48": [
+        {
+          "from": "I",
+          "to": "D",
+          "weight": 0.0093
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.0295
+        },
+        {
+          "from": "I",
+          "to": "H",
+          "weight": 0.0059
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.0762
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.0315
+        },
+        {
+          "from": "I",
+          "to": "N",
+          "weight": 0.11
+        },
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.3021
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.1084
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.1281
+        }
+      ],
+      "49": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.0266
+        }
+      ],
+      "50": [
+        {
+          "from": "E",
+          "to": "A",
+          "weight": 0.0395
+        },
+        {
+          "from": "E",
+          "to": "C",
+          "weight": 0.1307
+        },
+        {
+          "from": "E",
+          "to": "F",
+          "weight": 0.0554
+        },
+        {
+          "from": "E",
+          "to": "H",
+          "weight": 0.0231
+        },
+        {
+          "from": "E",
+          "to": "I",
+          "weight": 0.0028
+        },
+        {
+          "from": "E",
+          "to": "K",
+          "weight": 0.2149
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0831
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0
+        },
+        {
+          "from": "E",
+          "to": "V",
+          "weight": 0.0485
+        },
+        {
+          "from": "E",
+          "to": "Y",
+          "weight": 0.0501
+        }
+      ],
+      "53": [
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0366
+        },
+        {
+          "from": "D",
+          "to": "Q",
+          "weight": 0.2034
+        },
+        {
+          "from": "D",
+          "to": "S",
+          "weight": 0.3376
+        }
+      ],
+      "54": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2906
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0514
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0358
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1114
+        }
+      ],
+      "56": [
+        {
+          "from": "H",
+          "to": "F",
+          "weight": 0.0701
+        },
+        {
+          "from": "H",
+          "to": "I",
+          "weight": 0.0844
+        },
+        {
+          "from": "H",
+          "to": "W",
+          "weight": 0.0188
+        }
+      ],
+      "57": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.1081
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0025
+        },
+        {
+          "from": "Q",
+          "to": "L",
+          "weight": 0.0002
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0166
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.2623
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0361
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0148
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.1989
+        }
+      ],
+      "62": [
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.005
+        }
+      ],
+      "75": [
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.1007
+        }
+      ],
+      "78": [
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0546
+        }
+      ],
+      "79": [
+        {
+          "from": "F",
+          "to": "L",
+          "weight": 0.1434
+        }
+      ],
+      "80": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0661
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.1563
+        }
+      ],
+      "82": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.1991
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0303
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.004
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.1806
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3125
+        }
+      ],
+      "83": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0131
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0599
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0344
+        }
+      ],
+      "84": [
+        {
+          "from": "W",
+          "to": "F",
+          "weight": 0.0051
+        }
+      ],
+      "88": [
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.2329
+        }
+      ],
+      "91": [
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3123
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0074
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0022
+        }
+      ],
+      "92": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.1957
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0048
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.1552
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.195
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.1688
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.0657
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0206
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.2407
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.1918
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.2167
+        }
+      ],
+      "94": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.1745
+        },
+        {
+          "from": "Y",
+          "to": "K",
+          "weight": 0.1611
+        },
+        {
+          "from": "Y",
+          "to": "M",
+          "weight": 0.0594
+        },
+        {
+          "from": "Y",
+          "to": "N",
+          "weight": 0.0904
+        },
+        {
+          "from": "Y",
+          "to": "Q",
+          "weight": 0.2231
+        },
+        {
+          "from": "Y",
+          "to": "R",
+          "weight": 0.3945
+        },
+        {
+          "from": "Y",
+          "to": "S",
+          "weight": 0.0015
+        },
+        {
+          "from": "Y",
+          "to": "V",
+          "weight": 0.2494
+        },
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.0468
+        }
+      ],
+      "101": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0354
+        }
+      ],
+      "102": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0691
+        }
+      ],
+      "103": [
+        {
+          "from": "P",
+          "to": "D",
+          "weight": 0.0006
+        },
+        {
+          "from": "P",
+          "to": "I",
+          "weight": 0.152
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0281
+        },
+        {
+          "from": "P",
+          "to": "V",
+          "weight": 0.2053
+        }
+      ],
+      "104": [
+        {
+          "from": "D",
+          "to": "H",
+          "weight": 0.0255
+        },
+        {
+          "from": "D",
+          "to": "Y",
+          "weight": 0.0102
+        }
+      ],
+      "106": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.1335
+        },
+        {
+          "from": "A",
+          "to": "E",
+          "weight": 0.0125
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0103
+        }
+      ],
+      "107": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0532
+        }
+      ],
+      "112": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0257
+        }
+      ],
+      "114": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0697
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0218
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0513
+        }
+      ],
+      "115": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.012
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0544
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.141
+        }
+      ],
+      "117": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0291
+        }
+      ],
+      "121": [
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0159
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0064
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0057
+        }
+      ],
+      "122": [
+        {
+          "from": "N",
+          "to": "F",
+          "weight": 0.0197
+        }
+      ],
+      "124": [
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.1666
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0459
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.025
+        }
+      ],
+      "128": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0123
+        },
+        {
+          "from": "A",
+          "to": "F",
+          "weight": 0.0183
+        },
+        {
+          "from": "A",
+          "to": "I",
+          "weight": 0.0236
+        },
+        {
+          "from": "A",
+          "to": "P",
+          "weight": 0.0729
+        },
+        {
+          "from": "A",
+          "to": "Q",
+          "weight": 0.0264
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0252
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.0842
+        },
+        {
+          "from": "A",
+          "to": "W",
+          "weight": 0.0403
+        }
+      ],
+      "131": [
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.1991
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.0175
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.0175
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.1787
+        }
+      ],
+      "132": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.2476
+        }
+      ],
+      "133": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.1225
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0039
+        }
+      ],
+      "135": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.2927
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.4992
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.8778
+        },
+        {
+          "from": "K",
+          "to": "F",
+          "weight": 0.0345
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0715
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.9048
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.3581
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.5299
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 1.6559
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0313
+        }
+      ],
+      "137": [
+        {
+          "from": "F",
+          "to": "A",
+          "weight": 2.3575
+        },
+        {
+          "from": "F",
+          "to": "G",
+          "weight": 0.6454
+        },
+        {
+          "from": "F",
+          "to": "S",
+          "weight": 2.9104
+        }
+      ],
+      "140": [
+        {
+          "from": "I",
+          "to": "P",
+          "weight": 0.0278
+        }
+      ],
+      "142": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1363
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.2657
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.0123
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.4539
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.2588
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.1714
+        },
+        {
+          "from": "G",
+          "to": "Y",
+          "weight": 0.0285
+        }
+      ],
+      "143": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0427
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.2587
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.1871
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.3017
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0284
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0376
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.7896
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.1845
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0674
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0134
+        }
+      ],
+      "144": [
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.6628
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.7763
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0386
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.4575
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1926
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 1.1026
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0749
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1464
+        }
+      ],
+      "145": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 1.0116
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0023
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 1.2278
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 2.8559
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 1.7752
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1403
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 2.0437
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 1.109
+        }
+      ],
+      "150": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0327
+        }
+      ],
+      "155": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0052
+        }
+      ],
+      "158": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.02
+        }
+      ],
+      "159": [
+        {
+          "from": "Y",
+          "to": "W",
+          "weight": 0.1076
+        }
+      ],
+      "160": [
+        {
+          "from": "T",
+          "to": "A",
+          "weight": 0.2106
+        },
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.0119
+        },
+        {
+          "from": "T",
+          "to": "H",
+          "weight": 0.0183
+        },
+        {
+          "from": "T",
+          "to": "K",
+          "weight": 0.4875
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.1069
+        },
+        {
+          "from": "T",
+          "to": "N",
+          "weight": 0.2999
+        },
+        {
+          "from": "T",
+          "to": "Q",
+          "weight": 0.107
+        },
+        {
+          "from": "T",
+          "to": "R",
+          "weight": 0.2444
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0997
+        },
+        {
+          "from": "T",
+          "to": "V",
+          "weight": 0.0774
+        }
+      ],
+      "163": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.0777
+        }
+      ],
+      "164": [
+        {
+          "from": "L",
+          "to": "Q",
+          "weight": 0.1021
+        }
+      ],
+      "166": [
+        {
+          "from": "V",
+          "to": "A",
+          "weight": 0.0092
+        }
+      ],
+      "168": [
+        {
+          "from": "M",
+          "to": "Q",
+          "weight": 0.0868
+        }
+      ],
+      "171": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0177
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0892
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0051
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0137
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0708
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0092
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.1238
+        }
+      ],
+      "173": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0138
+        },
+        {
+          "from": "Q",
+          "to": "C",
+          "weight": 0.0224
+        },
+        {
+          "from": "Q",
+          "to": "N",
+          "weight": 0.0071
+        },
+        {
+          "from": "Q",
+          "to": "P",
+          "weight": 0.0199
+        },
+        {
+          "from": "Q",
+          "to": "S",
+          "weight": 0.0161
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.0683
+        },
+        {
+          "from": "Q",
+          "to": "Y",
+          "weight": 0.0854
+        }
+      ],
+      "182": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0132
+        }
+      ],
+      "186": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.4787
+        },
+        {
+          "from": "G",
+          "to": "C",
+          "weight": 0.1632
+        },
+        {
+          "from": "G",
+          "to": "D",
+          "weight": 0.5324
+        },
+        {
+          "from": "G",
+          "to": "E",
+          "weight": 0.2781
+        },
+        {
+          "from": "G",
+          "to": "F",
+          "weight": 0.0251
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1755
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0421
+        },
+        {
+          "from": "G",
+          "to": "L",
+          "weight": 0.0799
+        },
+        {
+          "from": "G",
+          "to": "M",
+          "weight": 0.0674
+        },
+        {
+          "from": "G",
+          "to": "N",
+          "weight": 0.3024
+        },
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.3449
+        },
+        {
+          "from": "G",
+          "to": "S",
+          "weight": 0.6516
+        },
+        {
+          "from": "G",
+          "to": "T",
+          "weight": 0.0124
+        }
+      ],
+      "187": [
+        {
+          "from": "T",
+          "to": "D",
+          "weight": 0.3003
+        },
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.4175
+        }
+      ],
+      "188": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0804
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0133
+        }
+      ],
+      "189": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.6104
+        },
+        {
+          "from": "K",
+          "to": "D",
+          "weight": 0.6148
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.7457
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0535
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.1468
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.3287
+        }
+      ],
+      "192": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.1989
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.1053
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.3357
+        }
+      ],
+      "193": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.055
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 1.3376
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2146
+        }
+      ],
+      "196": [
+        {
+          "from": "A",
+          "to": "G",
+          "weight": 0.0114
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.024
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0099
+        }
+      ],
+      "197": [
+        {
+          "from": "Q",
+          "to": "A",
+          "weight": 0.0012
+        },
+        {
+          "from": "Q",
+          "to": "H",
+          "weight": 0.027
+        },
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0373
+        },
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.1479
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.1166
+        },
+        {
+          "from": "Q",
+          "to": "T",
+          "weight": 0.0178
+        }
+      ],
+      "198": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.154
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2103
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.1071
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1055
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.1354
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0051
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.0357
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0161
+        }
+      ],
+      "199": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.2111
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.084
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0446
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.0243
+        },
+        {
+          "from": "S",
+          "to": "K",
+          "weight": 0.0313
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.072
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0274
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.3567
+        },
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0756
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0081
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0701
+        }
+      ],
+      "200": [
+        {
+          "from": "G",
+          "to": "P",
+          "weight": 0.001
+        }
+      ],
+      "201": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.019
+        },
+        {
+          "from": "R",
+          "to": "E",
+          "weight": 0.2189
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0311
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.0355
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0416
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.07
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.031
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.053
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0493
+        },
+        {
+          "from": "R",
+          "to": "T",
+          "weight": 0.0661
+        }
+      ],
+      "203": [
+        {
+          "from": "T",
+          "to": "E",
+          "weight": 0.1143
+        },
+        {
+          "from": "T",
+          "to": "M",
+          "weight": 0.0202
+        }
+      ],
+      "205": [
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.016
+        }
+      ],
+      "207": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0112
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.0181
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0532
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0856
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0044
+        }
+      ],
+      "208": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.0069
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0575
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.1086
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0097
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0559
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.1448
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1037
+        }
+      ],
+      "209": [
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.0233
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1258
+        }
+      ],
+      "210": [
+        {
+          "from": "Q",
+          "to": "I",
+          "weight": 0.0032
+        }
+      ],
+      "212": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.114
+        },
+        {
+          "from": "A",
+          "to": "V",
+          "weight": 0.2482
+        }
+      ],
+      "214": [
+        {
+          "from": "I",
+          "to": "E",
+          "weight": 0.052
+        },
+        {
+          "from": "I",
+          "to": "F",
+          "weight": 0.041
+        },
+        {
+          "from": "I",
+          "to": "K",
+          "weight": 0.199
+        },
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.3314
+        },
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.1139
+        },
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0076
+        },
+        {
+          "from": "I",
+          "to": "Y",
+          "weight": 0.0537
+        }
+      ],
+      "216": [
+        {
+          "from": "N",
+          "to": "D",
+          "weight": 0.0829
+        },
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0256
+        },
+        {
+          "from": "N",
+          "to": "I",
+          "weight": 0.1496
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.2273
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0321
+        },
+        {
+          "from": "N",
+          "to": "Q",
+          "weight": 0.0444
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.3386
+        }
+      ],
+      "217": [
+        {
+          "from": "I",
+          "to": "L",
+          "weight": 0.2314
+        }
+      ],
+      "218": [
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0381
+        }
+      ],
+      "219": [
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.2503
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.0278
+        },
+        {
+          "from": "S",
+          "to": "I",
+          "weight": 0.1159
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0105
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.1303
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0462
+        },
+        {
+          "from": "S",
+          "to": "V",
+          "weight": 0.0297
+        }
+      ],
+      "220": [
+        {
+          "from": "R",
+          "to": "A",
+          "weight": 0.3077
+        },
+        {
+          "from": "R",
+          "to": "C",
+          "weight": 0.0201
+        },
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0657
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.2109
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.1893
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0654
+        }
+      ],
+      "221": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.0046
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0368
+        }
+      ],
+      "222": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0999
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.111
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.003
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0304
+        },
+        {
+          "from": "R",
+          "to": "W",
+          "weight": 0.0448
+        },
+        {
+          "from": "R",
+          "to": "Y",
+          "weight": 0.0115
+        }
+      ],
+      "225": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.1315
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.1098
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.9465
+        }
+      ],
+      "226": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.3316
+        },
+        {
+          "from": "I",
+          "to": "Q",
+          "weight": 0.4639
+        },
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0293
+        }
+      ],
+      "227": [
+        {
+          "from": "P",
+          "to": "H",
+          "weight": 0.0575
+        }
+      ],
+      "228": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.8422
+        }
+      ],
+      "229": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0211
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.4543
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0715
+        }
+      ],
+      "230": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0317
+        }
+      ],
+      "231": [
+        {
+          "from": "S",
+          "to": "Q",
+          "weight": 0.0969
+        },
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.028
+        }
+      ],
+      "238": [
+        {
+          "from": "K",
+          "to": "P",
+          "weight": 0.0211
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0016
+        }
+      ],
+      "242": [
+        {
+          "from": "I",
+          "to": "M",
+          "weight": 0.2039
+        }
+      ],
+      "244": [
+        {
+          "from": "L",
+          "to": "A",
+          "weight": 0.0385
+        },
+        {
+          "from": "L",
+          "to": "E",
+          "weight": 0.0633
+        },
+        {
+          "from": "L",
+          "to": "F",
+          "weight": 0.211
+        },
+        {
+          "from": "L",
+          "to": "I",
+          "weight": 0.5426
+        },
+        {
+          "from": "L",
+          "to": "M",
+          "weight": 0.4738
+        },
+        {
+          "from": "L",
+          "to": "Y",
+          "weight": 0.305
+        }
+      ],
+      "247": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.0851
+        }
+      ],
+      "258": [
+        {
+          "from": "F",
+          "to": "Y",
+          "weight": 0.0113
+        }
+      ],
+      "259": [
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.001
+        }
+      ],
+      "261": [
+        {
+          "from": "R",
+          "to": "F",
+          "weight": 0.0283
+        },
+        {
+          "from": "R",
+          "to": "G",
+          "weight": 0.2558
+        },
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.1348
+        },
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0994
+        },
+        {
+          "from": "R",
+          "to": "L",
+          "weight": 0.0422
+        },
+        {
+          "from": "R",
+          "to": "N",
+          "weight": 0.0116
+        },
+        {
+          "from": "R",
+          "to": "P",
+          "weight": 0.081
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.059
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0406
+        },
+        {
+          "from": "R",
+          "to": "V",
+          "weight": 0.0186
+        }
+      ],
+      "262": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0458
+        },
+        {
+          "from": "S",
+          "to": "D",
+          "weight": 0.2377
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0957
+        },
+        {
+          "from": "S",
+          "to": "G",
+          "weight": 0.1037
+        },
+        {
+          "from": "S",
+          "to": "P",
+          "weight": 0.0141
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.1137
+        }
+      ],
+      "264": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0269
+        },
+        {
+          "from": "K",
+          "to": "G",
+          "weight": 0.1755
+        },
+        {
+          "from": "K",
+          "to": "H",
+          "weight": 0.0206
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.071
+        },
+        {
+          "from": "K",
+          "to": "R",
+          "weight": 0.0028
+        },
+        {
+          "from": "K",
+          "to": "T",
+          "weight": 0.0052
+        }
+      ],
+      "266": [
+        {
+          "from": "S",
+          "to": "T",
+          "weight": 0.1495
+        }
+      ],
+      "267": [
+        {
+          "from": "I",
+          "to": "V",
+          "weight": 0.0527
+        }
+      ],
+      "268": [
+        {
+          "from": "M",
+          "to": "I",
+          "weight": 0.0341
+        },
+        {
+          "from": "M",
+          "to": "L",
+          "weight": 0.0353
+        }
+      ],
+      "269": [
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.1568
+        },
+        {
+          "from": "R",
+          "to": "Q",
+          "weight": 0.0419
+        }
+      ],
+      "272": [
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.3241
+        },
+        {
+          "from": "A",
+          "to": "M",
+          "weight": 0.0119
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.0102
+        }
+      ],
+      "273": [
+        {
+          "from": "P",
+          "to": "K",
+          "weight": 0.1079
+        }
+      ],
+      "275": [
+        {
+          "from": "G",
+          "to": "A",
+          "weight": 0.1591
+        },
+        {
+          "from": "G",
+          "to": "H",
+          "weight": 0.1373
+        },
+        {
+          "from": "G",
+          "to": "I",
+          "weight": 0.0339
+        },
+        {
+          "from": "G",
+          "to": "K",
+          "weight": 0.0991
+        },
+        {
+          "from": "G",
+          "to": "Q",
+          "weight": 0.0315
+        }
+      ],
+      "276": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0717
+        },
+        {
+          "from": "K",
+          "to": "S",
+          "weight": 0.0608
+        }
+      ],
+      "278": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0701
+        },
+        {
+          "from": "K",
+          "to": "E",
+          "weight": 0.045
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.2065
+        },
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0059
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0087
+        },
+        {
+          "from": "K",
+          "to": "N",
+          "weight": 0.0933
+        },
+        {
+          "from": "K",
+          "to": "Q",
+          "weight": 0.0782
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0023
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.0144
+        }
+      ],
+      "279": [
+        {
+          "from": "S",
+          "to": "A",
+          "weight": 0.0553
+        },
+        {
+          "from": "S",
+          "to": "C",
+          "weight": 0.0549
+        },
+        {
+          "from": "S",
+          "to": "E",
+          "weight": 0.0346
+        },
+        {
+          "from": "S",
+          "to": "F",
+          "weight": 0.0724
+        },
+        {
+          "from": "S",
+          "to": "H",
+          "weight": 0.1766
+        },
+        {
+          "from": "S",
+          "to": "L",
+          "weight": 0.0754
+        },
+        {
+          "from": "S",
+          "to": "M",
+          "weight": 0.0364
+        },
+        {
+          "from": "S",
+          "to": "N",
+          "weight": 0.0062
+        },
+        {
+          "from": "S",
+          "to": "R",
+          "weight": 0.118
+        },
+        {
+          "from": "S",
+          "to": "Y",
+          "weight": 0.0735
+        }
+      ],
+      "280": [
+        {
+          "from": "E",
+          "to": "L",
+          "weight": 0.0098
+        },
+        {
+          "from": "E",
+          "to": "M",
+          "weight": 0.0022
+        },
+        {
+          "from": "E",
+          "to": "P",
+          "weight": 0.0301
+        },
+        {
+          "from": "E",
+          "to": "Q",
+          "weight": 0.089
+        },
+        {
+          "from": "E",
+          "to": "W",
+          "weight": 0.0055
+        }
+      ],
+      "283": [
+        {
+          "from": "T",
+          "to": "S",
+          "weight": 0.0751
+        }
+      ],
+      "289": [
+        {
+          "from": "P",
+          "to": "E",
+          "weight": 0.0916
+        },
+        {
+          "from": "P",
+          "to": "T",
+          "weight": 0.0663
+        }
+      ],
+      "291": [
+        {
+          "from": "D",
+          "to": "E",
+          "weight": 0.0095
+        },
+        {
+          "from": "D",
+          "to": "G",
+          "weight": 0.0364
+        },
+        {
+          "from": "D",
+          "to": "I",
+          "weight": 0.0111
+        },
+        {
+          "from": "D",
+          "to": "N",
+          "weight": 0.1088
+        },
+        {
+          "from": "D",
+          "to": "T",
+          "weight": 0.1494
+        },
+        {
+          "from": "D",
+          "to": "V",
+          "weight": 0.0015
+        }
+      ],
+      "296": [
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.0289
+        }
+      ],
+      "298": [
+        {
+          "from": "N",
+          "to": "H",
+          "weight": 0.0194
+        }
+      ],
+      "299": [
+        {
+          "from": "R",
+          "to": "H",
+          "weight": 0.0132
+        }
+      ],
+      "300": [
+        {
+          "from": "I",
+          "to": "W",
+          "weight": 0.0053
+        }
+      ],
+      "302": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0563
+        }
+      ],
+      "304": [
+        {
+          "from": "A",
+          "to": "D",
+          "weight": 0.1629
+        },
+        {
+          "from": "A",
+          "to": "H",
+          "weight": 0.1804
+        },
+        {
+          "from": "A",
+          "to": "K",
+          "weight": 0.0071
+        },
+        {
+          "from": "A",
+          "to": "L",
+          "weight": 0.0044
+        },
+        {
+          "from": "A",
+          "to": "N",
+          "weight": 0.0454
+        },
+        {
+          "from": "A",
+          "to": "S",
+          "weight": 0.0993
+        },
+        {
+          "from": "A",
+          "to": "T",
+          "weight": 0.022
+        }
+      ],
+      "307": [
+        {
+          "from": "R",
+          "to": "I",
+          "weight": 0.0029
+        },
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0875
+        },
+        {
+          "from": "R",
+          "to": "M",
+          "weight": 0.0138
+        },
+        {
+          "from": "R",
+          "to": "S",
+          "weight": 0.0365
+        }
+      ],
+      "308": [
+        {
+          "from": "Y",
+          "to": "F",
+          "weight": 0.0073
+        }
+      ],
+      "309": [
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0373
+        }
+      ],
+      "310": [
+        {
+          "from": "K",
+          "to": "L",
+          "weight": 0.0956
+        },
+        {
+          "from": "K",
+          "to": "V",
+          "weight": 0.0415
+        }
+      ],
+      "311": [
+        {
+          "from": "Q",
+          "to": "K",
+          "weight": 0.1021
+        },
+        {
+          "from": "Q",
+          "to": "M",
+          "weight": 0.0158
+        },
+        {
+          "from": "Q",
+          "to": "R",
+          "weight": 0.0333
+        },
+        {
+          "from": "Q",
+          "to": "V",
+          "weight": 0.1159
+        },
+        {
+          "from": "Q",
+          "to": "W",
+          "weight": 0.0228
+        }
+      ],
+      "312": [
+        {
+          "from": "N",
+          "to": "G",
+          "weight": 0.0224
+        },
+        {
+          "from": "N",
+          "to": "K",
+          "weight": 0.2301
+        },
+        {
+          "from": "N",
+          "to": "M",
+          "weight": 0.0021
+        },
+        {
+          "from": "N",
+          "to": "P",
+          "weight": 0.0359
+        },
+        {
+          "from": "N",
+          "to": "R",
+          "weight": 0.0959
+        },
+        {
+          "from": "N",
+          "to": "S",
+          "weight": 0.1471
+        },
+        {
+          "from": "N",
+          "to": "T",
+          "weight": 0.0118
+        }
+      ],
+      "315": [
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.2099
+        }
+      ],
+      "318": [
+        {
+          "from": "T",
+          "to": "L",
+          "weight": 0.0439
+        }
+      ],
+      "323": [
+        {
+          "from": "V",
+          "to": "F",
+          "weight": 0.0134
+        },
+        {
+          "from": "V",
+          "to": "H",
+          "weight": 0.0279
+        },
+        {
+          "from": "V",
+          "to": "I",
+          "weight": 0.0699
+        },
+        {
+          "from": "V",
+          "to": "K",
+          "weight": 0.5055
+        },
+        {
+          "from": "V",
+          "to": "L",
+          "weight": 0.1991
+        },
+        {
+          "from": "V",
+          "to": "N",
+          "weight": 0.1048
+        },
+        {
+          "from": "V",
+          "to": "R",
+          "weight": 0.5009
+        },
+        {
+          "from": "V",
+          "to": "W",
+          "weight": 0.0896
+        },
+        {
+          "from": "V",
+          "to": "Y",
+          "weight": 0.0193
+        }
+      ],
+      "324": [
+        {
+          "from": "P",
+          "to": "A",
+          "weight": 0.2096
+        },
+        {
+          "from": "P",
+          "to": "M",
+          "weight": 0.0092
+        },
+        {
+          "from": "P",
+          "to": "N",
+          "weight": 0.0075
+        },
+        {
+          "from": "P",
+          "to": "Q",
+          "weight": 0.0404
+        }
+      ],
+      "326": [
+        {
+          "from": "K",
+          "to": "A",
+          "weight": 0.0638
+        },
+        {
+          "from": "K",
+          "to": "I",
+          "weight": 0.0542
+        },
+        {
+          "from": "K",
+          "to": "M",
+          "weight": 0.0126
+        },
+        {
+          "from": "K",
+          "to": "W",
+          "weight": 0.0811
+        },
+        {
+          "from": "K",
+          "to": "Y",
+          "weight": 0.2728
+        }
+      ],
+      "327": [
+        {
+          "from": "Q",
+          "to": "E",
+          "weight": 0.0545
+        }
+      ],
+      "328": [
+        {
+          "from": "T",
+          "to": "F",
+          "weight": 0.3391
+        },
+        {
+          "from": "T",
+          "to": "Y",
+          "weight": 0.0605
+        }
+      ],
+      "329": [
+        {
+          "from": "R",
+          "to": "K",
+          "weight": 0.0545
+        }
+      ]
+    }
+  }
+}

--- a/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/AUSAB-13.json
+++ b/config/distance_maps/h3n2/ha/welsh_escape_by_site_and_amino_acid_by_serum/AUSAB-13.json
@@ -2,6 +2,7 @@
   "name": "Welsh et al. escape scores per site and amino acid for sample 'AUSAB-13' in cohort '68_years'",
   "serum": "AUSAB-13",
   "cohort": "68_years",
+  "cohort_serum": "68_years/AUSAB-13",
   "default": 0,
   "map": {
     "HA1": {

--- a/notebooks/2023-12-15-identify-epitope-sites-and-scores-from-Welsh-et-al-data.ipynb
+++ b/notebooks/2023-12-15-identify-epitope-sites-and-scores-from-Welsh-et-al-data.ipynb
@@ -600,6 +600,7 @@
     "        \"name\": f\"Welsh et al. escape scores per site and amino acid for sample '{serum}' in cohort '{cohort}'\",\n",
     "        \"serum\": serum,\n",
     "        \"cohort\": cohort,\n",
+    "        \"cohort_serum\": f\"{cohort}/{serum}\",\n",
     "        \"default\": 0,\n",
     "        \"map\": {\n",
     "            \"HA1\": {}\n",

--- a/notebooks/2023-12-15-identify-epitope-sites-and-scores-from-Welsh-et-al-data.ipynb
+++ b/notebooks/2023-12-15-identify-epitope-sites-and-scores-from-Welsh-et-al-data.ipynb
@@ -28,7 +28,8 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "import pandas as pd"
+    "import pandas as pd\n",
+    "from pathlib import Path"
    ]
   },
   {
@@ -553,9 +554,91 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "935dd658-3b21-4399-a104-b564d43b116a",
+   "metadata": {},
+   "source": [
+    "## Create distance map per serum sample"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10bb367b-ad31-43ca-afff-7226f59349a6",
+   "id": "38ad1e18-0459-45db-806f-534213290614",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_dir = Path(\"welsh_escape_by_site_and_amino_acid_by_serum\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b4aff470-c3e1-4ebb-8768-ec42f4bbe006",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_dir.mkdir(exist_ok=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "486de66c-1d23-44a9-83e2-0e65b8917ca7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for (serum, cohort), serum_scores in nonnegative_ha1_escape_scores.groupby([\"serum\", \"cohort\"]):\n",
+    "    serum_escape_records = serum_scores[[\n",
+    "        \"site\",\n",
+    "        \"wildtype\",\n",
+    "        \"mutant\",\n",
+    "        \"escape_mean\",\n",
+    "    ]].to_dict(orient=\"records\")\n",
+    "    \n",
+    "    distance_map = {\n",
+    "        \"name\": f\"Welsh et al. escape scores per site and amino acid for sample '{serum}' in cohort '{cohort}'\",\n",
+    "        \"serum\": serum,\n",
+    "        \"cohort\": cohort,\n",
+    "        \"default\": 0,\n",
+    "        \"map\": {\n",
+    "            \"HA1\": {}\n",
+    "        }\n",
+    "    }\n",
+    "    \n",
+    "    for record in serum_escape_records:\n",
+    "        site = str(record[\"site\"])\n",
+    "        if str(site) not in distance_map[\"map\"][\"HA1\"]:\n",
+    "            distance_map[\"map\"][\"HA1\"][str(site)] = []\n",
+    "\n",
+    "        distance_map[\"map\"][\"HA1\"][str(site)].append({\n",
+    "            \"from\": record[\"wildtype\"],\n",
+    "            \"to\": record[\"mutant\"],\n",
+    "            \"weight\": round(record[\"escape_mean\"], 6),\n",
+    "        })\n",
+    "        \n",
+    "    with open(output_dir / f\"{serum}.json\", \"w\") as oh:\n",
+    "        json.dump(\n",
+    "            distance_map,\n",
+    "            oh,\n",
+    "            indent=2,\n",
+    "        )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31a4b0cb-0a24-408d-a020-9e3941dfcd42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls -l welsh_escape_by_site_and_amino_acid_by_serum/"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9eb7029c-ea8c-4816-b9d4-f35a5b5560b8",
    "metadata": {},
    "outputs": [],
    "source": []
@@ -577,7 +660,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.12.0"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,

--- a/scripts/convert_welsh_epitope_distances_to_table.py
+++ b/scripts/convert_welsh_epitope_distances_to_table.py
@@ -1,0 +1,44 @@
+import argparse
+from augur.utils import read_node_data, read_tree
+import csv
+import json
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--tree", required=True, help="Newick tree used to identify leaf nodes in distances JSON")
+    parser.add_argument("--distances", required=True, help="distances in node data JSON format")
+    parser.add_argument("--distance-map", help="distance map with metadata stored in specific top-level attributes")
+    parser.add_argument("--distance-map-attributes", nargs="*", help="optional list of top-level attributes to extract as metadata from the distance map")
+    parser.add_argument("--output", required=True, help="distances in TSV format")
+
+    args = parser.parse_args()
+
+    # Load tree.
+    tree = read_tree(args.tree)
+
+    # Load distances.
+    distances_per_node = read_node_data(args.distances)["nodes"]
+
+    # Load distance map, if attributes requested.
+    attributes = {}
+    if args.distance_map and args.distance_map_attributes:
+        with open(args.distance_map, encoding="utf-8") as fh:
+            distance_map = json.load(fh)
+
+        attributes = [
+            distance_map[attribute]
+            for attribute in args.distance_map_attributes
+        ]
+
+    # Write out distances in TSV format.
+    with open(args.output, "w", encoding="utf-8") as oh:
+        writer = csv.writer(oh, delimiter="\t", lineterminator="\n")
+        writer.writerow(["strain", "welsh_escape_for_serum"] + args.distance_map_attributes)
+
+        for node in tree.find_clades(terminal=True):
+            record = [
+                node,
+                distances_per_node[node]["welsh_escape_for_serum"],
+            ] + attributes
+            writer.writerow(record)

--- a/scripts/convert_welsh_epitope_distances_to_table.py
+++ b/scripts/convert_welsh_epitope_distances_to_table.py
@@ -38,7 +38,7 @@ if __name__ == '__main__':
 
         for node in tree.find_clades(terminal=True):
             record = [
-                node,
-                distances_per_node[node]["welsh_escape_for_serum"],
+                node.name,
+                distances_per_node[node.name]["welsh_escape_for_serum"],
             ] + attributes
             writer.writerow(record)

--- a/workflow/snakemake_rules/titer_models.smk
+++ b/workflow/snakemake_rules/titer_models.smk
@@ -226,6 +226,9 @@ def get_titer_collections(wildcards):
     for collection in config["builds"][wildcards.build_name]["titer_collections"]:
         files.append(f"builds/{wildcards.build_name}/{wildcards.segment}/measurements/{collection['name']}.json")
 
+    if wildcards.build_name == "h3n2_2y" and wildcards.segment == "ha":
+        files.append(f"builds/{wildcards.build_name}/{wildcards.segment}/welsh_measurements.json",)
+
     return files
 
 rule concat_measurements:


### PR DESCRIPTION
## Description of proposed changes

Add measurements panel to H3N2 HA build for Welsh et al. escape scores grouped by serum or cohort. Enables interactive visualization and filtering of data.

As we've found with titer data, this view of the raw data allows us to discover patterns that we would miss from summary statistics alone. The following image shows an example of a multimodal distribution for one sample that appears as high variance in the summary view.

![image](https://github.com/nextstrain/seasonal-flu/assets/85372/879273db-5d2a-4355-8744-cace6c990884)

## Checklist

- [x] Checks pass
- [x] Tested with real build