### PR TITLE
Summarize haplotype coverage by titer references using frequencies per haplotype from all available data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 data/
 builds/
 results/
+tables/
 auspice/
 auspice-who/
 auspice_renamed/

--- a/.pylintrc
+++ b/.pylintrc
@@ -311,13 +311,6 @@ max-line-length=100
 # Maximum number of lines in a module
 max-module-lines=1000
 
-# List of optional constructs for which whitespace checking is disabled. `dict-
-# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
-# `trailing-comma` allows a space between comma and closing bracket: (a, ).
-# `empty-line` allows space-only lines.
-no-space-check=trailing-comma,
-               dict-separator
-
 # Allow the body of a class to be on the same line as the declaration if body
 # contains single statement.
 single-line-class-stmt=no

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -1,5 +1,6 @@
 rule all_report_outputs:
     input:
+        derived_haplotypes=expand("tables/{lineage}/derived_haplotypes.md", lineage=["h1n1pdm", "h3n2", "vic"]),
         counts_by_clade=expand("tables/{lineage}/counts_of_recent_sequences_by_clade.md", lineage=["h1n1pdm", "h3n2", "vic"]),
         total_sample_count_by_lineage="figures/total-sample-count-by-lineage.png",
 
@@ -149,6 +150,7 @@ rule summarize_derived_haplotypes:
         titers=lambda wildcards: [
             collection["data"]
             for collection in config["builds"][f"{wildcards.lineage}_2y_titers"]["titer_collections"]
+            if "ferret" in collection["data"]
         ],
     output:
         table="tables/{lineage}/derived_haplotypes.tsv",
@@ -158,6 +160,7 @@ rule summarize_derived_haplotypes:
         titer_names=lambda wildcards: [
             collection["name"]
             for collection in config["builds"][f"{wildcards.lineage}_2y_titers"]["titer_collections"]
+            if "ferret" in collection["data"]
         ],
     shell:
         """

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -66,10 +66,22 @@ rule download_nextclade:
         aws s3 cp {params.s3_path} {output.nextclade}
         """
 
+rule filter_nextclade_by_qc:
+    input:
+        nextclade="data/{lineage}/{segment}/nextclade.tsv.xz",
+    output:
+        nextclade="data/{lineage}/{segment}/nextclade_without_bad_qc.tsv",
+    conda: "../../workflow/envs/nextstrain.yaml"
+    shell:
+        """
+        xz -c -d {input.nextclade} \
+            | tsv-filter -H --str-ne "qc.overallStatus:bad" > {output.nextclade}
+        """
+
 rule count_recent_tips_by_clade:
     input:
         recency="tables/{lineage}/recency.json",
-        clades="data/{lineage}/ha/nextclade.tsv.xz",
+        clades="data/{lineage}/ha/nextclade_without_bad_qc.tsv",
     output:
         counts="tables/{lineage}/counts_of_recent_sequences_by_clade.md",
     conda: "../../workflow/envs/nextstrain.yaml"

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -141,3 +141,20 @@ rule estimate_derived_haplotype_frequencies:
             --max-date {params.max_date} \
             --output {output.frequencies}
         """
+
+rule summarize_derived_haplotypes:
+    input:
+        metadata="data/{lineage}/metadata_with_derived_haplotypes.tsv",
+        frequencies="tables/{lineage}/derived_haplotype_frequencies.json",
+    output:
+        table="tables/{lineage}/derived_haplotypes.tsv",
+        markdown_table="tables/{lineage}/derived_haplotypes.md",
+    conda: "../../workflow/envs/nextstrain.yaml"
+    shell:
+        """
+        python3 scripts/summarize_haplotypes.py \
+            --metadata {input.metadata} \
+            --frequencies {input.frequencies} \
+            --output-table {output.table} \
+            --output-markdown-table {output.markdown_table}
+        """

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -132,7 +132,7 @@ rule estimate_derived_haplotype_frequencies:
     params:
         narrow_bandwidth=1 / 12.0,
         min_date="16W",
-        max_date="4W",
+        max_date=config.get("build_date", "4W"),
     shell:
         """
         python3 scripts/estimate_frequencies_from_metadata.py \

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -146,15 +146,26 @@ rule summarize_derived_haplotypes:
     input:
         metadata="data/{lineage}/metadata_with_derived_haplotypes.tsv",
         frequencies="tables/{lineage}/derived_haplotype_frequencies.json",
+        titers=lambda wildcards: [
+            collection["data"]
+            for collection in config["builds"][f"{wildcards.lineage}_2y_titers"]["titer_collections"]
+        ],
     output:
         table="tables/{lineage}/derived_haplotypes.tsv",
         markdown_table="tables/{lineage}/derived_haplotypes.md",
     conda: "../../workflow/envs/nextstrain.yaml"
+    params:
+        titer_names=lambda wildcards: [
+            collection["name"]
+            for collection in config["builds"][f"{wildcards.lineage}_2y_titers"]["titer_collections"]
+        ],
     shell:
         """
         python3 scripts/summarize_haplotypes.py \
             --metadata {input.metadata} \
             --frequencies {input.frequencies} \
+            --titers {input.titers:q} \
+            --titer-names {params.titer_names:q} \
             --output-table {output.table} \
             --output-markdown-table {output.markdown_table}
         """

--- a/profiles/nextflu-private/report.smk
+++ b/profiles/nextflu-private/report.smk
@@ -115,9 +115,29 @@ rule join_metadata_and_nextclade:
         metadata="data/{lineage}/metadata.tsv",
         nextclade="data/{lineage}/nextclade_with_derived_haplotypes.tsv",
     output:
-        nextclade="data/{lineage}/metadata_with_derived_haplotypes.tsv",
+        metadata="data/{lineage}/metadata_with_derived_haplotypes.tsv",
     conda: "../../workflow/envs/nextstrain.yaml"
     shell:
         """
-        tsv-join -H -f {input.nextclade} -a haplotype -k seqName -d strain {input.metadata} > {output.nextclade}
+        tsv-join -H -f {input.nextclade} -a haplotype -k seqName -d strain {input.metadata} > {output.metadata}
+        """
+
+rule estimate_derived_haplotype_frequencies:
+    input:
+        metadata="data/{lineage}/metadata_with_derived_haplotypes.tsv",
+    output:
+        frequencies="tables/{lineage}/derived_haplotype_frequencies.json",
+    conda: "../../workflow/envs/nextstrain.yaml"
+    params:
+        narrow_bandwidth=1 / 12.0,
+        min_date="16W",
+        max_date="4W",
+    shell:
+        """
+        python3 scripts/estimate_frequencies_from_metadata.py \
+            --metadata {input.metadata} \
+            --narrow-bandwidth {params.narrow_bandwidth} \
+            --min-date {params.min_date} \
+            --max-date {params.max_date} \
+            --output {output.frequencies}
         """

--- a/scripts/add_derived_haplotypes.py
+++ b/scripts/add_derived_haplotypes.py
@@ -22,7 +22,7 @@ def create_haplotype_for_record(record, clade_column, mutations_column, genes=No
             if mutation.split(":")[0] in genes
         ]
 
-    mutations = "|".join(mutations).replace(":", "-")
+    mutations = "-".join(mutations).replace(":", "-")
 
     if mutations:
         if strip_genes and genes is not None:

--- a/scripts/add_derived_haplotypes.py
+++ b/scripts/add_derived_haplotypes.py
@@ -1,0 +1,80 @@
+"""
+Annotate derived haplotypes per node from annotated clades and store as node data JSON.
+"""
+import argparse
+import pandas as pd
+
+
+def create_haplotype_for_record(record, clade_column, mutations_column, genes=None, strip_genes=False):
+    """Create a haplotype string for the given record based on the values in its
+    clade and mutations column. If a list of genes is given, filter mutations to
+    only those in the requested genes.
+
+    """
+    clade = record[clade_column]
+    mutations = record[mutations_column].split(",")
+
+    # Filter mutations to requested genes.
+    if genes is not None:
+        mutations = [
+            mutation
+            for mutation in mutations
+            if mutation.split(":")[0] in genes
+        ]
+
+    mutations = "|".join(mutations).replace(":", "-")
+
+    if mutations:
+        if strip_genes and genes is not None:
+            for gene in genes:
+                mutations = mutations.replace(f"{gene}-", "")
+
+        return f"{clade}:{mutations}"
+    else:
+        return clade
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Annotate derived haplotypes per record in Nextclade annotations",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("--nextclade", required=True, help="TSV file of Nextclade annotations with columns for clade and AA mutations derived from clade")
+    parser.add_argument("--clade-column", help="name of the branch attribute for clade labels in the given Nextclade annotations", default="subclade")
+    parser.add_argument("--mutations-column", help="name of the attribute for mutations relative to clades in the given Nextclade annotations", default="founderMuts['subclade'].aaSubstitutions")
+    parser.add_argument("--genes", nargs="+", help="list of genes to filter mutations to. If not provided, all mutations will be used.")
+    parser.add_argument("--strip-genes", action="store_true", help="strip gene names from coordinates in output haplotypes")
+    parser.add_argument("--attribute-name", default="haplotype", help="name of attribute to store the derived haplotype in the output file")
+    parser.add_argument("--output", help="TSV file of Nextclade annotations with derived haplotype column added", required=True)
+    args = parser.parse_args()
+
+    # Load Nextclade annotations.
+    df = pd.read_csv(
+        args.nextclade,
+        sep="\t",
+        dtype={
+            args.clade_column: "str",
+            args.mutations_column: "str",
+        },
+        na_filter=False,
+    )
+
+    # Annotate derived haplotypes.
+    df[args.attribute_name] = df.apply(
+        lambda record: create_haplotype_for_record(
+            record,
+            args.clade_column,
+            args.mutations_column,
+            args.genes,
+            args.strip_genes,
+        ),
+        axis=1
+    )
+
+    # Save updated Nextclade annotations
+    df.to_csv(
+        args.output,
+        sep="\t",
+        index=False,
+    )

--- a/scripts/annotate_haplotypes.py
+++ b/scripts/annotate_haplotypes.py
@@ -80,12 +80,12 @@ if __name__ == '__main__':
             mutations = []
             for i in range(len(sequence_by_node[node.name])):
                 if sequence_by_node[node.name][i] != sequence_by_clade[clade][i]:
-                    # Store 1-based mutation position and derived allele.
-                    mutations.append(f"{i + 1}{sequence_by_node[node.name][i]}")
+                    # Store ancestral allele, 1-based mutation position, and derived allele.
+                    mutations.append(f"{sequence_by_clade[clade][i]}{i + 1}{sequence_by_node[node.name][i]}")
 
-            # Store the clade name plus a comma-delimited list of derived
-            # mutations present in the current node.
-            haplotype = f"{clade}:{','.join(mutations)}"
+            # Store the clade name plus a delimited list of derived mutations
+            # present in the current node.
+            haplotype = f"{clade}:{'-'.join(mutations)}"
 
         # Store the clade and haplotype values for this node.
         haplotypes[node.name][args.attribute_name] = haplotype

--- a/scripts/count_recent_tips_by_clade.py
+++ b/scripts/count_recent_tips_by_clade.py
@@ -31,14 +31,13 @@ if __name__ == '__main__':
     clades = pd.read_csv(
         args.clades,
         sep="\t",
-        usecols=["seqName", "subclade", "qc.overallStatus"],
+        usecols=["seqName", "subclade"],
     )
 
 
     # Filter clade labels to recent non-low-quality sequences and count the
     # clade membership for each recent tip.
     count_by_clade = clades[
-        (clades["qc.overallStatus"] != "bad") &
         (clades["seqName"].isin(recent_tips))
     ].groupby(
         "subclade"

--- a/scripts/estimate_frequencies_from_metadata.py
+++ b/scripts/estimate_frequencies_from_metadata.py
@@ -55,12 +55,16 @@ if __name__ == '__main__':
         observations,
         pivots,
     )
-    frequencies.frequencies = {
+    tip_frequencies = {
         strain: frequency_matrix[index]
         for index, strain in enumerate(metadata.index.values)
         if frequency_matrix[index].sum() > 0
     }
-    frequencies.pivots = pivots
 
-    frequency_dict = frequencies.to_json()
+    frequency_dict = {"pivots": list(pivots)}
+    for node_name in tip_frequencies:
+        frequency_dict[node_name] = {
+            "frequencies": format_frequencies(tip_frequencies[node_name])
+        }
+
     write_json(frequency_dict, args.output)

--- a/scripts/estimate_frequencies_from_metadata.py
+++ b/scripts/estimate_frequencies_from_metadata.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+import argparse
+import numpy as np
+
+from augur.dates import get_numerical_dates, numeric_date_type
+from augur.frequencies import format_frequencies
+from augur.frequency_estimators import get_pivots, KdeFrequencies
+from augur.io import read_metadata
+from augur.utils import write_json
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description="Estimate sequence frequencies from metadata with collection dates",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+
+    parser.add_argument("--metadata", required=True, help="TSV file of metadata with at least 'strain' and 'date' columns")
+    parser.add_argument("--narrow-bandwidth", required=True, type=float, help="narrow bandwidth for KDE frequencies")
+    parser.add_argument("--proportion-wide", type=float, default=0.0, help="proportion of wide bandwidth to use for KDE frequencies")
+    parser.add_argument("--pivot-interval", type=int, default=4, help="interval between pivots in weeks")
+    parser.add_argument("--min-date", type=numeric_date_type, help="minimum date to estimate frequencies for")
+    parser.add_argument("--max-date", type=numeric_date_type, help="maximum date to estimate frequencies for")
+    parser.add_argument("--output", required=True, help="JSON file in tip-frequencies format")
+    args = parser.parse_args()
+
+    columns_to_load = ["strain", "date"]
+    metadata = read_metadata(
+        args.metadata,
+        columns=columns_to_load,
+        dtype="string",
+    )
+    dates = get_numerical_dates(metadata, fmt='%Y-%m-%d')
+
+    observations = [
+        np.mean(dates[strain])
+        for strain in metadata.index.values
+    ]
+    pivots = get_pivots(
+        observations,
+        args.pivot_interval,
+        args.min_date,
+        args.max_date,
+        "weeks",
+    )
+
+    frequencies = KdeFrequencies(
+        sigma_narrow=args.narrow_bandwidth,
+        proportion_wide=args.proportion_wide,
+        pivot_frequency=args.pivot_interval,
+        start_date=args.min_date,
+        end_date=args.max_date,
+    )
+    frequency_matrix = frequencies.estimate_frequencies(
+        observations,
+        pivots,
+    )
+    frequencies.frequencies = {
+        strain: frequency_matrix[index]
+        for index, strain in enumerate(metadata.index.values)
+        if frequency_matrix[index].sum() > 0
+    }
+    frequencies.pivots = pivots
+
+    frequency_dict = frequencies.to_json()
+    write_json(frequency_dict, args.output)

--- a/scripts/estimate_frequencies_from_metadata.py
+++ b/scripts/estimate_frequencies_from_metadata.py
@@ -32,10 +32,13 @@ if __name__ == '__main__':
     )
     dates = get_numerical_dates(metadata, fmt='%Y-%m-%d')
 
-    observations = [
-        np.mean(dates[strain])
-        for strain in metadata.index.values
-    ]
+    strains = []
+    observations = []
+    for strain in metadata.index.values:
+        if dates.get(strain):
+            strains.append(strain)
+            observations.append(np.mean(dates[strain]))
+
     pivots = get_pivots(
         observations,
         args.pivot_interval,
@@ -57,7 +60,7 @@ if __name__ == '__main__':
     )
     tip_frequencies = {
         strain: frequency_matrix[index]
-        for index, strain in enumerate(metadata.index.values)
+        for index, strain in enumerate(strains)
         if frequency_matrix[index].sum() > 0
     }
 

--- a/scripts/summarize_haplotypes.py
+++ b/scripts/summarize_haplotypes.py
@@ -1,0 +1,97 @@
+"""Summarize coverage of haplotypes by titers.
+"""
+import argparse
+import json
+import pandas as pd
+
+from augur.io import read_metadata
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--metadata", required=True, help="metadata TSV with derived haplotypes per strain")
+    parser.add_argument("--frequencies", required=True, help="tip frequencies JSON")
+    parser.add_argument("--output-table", required=True, help="TSV of haplotypes along with number of reference viruses, distinct reference viruses, number of test viruses, current frequency, and delta frequency from the last month.")
+    parser.add_argument("--output-markdown-table", required=True, help="Markdown table of the TSV table above for use in narratives.")
+
+    args = parser.parse_args()
+
+    # Load metadata with derived haplotypes.
+    metadata = read_metadata(args.metadata)
+
+    # Load frequencies.
+    with open(args.frequencies) as fh:
+        frequencies_data = json.load(fh)
+
+    # Get the current and previous frequency per strain.
+    current_frequency_by_strain = {}
+    previous_frequency_by_strain = {}
+    for strain, strain_data in frequencies_data.items():
+        if "frequencies" in strain_data:
+            current_frequency_by_strain[strain] = strain_data["frequencies"][-1]
+            previous_frequency_by_strain[strain] = strain_data["frequencies"][-2]
+
+    # Calculate haplotype frequencies and delta frequencies.
+    haplotype_frequencies = {}
+    for strain, record in metadata.iterrows():
+        if strain not in current_frequency_by_strain:
+            continue
+
+        haplotype = record["haplotype"]
+
+        if haplotype not in haplotype_frequencies:
+            haplotype_frequencies[haplotype] = {
+                "current_frequency": 0.0,
+                "previous_frequency": 0.0,
+            }
+
+        haplotype_frequencies[haplotype]["current_frequency"] += current_frequency_by_strain[strain]
+        haplotype_frequencies[haplotype]["previous_frequency"] += previous_frequency_by_strain[strain]
+
+    # Build a data frame of haplotypes and their frequencies.
+    # TODO: Report haplotype counts associated with frequencies.
+    haplotype_records = []
+    for haplotype in haplotype_frequencies:
+        haplotype_records.append({
+            "haplotype": haplotype,
+            "current_frequency": haplotype_frequencies[haplotype]["current_frequency"],
+            "delta_frequency": (haplotype_frequencies[haplotype]["current_frequency"] - haplotype_frequencies[haplotype]["previous_frequency"]),
+        })
+
+    haplotypes_df = pd.DataFrame(haplotype_records).set_index("haplotype")
+
+    # Join haplotypes with titer reference counts and names.
+    annotated_haplotypes = haplotypes_df
+    # TODO: Annotate haplotypes with number and list of titer references and number of titer test strains.
+    annotated_haplotypes = annotated_haplotypes.query("current_frequency > 0").copy()
+    annotated_haplotypes = annotated_haplotypes.sort_values("current_frequency", ascending=False)
+
+    annotated_haplotypes.to_csv(
+        args.output_table,
+        sep="\t",
+        header=True,
+        index=True,
+    )
+
+    # Create the Markdown version for display in narratives.
+    annotated_haplotypes = annotated_haplotypes.reset_index()
+
+    # Use spaces instead of commas, allowing Markdown to wrap
+    # lines.
+    annotated_haplotypes["haplotype"] = annotated_haplotypes["haplotype"].str.replace(",", " ")
+
+    # Keep haplotypes with at least 1% frequency.
+    annotated_haplotypes = annotated_haplotypes.query("current_frequency >= 0.01").copy()
+
+    # Round frequencies prior to writing out the markdown table.
+    annotated_haplotypes["current_frequency"] = (annotated_haplotypes["current_frequency"] * 100).round(0).astype(int)
+    annotated_haplotypes["delta_frequency"] = (annotated_haplotypes["delta_frequency"] * 100).round(0).astype(int)
+
+    # Save Markdown table.
+    with open(args.output_markdown_table, "w", encoding="utf-8") as oh:
+        print(
+            annotated_haplotypes.to_markdown(
+                index=False,
+            ),
+            file=oh,
+        )


### PR DESCRIPTION
## Description of proposed changes

Replaces the current table of derived haplotype frequencies and titer references that is based on a subsampled HA tree with a table based on all available sequences during the same time period.

With the latest version of Nextclade, we can determine derived haplotype strings per record from a Nextclade annotations file with columns for clade and mutations relative to each clade. We can then calculate haplotype frequencies from all available data instead of a subset of data used to build a tree.

## Development checklist

 - [x] Identify derived HA1 haplotypes from all data with Nextclade for haplotypes
 - [x] Estimate frequencies per haplotype from all data including at 4 weeks ago and 8 weeks ago, reporting delta frequency for that time period
 - [x] Include distinct references per haplotype across all titer collections (e.g., cell FRA, cell HI, egg FRA, egg HI, etc.)
 - [x] Generate table of haplotype frequencies and references with links to haplotype view in the corresponding tree

## Related issue(s)

Related to #130
Depends on https://github.com/nextstrain/nextclade/pull/1492

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
