### PR TITLE
Upload trigger matrix

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -28,7 +28,7 @@ on:
         description: "Specific container image to use for nextflu-private group builds"
         required: false
         type: string
-        
+
 jobs:
   upload:
     permissions:
@@ -51,44 +51,28 @@ jobs:
           upload_all_metadata \
           --configfile profiles/upload.yaml
 
-  trigger-public-builds:
+  trigger:
     needs: [upload]
-    if: ${{ inputs.triggerPublic }}
+    strategy:
+      matrix:
+        include:
+          - trigger: ${{ inputs.triggerPublic }}
+            workflow: run-public-builds.yaml
+            image: ${{ inputs.publicDockerImage }}
+          - trigger: ${{ inputs.triggerPrivateNextflu }}
+            workflow: run-private-nextflu-builds.yaml
+            image: ${{ inputs.privateNextfluDockerImage }}
+          - trigger: ${{ inputs.triggerNextfluPrivate }}
+            workflow: run-nextflu-private-builds.yaml
+            image: ${{ inputs.nextfluPrivateDockerImage }}
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger Nextstrain public builds
+      - if: ${{ matrix.trigger }}
+        name: Trigger ${{ matrix.workflow }}
         run: |
           gh workflow run \
-            run-public-builds.yaml \
+            ${{ matrix.workflow }} \
             --repo nextstrain/seasonal-flu \
-            -f dockerImage=${{ github.event.inputs.publicDockerImage }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-  trigger-private-nextflu-builds:
-    needs: [upload]
-    if: ${{ inputs.triggerPrivateNextflu }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger private Nextflu builds
-        run: |
-          gh workflow run \
-            run-private-nextflu-builds.yaml \
-            --repo nextstrain/seasonal-flu \
-            -f dockerImage=${{ github.event.inputs.privateNextfluDockerImage }}
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-  trigger-nextflu-private-builds:
-    needs: [upload]
-    if: ${{ inputs.triggerNextfluPrivate }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger nextflu-private group builds
-        run: |
-          gh workflow run \
-            run-nextflu-private-builds.yaml \
-            --repo nextstrain/seasonal-flu \
-            -f dockerImage=${{ github.event.inputs.nextfluPrivateDockerImage }}
+            -f dockerImage=${{ matrix.image }}
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -28,6 +28,14 @@ on:
         description: "Specific container image to use for nextflu-private group builds"
         required: false
         type: string
+      triggerNextclade:
+        description: "Trigger run-nextclade workflow"
+        required: true
+        type: boolean
+      nextcladeDockerImage:
+        description: "Specific container image to use for the Nextclade workflow"
+        required: false
+        type: string
 
 jobs:
   upload:
@@ -65,6 +73,9 @@ jobs:
           - trigger: ${{ inputs.triggerNextfluPrivate }}
             workflow: run-nextflu-private-builds.yaml
             image: ${{ inputs.nextfluPrivateDockerImage }}
+          - trigger: ${{ inputs.triggerNextclade }}
+            workflow: run-nextclade.yaml
+            image: ${{ inputs.nextcladeDockerImage }}
     runs-on: ubuntu-latest
     steps:
       - if: ${{ matrix.trigger }}


### PR DESCRIPTION
## Description of proposed changes

Updates the upload GH Action workflow to use a matrix to define downstream triggers after upload job is complete. 
Also adds the `run-nextclade.yaml` workflow to the matrix of triggers for the upload workflow.

## Related issue(s)

Follow up to https://github.com/nextstrain/seasonal-flu/pull/158

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test run of upload workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/9070404138)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
