### PR TITLE
Update Suffolk lat/longs

### DIFF
--- a/config/lat_longs.tsv
+++ b/config/lat_longs.tsv
@@ -10030,7 +10030,7 @@ location	Sucre EC	-0.7326786000000001	-80.41990564699557
 location	Sueca	39.2025604	-0.3111645
 location	Südoststeiermark	46.85967165	15.850364747446001
 location	Suesca	5.103373	-73.799748
-location	Suffolk	42.3544455	-70.9788771
+location	Suffolk	52.2410014	1.046683
 location	Suffolk County	40.9849	-72.6151
 location	Suffolk County MA	42.3544455	-70.9788771
 location	Suffolk County NY	40.8832318	-72.8578027
@@ -14597,4 +14597,3 @@ country	Oceania	-25.0562891	152.008576
 country	South America	-13.083583	-58.470721
 
 region	Asia	30.451098	86.654576
-


### PR DESCRIPTION
Fixes https://github.com/nextstrain/seasonal-flu/issues/155

Interestingly, we don't have any entries for "Suffolk" in the fauna/source-data/geo_synonyms.tsv¹ and I couldn't find any metadata in our private S3 bucket that includes "Suffolk" as a location.

¹ https://github.com/nextstrain/fauna/blob/75e309e9afe2cc97fb56d7a24e22a07b698805bf/source-data/geo_synonyms.tsv

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
