### PR TITLE
Add isolate_id field to metadata

### DIFF
--- a/profiles/upload.yaml
+++ b/profiles/upload.yaml
@@ -8,6 +8,7 @@ fauna_fasta_fields:
   - strain
   - virus
   - locus
+  - isolate_id
   - accession
   - collection_date
   - submission_date
@@ -24,6 +25,7 @@ fasta_fields:
   - strain
   - virus
   - segment
+  - isolate_id
   - accession
   - date
   - date_submitted


### PR DESCRIPTION
## Description of proposed changes

Adds the field containing GISAID isolate id (values prefixed by "EPI_ISL_") to the list of fields to include in the download from fauna in the "upload" configuration file. When we run the upload workflow with this change, the parsed metadata files on S3 should include the new column without any other changes needed by other workflows that download the data from S3.

This isolate id field is important in that it represents a single viral isolate that has one or more segment accessions for genes like HA, NA, etc.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [GitHub Actions upload workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/8693198037) runs and uploads the updated metadata to S3

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
