### PR TITLE
Add t-SNE embeddings and clusters to workflow

### DIFF
--- a/config/h1n1pdm/auspice_config.json
+++ b/config/h1n1pdm/auspice_config.json
@@ -121,6 +121,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -141,7 +156,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/config/h3n2/auspice_config.json
+++ b/config/h3n2/auspice_config.json
@@ -131,6 +131,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -151,7 +166,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/config/vic/auspice_config.json
+++ b/config/vic/auspice_config.json
@@ -106,6 +106,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -126,7 +141,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/profiles/ci/builds.yaml
+++ b/profiles/ci/builds.yaml
@@ -39,6 +39,10 @@ recency:
   date_bin_labels: ["last week", "last month", "last quarter"]
   upper_bin_label: older
 
+embedding:
+  # Set lower value of perplexity when sample size is small.
+  perplexity: 9
+
 builds:
     "ci_build":
       lineage: h3n2

--- a/profiles/ci/builds.yaml
+++ b/profiles/ci/builds.yaml
@@ -55,6 +55,7 @@ builds:
       enable_titer_models: true
       enable_lbi: true
       enable_glycosylation: true
+      enable_embeddings: true
       titer_collections:
         - name: cdc_cell_fra
           data: "example_data/cdc_h3n2_cell_fra_titers.tsv"

--- a/profiles/nextflu-private.yaml
+++ b/profiles/nextflu-private.yaml
@@ -185,6 +185,7 @@ builds:
     enable_lbi: true
     enable_titer_models: true
     enable_measurements: true
+    enable_embeddings: true
     min_date: "2Y"
     reference_min_date: "6Y"
     max_date: "4W"
@@ -218,6 +219,7 @@ builds:
     enable_forecasts: true
     enable_titer_models: true
     enable_measurements: true
+    enable_embeddings: true
     min_date: "2Y"
     reference_min_date: "6Y"
     max_date: "4W"
@@ -246,6 +248,7 @@ builds:
     enable_lbi: true
     enable_titer_models: true
     enable_measurements: true
+    enable_embeddings: true
     min_date: "2Y"
     reference_min_date: "6Y"
     max_date: "4W"

--- a/profiles/nextflu-private/h1n1pdm/ha/auspice_config.json
+++ b/profiles/nextflu-private/h1n1pdm/ha/auspice_config.json
@@ -344,6 +344,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -370,7 +385,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/profiles/nextflu-private/h1n1pdm/na/auspice_config.json
+++ b/profiles/nextflu-private/h1n1pdm/na/auspice_config.json
@@ -154,6 +154,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -175,7 +190,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/profiles/nextflu-private/h3n2/ha/auspice_config.json
+++ b/profiles/nextflu-private/h3n2/ha/auspice_config.json
@@ -496,6 +496,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -526,7 +541,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/profiles/nextflu-private/h3n2/na/auspice_config.json
+++ b/profiles/nextflu-private/h3n2/na/auspice_config.json
@@ -188,6 +188,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -209,7 +224,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/profiles/nextflu-private/vic/ha/auspice_config.json
+++ b/profiles/nextflu-private/vic/ha/auspice_config.json
@@ -230,6 +230,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -256,7 +271,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/profiles/nextflu-private/vic/na/auspice_config.json
+++ b/profiles/nextflu-private/vic/na/auspice_config.json
@@ -132,6 +132,21 @@
       "key": "year_month",
       "title": "Year/month",
       "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": [
@@ -153,7 +168,8 @@
     "submitting_lab",
     "recency",
     "epiweek",
-    "year_month"
+    "year_month",
+    "tsne_cluster"
   ],
   "panels": [
     "tree",

--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -70,6 +70,7 @@ array-builds:
       enable_glycosylation: true
       enable_lbi: true
       enable_titer_models: true
+      enable_embeddings: true
       include: "'config/{lineage}/reference_strains.txt'"
       exclude: "'config/{lineage}/outliers.txt'"
       titer_collections:
@@ -162,6 +163,7 @@ array-builds:
       enable_glycosylation: true
       enable_lbi: true
       enable_titer_models: true
+      enable_embeddings: true
       include: "'config/{lineage}/reference_strains.txt'"
       exclude: "'config/{lineage}/outliers.txt'"
       titer_collections:
@@ -192,6 +194,7 @@ array-builds:
       enable_lbi: true
       enable_titer_models: true
       enable_forecasts: false
+      enable_embeddings: true
       include: "'config/{lineage}/reference_strains.txt'"
       exclude: "'config/{lineage}/outliers.txt'"
       titer_collections:

--- a/scripts/intersect_items.py
+++ b/scripts/intersect_items.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+import argparse
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--items", nargs="+", required=True, help="one or more files containing a list of items")
+    parser.add_argument("--output", required=True, help="list of items shared by all input files (the intersection)")
+
+    args = parser.parse_args()
+
+    with open(args.items[0], "r", encoding="utf-8") as fh:
+        shared_items = {line.strip() for line in fh}
+
+    for item_file in args.items[1:]:
+        with open(item_file, "r", encoding="utf-8") as fh:
+            items = {line.strip() for line in fh}
+
+        shared_items = shared_items & items
+
+    with open(args.output, "w", encoding="utf-8") as oh:
+        for item in sorted(shared_items):
+            print(item, file=oh)

--- a/scripts/table_to_node_data.py
+++ b/scripts/table_to_node_data.py
@@ -1,0 +1,32 @@
+"""Create Augur-compatible node data JSON from a pandas data frame.
+"""
+import argparse
+import pandas as pd
+from augur.utils import write_json
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--table", help="table to convert to a node data JSON")
+    parser.add_argument("--index-column", default="strain", help="name of the column to use as an index")
+    parser.add_argument("--delimiter", default=",", help="separator between columns in the given table")
+    parser.add_argument("--node-name", default="nodes", help="name of the node data attribute in the JSON output")
+    parser.add_argument("--output", help="node data JSON file")
+
+    args = parser.parse_args()
+
+    if args.output is not None:
+        table = pd.read_csv(
+            args.table,
+            sep=args.delimiter,
+            index_col=args.index_column,
+            dtype=str,
+        )
+
+        # # Convert columns that aren't strain names or labels to floats.
+        # for column in table.columns:
+        #     if column != "strain" and not "label" in column:
+        #         table[column] = table[column].astype(float)
+
+        table_dict = table.transpose().to_dict()
+        write_json({args.node_name: table_dict}, args.output)

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -4,14 +4,13 @@ channels:
   - bioconda
   - defaults
 dependencies:
-  - augur=24.0.0
-  - biopython=1.80
+  - augur=25.3.0
   - awscli=1.27.9
   - epiweeks=2.1.2
   - iqtree=2.2.0_beta
   - mafft=7.526
-  - nextclade>=3.*
-  - python=3.9*
+  - nextclade=3.8.2
+  - python=3.11.*
   - seaborn>=0.11*
   - seqkit=2.2.0
   - csvtk=0.23.0
@@ -19,5 +18,6 @@ dependencies:
   - tabulate=0.9.0
   - xlrd=1.*
   - pip=23.0.1
+  - pathogen-embed=3.1.0
   - pip:
     - rethinkdb==2.3.0.post6

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -587,7 +587,7 @@ rule embed_with_tsne:
     params:
         perplexity=config.get("embedding", {}).get("perplexity", 200),
     benchmark:
-        "benchmarks/embd_with_tsne_{build_name}.txt"
+        "benchmarks/embed_with_tsne_{build_name}.txt"
     shell:
         """
         pathogen-embed \

--- a/workflow/snakemake_rules/export.smk
+++ b/workflow/snakemake_rules/export.smk
@@ -12,7 +12,6 @@ def _get_node_data_by_wildcards(wildcards):
         rules.traits.output.node_data,
         rules.annotate_epiweeks.output.node_data,
         rules.annotate_recency_of_submissions.output.node_data,
-        rules.convert_embedding_clusters_to_node_data.output.node_data,
     ]
 
     # Only request a distance file for builds that have distance map
@@ -45,6 +44,9 @@ def _get_node_data_by_wildcards(wildcards):
 
     if config['builds'][wildcards.build_name].get('vaccines', False):
         inputs.append(config['builds'][wildcards.build_name].get('vaccines'))
+
+    if config["builds"][wildcards.build_name].get("enable_embeddings", False):
+        inputs.append(rules.convert_embedding_clusters_to_node_data.output.node_data)
 
     if wildcards.segment == "ha":
         inputs.append(rules.annotate_haplotypes.output.haplotypes)

--- a/workflow/snakemake_rules/export.smk
+++ b/workflow/snakemake_rules/export.smk
@@ -12,6 +12,7 @@ def _get_node_data_by_wildcards(wildcards):
         rules.traits.output.node_data,
         rules.annotate_epiweeks.output.node_data,
         rules.annotate_recency_of_submissions.output.node_data,
+        rules.convert_embedding_clusters_to_node_data.output.node_data,
     ]
 
     # Only request a distance file for builds that have distance map


### PR DESCRIPTION
## Description of proposed changes

Adds logic and scripts to the core workflow to create a t-SNE embedding per build with all segments and create HDBSCAN clusters from the embeddings. Updates the Auspice config JSONs the public and private builds to include the new t-SNE coordinate fields and the t-SNE cluster field.

Although we select the same strains for each gene segment, not all segment sequences can be aligned. As a result, different sets of strains can appear in the final Nextclade alignment for each gene segment. Since the t-SNE embedding requires the same strains to be present for all of its inputs and in the same order, we need to find the list of strains shared across all segments, extract only those strain sequences from each segment alignment, and sort the alignments prior to calculating pairwise distances and the embedding. We could perform the necessary set operations on multiple segment alignments with shell commands only, but this implementation was not as readable as the simple Python script included here.

This approach is based on our work in [Nanduri et al.](https://bedford.io/papers/nanduri-cartography/) showing that HDBSCAN clusters of t-SNE embeddings from HA and NA alignments can reliably detect phylogenetic clusters including reassortment groups.

## Examples

H1N1pdm HA and NA clusters showing reassortment within subclade D.1:
<img width="1142" alt="image" src="https://github.com/user-attachments/assets/5855bd8e-3edb-48f6-b2dd-c5638e5b46bd">

H3N2 HA and NA clusters (unfortunately both in yellow) showing reassortment within a recent HA clade carrying a HA1:145N substitution:
<img width="1136" alt="image 2" src="https://github.com/user-attachments/assets/d3f38d9c-57bb-449a-977d-f19b8bdc31dd">

Vic HA and NA clusters showing two clusters that completely lack monophyly in the HA tree but which appear monophyletic in the NA tree:
<img width="1142" alt="image 3" src="https://github.com/user-attachments/assets/f47c0cfc-62c4-4fd0-ae0e-e258c2833e72">

## Related issue(s)

Closes #174

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
