### PR TITLE
Add GitHub Action for Nextclade annotations

### DIFF
--- a/.github/workflows/run-nextclade.yaml
+++ b/.github/workflows/run-nextclade.yaml
@@ -1,7 +1,6 @@
 name: Run Nextclade on all sequences
 
 on:
-  pull_request:
   workflow_dispatch:
     inputs:
       dockerImage:

--- a/.github/workflows/run-nextclade.yaml
+++ b/.github/workflows/run-nextclade.yaml
@@ -1,0 +1,32 @@
+name: Run Nextclade on all sequences
+
+on:
+  workflow_dispatch:
+    inputs:
+      dockerImage:
+        description: "Specific container image to use for build (will override the default of `nextstrain build`)"
+        required: false
+        type: string
+
+jobs:
+  run-build:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: aws-batch
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
+      run: |
+        nextstrain build \
+          --detach \
+          --cpus 36 \
+          --memory 72gib \
+          --env AWS_ACCESS_KEY_ID \
+          --env AWS_SECRET_ACCESS_KEY \
+          . \
+          upload_all_nextclade_files \
+          -p \
+          --configfile profiles/nextclade.yaml \
+          --set-threads run_nextclade=16

--- a/.github/workflows/run-nextclade.yaml
+++ b/.github/workflows/run-nextclade.yaml
@@ -29,4 +29,4 @@ jobs:
           upload_all_nextclade_files \
           -p \
           --configfile profiles/nextclade.yaml \
-          --set-threads run_nextclade=16
+          --set-threads run_nextclade=12

--- a/.github/workflows/run-nextclade.yaml
+++ b/.github/workflows/run-nextclade.yaml
@@ -1,6 +1,7 @@
 name: Run Nextclade on all sequences
 
 on:
+  pull_request:
   workflow_dispatch:
     inputs:
       dockerImage:

--- a/Snakefile
+++ b/Snakefile
@@ -4,6 +4,7 @@ from treetime.utils import numeric_date
 
 
 wildcard_constraints:
+    lineage = r'h1n1pdm|h3n2|vic|yam',
     segment = r'pb2|pb1|pa|ha|np|na|mp|ns',
     center = r'who|cdc|crick|niid|crick|vidrl',
     passage = r'cell|egg',

--- a/profiles/nextclade.yaml
+++ b/profiles/nextclade.yaml
@@ -6,6 +6,7 @@ s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu"
 
 segments:
   - ha
+  - na
 
 builds:
   h1n1pdm:

--- a/profiles/nextclade.yaml
+++ b/profiles/nextclade.yaml
@@ -10,3 +10,7 @@ segments:
 builds:
   h1n1pdm:
     lineage: h1n1pdm
+  h3n2:
+    lineage: h3n2
+  vic:
+    lineage: vic

--- a/profiles/nextclade.yaml
+++ b/profiles/nextclade.yaml
@@ -1,0 +1,20 @@
+custom_rules:
+  - workflow/snakemake_rules/download_from_s3.smk
+  - profiles/nextclade/run-nextclade.smk
+
+s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu"
+
+lat-longs: "config/lat_longs.tsv"
+
+segments:
+  - ha
+
+submission_date_field: date_submitted
+recency:
+  date_bins: [7, 30, 90]
+  date_bin_labels: ["last week", "last month", "last quarter"]
+  upper_bin_label: older
+
+builds:
+  h1n1pdm:
+    lineage: h1n1pdm

--- a/profiles/nextclade.yaml
+++ b/profiles/nextclade.yaml
@@ -4,16 +4,8 @@ custom_rules:
 
 s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu"
 
-lat-longs: "config/lat_longs.tsv"
-
 segments:
   - ha
-
-submission_date_field: date_submitted
-recency:
-  date_bins: [7, 30, 90]
-  date_bin_labels: ["last week", "last month", "last quarter"]
-  upper_bin_label: older
 
 builds:
   h1n1pdm:

--- a/profiles/nextclade/run-nextclade.smk
+++ b/profiles/nextclade/run-nextclade.smk
@@ -1,0 +1,86 @@
+nextclade_dataset_by_lineage_and_segment = {
+    "h1n1pdm": {
+        "ha": "nextstrain/flu/h1n1pdm/ha/california-7-2009",
+    },
+    "h3n2": {
+        "ha": "nextstrain/flu/h3n2/ha/wisconsin-67-2005",
+    },
+    "vic": {
+        "ha": "nextstrain/flu/vic/ha/brisbane-60-2008",
+    },
+}
+
+rule upload_all_nextclade_files:
+    input:
+        files=lambda wildcards: [
+            "data/upload/s3/{filetype}_{lineage}_{segment}.done".format(filetype=filetype, lineage=lineage, segment=segment)
+            for filetype in ("alignment", "nextclade")
+            for lineage in nextclade_dataset_by_lineage_and_segment.keys()
+            for segment in nextclade_dataset_by_lineage_and_segment[lineage].keys()
+        ]
+
+rule get_nextclade_dataset_for_lineage_and_segment:
+    output:
+        nextclade_dir=directory("nextclade_dataset/{lineage}_{segment}/"),
+    params:
+        dataset_name=lambda wildcards: nextclade_dataset_by_lineage_and_segment.get(wildcards.lineage, {}).get(wildcards.segment),
+    shell:
+        """
+        nextclade3 dataset get \
+            -n {params.dataset_name:q} \
+            --output-dir {output.nextclade_dir}
+        """
+
+rule run_nextclade:
+    input:
+        nextclade_dir="nextclade_dataset/{lineage}_{segment}/",
+        sequences="data/{lineage}/{segment}.fasta",
+    output:
+        alignment="data/upload/s3/{lineage}/{segment}/aligned.fasta",
+        annotations="data/upload/s3/{lineage}/{segment}/nextclade.tsv",
+    log:
+        "logs/run_nextclade_{lineage}_{segment}.txt"
+    threads: 8
+    shell:
+        """
+        nextclade3 run \
+            -j {threads} \
+            -D {input.nextclade_dir} \
+            --output-fasta {output.alignment} \
+            --output-tsv {output.annotations} \
+            {input.sequences}
+        """
+
+rule upload_alignment:
+    input:
+        alignment="data/upload/s3/{lineage}/{segment}/aligned.fasta",
+    output:
+        flag="data/upload/s3/alignment_{lineage}_{segment}.done",
+    params:
+        s3_dst=config["s3_dst"],
+    log:
+        "logs/upload_alignment_{lineage}_{segment}.txt"
+    shell:
+        """
+        ./scripts/upload-to-s3 \
+            --quiet \
+            {input.alignment:q} \
+            {params.s3_dst:q}/{wildcards.lineage}/{wildcards.segment}/aligned.fasta.xz 2>&1 | tee {output.flag}
+        """
+
+rule upload_nextclade_annotations:
+    input:
+        annotations="data/upload/s3/{lineage}/{segment}/nextclade.tsv",
+    output:
+        flag="data/upload/s3/nextclade_{lineage}_{segment}.done",
+    params:
+        s3_dst=config["s3_dst"],
+    log:
+        "logs/upload_nextclade_annotations_{lineage}_{segment}.txt"
+    shell:
+        """
+        ./scripts/upload-to-s3 \
+            --quiet \
+            {input.annotations:q} \
+            {params.s3_dst:q}/{wildcards.lineage}/{wildcards.segment}/nextclade.tsv.xz 2>&1 | tee {output.flag}
+        """

--- a/profiles/nextclade/run-nextclade.smk
+++ b/profiles/nextclade/run-nextclade.smk
@@ -1,33 +1,19 @@
-nextclade_dataset_by_lineage_and_segment = {
-    "h1n1pdm": {
-        "ha": "nextstrain/flu/h1n1pdm/ha/california-7-2009",
-    },
-    "h3n2": {
-        "ha": "nextstrain/flu/h3n2/ha/wisconsin-67-2005",
-    },
-    "vic": {
-        "ha": "nextstrain/flu/vic/ha/brisbane-60-2008",
-    },
-}
-
 rule upload_all_nextclade_files:
     input:
         files=lambda wildcards: [
-            "data/upload/s3/{filetype}_{lineage}_{segment}.done".format(filetype=filetype, lineage=lineage, segment=segment)
+            "data/upload/s3/{filetype}_{lineage}_{segment}.done".format(filetype=filetype, lineage=build["lineage"], segment=segment)
             for filetype in ("alignment", "nextclade")
-            for lineage in nextclade_dataset_by_lineage_and_segment.keys()
-            for segment in nextclade_dataset_by_lineage_and_segment[lineage].keys()
+            for build in config["builds"].values()
+            for segment in config["segments"]
         ]
 
 rule get_nextclade_dataset_for_lineage_and_segment:
     output:
         nextclade_dir=directory("nextclade_dataset/{lineage}_{segment}/"),
-    params:
-        dataset_name=lambda wildcards: nextclade_dataset_by_lineage_and_segment.get(wildcards.lineage, {}).get(wildcards.segment),
     shell:
         """
         nextclade3 dataset get \
-            -n {params.dataset_name:q} \
+            -n flu_{wildcards.lineage}_{wildcards.segment} \
             --output-dir {output.nextclade_dir}
         """
 

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -488,10 +488,10 @@ rule annotate_recency_of_submissions:
     output:
         node_data = "builds/{build_name}/recency.json",
     params:
-        submission_date_field=config["submission_date_field"],
-        date_bins=config["recency"]["date_bins"],
-        date_bin_labels=config["recency"]["date_bin_labels"],
-        upper_bin_label=config["recency"]["upper_bin_label"],
+        submission_date_field=config.get("submission_date_field"),
+        date_bins=config.get("recency", {}).get("date_bins"),
+        date_bin_labels=config.get("recency", {}).get("date_bin_labels"),
+        upper_bin_label=config.get("recency", {}).get("upper_bin_label"),
     conda: "../envs/nextstrain.yaml"
     benchmark:
         "benchmarks/recency_{build_name}.txt"

--- a/workflow/snakemake_rules/download_from_s3.smk
+++ b/workflow/snakemake_rules/download_from_s3.smk
@@ -1,3 +1,6 @@
+ruleorder: download_parsed_sequences > parse
+ruleorder: download_parsed_metadata > annotate_metadata_with_reference_strains
+
 rule download_sequences:
     output:
         sequences="data/{lineage}/raw_{segment}.fasta"
@@ -18,4 +21,26 @@ rule download_titers:
     shell:
         """
         aws s3 cp {params.s3_path} - | gzip -c -d > {output.titers}
+        """
+
+rule download_parsed_sequences:
+    output:
+        sequences="data/{lineage}/{segment}.fasta"
+    params:
+        s3_path="s3://nextstrain-data-private/files/workflows/seasonal-flu/{lineage}/{segment}/sequences.fasta.xz"
+    conda: "../../workflow/envs/nextstrain.yaml"
+    shell:
+        """
+        aws s3 cp {params.s3_path} - | xz -c -d > {output.sequences}
+        """
+
+rule download_parsed_metadata:
+    output:
+        metadata="data/{lineage}/metadata.tsv",
+    params:
+        s3_path="s3://nextstrain-data-private/files/workflows/seasonal-flu/{lineage}/metadata.tsv.xz"
+    conda: "../../workflow/envs/nextstrain.yaml"
+    shell:
+        """
+        aws s3 cp {params.s3_path} - | xz -c -d > {output.metadata}
         """

--- a/workflow/snakemake_rules/export.smk
+++ b/workflow/snakemake_rules/export.smk
@@ -59,7 +59,7 @@ rule export:
         metadata = build_dir + "/{build_name}/metadata.tsv",
         node_data = _get_node_data_by_wildcards,
         auspice_config = lambda w: config['builds'][w.build_name]['auspice_config'],
-        lat_longs = config['lat-longs']
+        lat_longs = config.get('lat-longs', "config/lat_longs.tsv"),
     output:
         auspice_json = "auspice/{build_name}_{segment}.json",
         root_sequence_json = "auspice/{build_name}_{segment}_root-sequence.json",


### PR DESCRIPTION
## Description of proposed changes

Adds rules, config, and GitHub Action file to support running Nextclade on all available HA and NA sequences for H1N1pdm, H3N2, and Vic.

The new Snakemake logic lives in a custom build config named `nextclade` which skips most of the standard workflow build logic, using only the "download from S3" rules and its own custom rules to run Nextclade for the lineages and segments defined in the build config. This custom logic runs Nextclade with the default dataset per lineage and segment [just like the flu_frequencies workflow](https://github.com/nextstrain/flu_frequencies/blob/6e4298fac3361f4a6751d85bcb963064dbb9eee1/Snakefile#L89-L960) and uploads the results to S3. Once we have merged this PR, we should be able to automatically run Nextclade with each ingest of new data and run flu_frequencies from the resulting files on S3.

This PR includes a couple of minor changes to other parts of the standard workflow to allow the Nextclade build config YAML to be as simple as possible and also to allow all workflows to download the parsed sequences and metadata from S3 instead of downloading the raw sequences and parsing them again locally.

To run the Nextclade workflow, use the following command:

```
nextstrain build . upload_all_nextclade_files --configfile profiles/nextclade.yaml
```

This uploads Nextclade annotations and alignment files to S3 per lineage and segment like `seasonal-flu/vic/ha/nextclade.tsv.xz` and `seasonal-flu/vic/ha/aligned.fasta.xz`.

This PR does not produce a merged metadata and Nextclade annotations file like [the one used in the flu_frequencies workflow](https://github.com/nextstrain/flu_frequencies/blob/6e4298fac3361f4a6751d85bcb963064dbb9eee1/Snakefile#L113-L130) or the analogous ncov metadata files with Nextclade annotations included. I stopped short of creating this merged file in S3, too, because we use a single metadata TSV per lineage (for all segments) but we produce Nextclade annotations per segment. We could upload the metadata TSVs per lineage and segment with Nextclade annotations merged into a single file, but this would duplicate a lot of information across segments. Maybe that duplication is acceptable, but it's worth discussing more internally first.

~~Note: since this PR adds a new GitHub Action, I can't test the action until we've merged the PR into master.~~

## Related issue(s)

Related to #144 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] GitHub Action runs and deploys data to S3 as expected

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
