### PR TITLE
Add segment-specific Auspice configs for 2y builds

### DIFF
--- a/config/h1n1pdm/ha/auspice_config.json
+++ b/config/h1n1pdm/ha/auspice_config.json
@@ -1,0 +1,243 @@
+{
+  "title": "Real-time tracking of influenza A/H1N1pdm evolution",
+  "maintainers": [
+    {
+      "name": "Jennifer Chang",
+      "url": "https://bedford.io/team/jennifer-chang/"
+    },
+    {
+      "name": "Jover Lee",
+      "url": "https://bedford.io/team/jover-lee/"
+    },
+    {
+      "name": "John Huddleston",
+      "url": "https://bedford.io/team/john-huddleston/"
+    },
+    {
+      "name": "Richard Neher",
+      "url": "https://neherlab.org/richard-neher.html"
+    },
+    {
+      "name": "Trevor Bedford",
+      "url": "https://bedford.io/team/trevor-bedford/"
+    }
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "clade_membership",
+      "title": "Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade",
+      "title": "Subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "C.1",
+          "#492AB5"
+        ],
+        [
+          "C.1.1",
+          "#3F4CCB"
+        ],
+        [
+          "C.1.2",
+          "#4271CE"
+        ],
+        [
+          "C.1.5",
+          "#4C8FC0"
+        ],
+        [
+          "C.1.7",
+          "#5AA5A8"
+        ],
+        [
+          "C.1.7.1",
+          "#6DB38A"
+        ],
+        [
+          "C.1.7.2",
+          "#85BA6F"
+        ],
+        [
+          "C.1.8",
+          "#A0BE59"
+        ],
+        [
+          "C.1.9",
+          "#BBBC49"
+        ],
+        [
+          "D",
+          "#D2B340"
+        ],
+        [
+          "D.1",
+          "#E19F3A"
+        ],
+        [
+          "D.2",
+          "#E68033"
+        ],
+        [
+          "D.3",
+          "#E2562B"
+        ],
+        [
+          "D.4",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
+      "key": "haplotype",
+      "title": "Derived haplotype",
+      "type": "categorical"
+    },
+    {
+      "key": "cTiter",
+      "title": "Antigenic advance (tree model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiterSub",
+      "title": "Antigenic advance (sub model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiter_x",
+      "title": "HI antigenic novelty",
+      "type": "continuous"
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "ep",
+      "title": "Epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "ne",
+      "title": "Non-epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "glyc",
+      "title": "Glycosylation changes",
+      "type": "continuous"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission date",
+      "type": "ordinal"
+    },
+    {
+      "key": "epiweek",
+      "title": "Epiweek (CDC)",
+      "type": "ordinal"
+    },
+    {
+      "key": "year_month",
+      "title": "Year/month",
+      "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
+  },
+  "filters": [
+    "clade_membership",
+    "subclade",
+    "region",
+    "country",
+    "division",
+    "submitting_lab",
+    "recency",
+    "epiweek",
+    "year_month",
+    "tsne_cluster"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ]
+}

--- a/config/h1n1pdm/na/auspice_config.json
+++ b/config/h1n1pdm/na/auspice_config.json
@@ -1,0 +1,208 @@
+{
+  "title": "Real-time tracking of influenza A/H1N1pdm evolution",
+  "maintainers": [
+    {
+      "name": "Jennifer Chang",
+      "url": "https://bedford.io/team/jennifer-chang/"
+    },
+    {
+      "name": "Jover Lee",
+      "url": "https://bedford.io/team/jover-lee/"
+    },
+    {
+      "name": "John Huddleston",
+      "url": "https://bedford.io/team/john-huddleston/"
+    },
+    {
+      "name": "Richard Neher",
+      "url": "https://neherlab.org/richard-neher.html"
+    },
+    {
+      "name": "Trevor Bedford",
+      "url": "https://bedford.io/team/trevor-bedford/"
+    }
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "clade_membership",
+      "title": "Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade",
+      "title": "Subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "C",
+          "#3E5DD0"
+        ],
+        [
+          "C.3",
+          "#4A8CC2"
+        ],
+        [
+          "C.4",
+          "#60AA9E"
+        ],
+        [
+          "C.5.1.1",
+          "#80B974"
+        ],
+        [
+          "C.5.2",
+          "#A6BE55"
+        ],
+        [
+          "C.5.3",
+          "#CBB742"
+        ],
+        [
+          "C.5.3.1",
+          "#E29D39"
+        ],
+        [
+          "C.5.3.2",
+          "#E56A2F"
+        ],
+        [
+          "C.5.3.3",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
+      "key": "haplotype",
+      "title": "Derived haplotype",
+      "type": "categorical"
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "ep",
+      "title": "Epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "ne",
+      "title": "Non-epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "glyc",
+      "title": "Glycosylation changes",
+      "type": "continuous"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission date",
+      "type": "ordinal"
+    },
+    {
+      "key": "epiweek",
+      "title": "Epiweek (CDC)",
+      "type": "ordinal"
+    },
+    {
+      "key": "year_month",
+      "title": "Year/month",
+      "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
+  },
+  "filters": [
+    "clade_membership",
+    "subclade",
+    "region",
+    "country",
+    "division",
+    "submitting_lab",
+    "recency",
+    "epiweek",
+    "year_month",
+    "tsne_cluster"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ]
+}

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -1,0 +1,221 @@
+{
+  "title": "Real-time tracking of influenza A/H3N2 evolution",
+  "maintainers": [
+    {
+      "name": "Jennifer Chang",
+      "url": "https://bedford.io/team/jennifer-chang/"
+    },
+    {
+      "name": "Jover Lee",
+      "url": "https://bedford.io/team/jover-lee/"
+    },
+    {
+      "name": "John Huddleston",
+      "url": "https://bedford.io/team/john-huddleston/"
+    },
+    {
+      "name": "Richard Neher",
+      "url": "https://neherlab.org/richard-neher.html"
+    },
+    {
+      "name": "Trevor Bedford",
+      "url": "https://bedford.io/team/trevor-bedford/"
+    }
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "clade_membership",
+      "title": "Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade",
+      "title": "Subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "G.1.3.1",
+          "#447CCD"
+        ],
+        [
+          "J",
+          "#5EA9A1"
+        ],
+        [
+          "J.1",
+          "#8ABB6A"
+        ],
+        [
+          "J.2",
+          "#BEBB48"
+        ],
+        [
+          "J.3",
+          "#E29E39"
+        ],
+        [
+          "J.4",
+          "#E2562B"
+        ]
+      ]
+    },
+    {
+      "key": "haplotype",
+      "title": "Derived haplotype",
+      "type": "categorical"
+    },
+    {
+      "key": "ne_star",
+      "title": "Mutational load",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiter",
+      "title": "Antigenic advance (tree model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiterSub",
+      "title": "Antigenic advance (sub model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiter_x",
+      "title": "HI antigenic novelty",
+      "type": "continuous"
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "ep",
+      "title": "Epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "ne",
+      "title": "Non-epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "rb",
+      "title": "RBS adjacent mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "glyc",
+      "title": "Glycosylation changes",
+      "type": "continuous"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission date",
+      "type": "ordinal"
+    },
+    {
+      "key": "epiweek",
+      "title": "Epiweek (CDC)",
+      "type": "ordinal"
+    },
+    {
+      "key": "year_month",
+      "title": "Year/month",
+      "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
+  },
+  "filters": [
+    "clade_membership",
+    "subclade",
+    "region",
+    "country",
+    "division",
+    "submitting_lab",
+    "recency",
+    "epiweek",
+    "year_month",
+    "tsne_cluster"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ]
+}

--- a/config/h3n2/na/auspice_config.json
+++ b/config/h3n2/na/auspice_config.json
@@ -1,0 +1,193 @@
+{
+  "title": "Real-time tracking of influenza A/H3N2 evolution",
+  "maintainers": [
+    {
+      "name": "Jennifer Chang",
+      "url": "https://bedford.io/team/jennifer-chang/"
+    },
+    {
+      "name": "Jover Lee",
+      "url": "https://bedford.io/team/jover-lee/"
+    },
+    {
+      "name": "John Huddleston",
+      "url": "https://bedford.io/team/john-huddleston/"
+    },
+    {
+      "name": "Richard Neher",
+      "url": "https://neherlab.org/richard-neher.html"
+    },
+    {
+      "name": "Trevor Bedford",
+      "url": "https://bedford.io/team/trevor-bedford/"
+    }
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "clade_membership",
+      "title": "Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade",
+      "title": "Subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "B.4",
+          "#4A8CC2"
+        ],
+        [
+          "B.4.1",
+          "#71B486"
+        ],
+        [
+          "B.4.2",
+          "#ABBD52"
+        ],
+        [
+          "B.4.3",
+          "#DEA73C"
+        ]
+      ]
+    },
+    {
+      "key": "haplotype",
+      "title": "Derived haplotype",
+      "type": "categorical"
+    },
+    {
+      "key": "ne_star",
+      "title": "Mutational load",
+      "type": "continuous"
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "ep",
+      "title": "Epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "ne",
+      "title": "Non-epitope mutations",
+      "type": "continuous"
+    },
+    {
+      "key": "glyc",
+      "title": "Glycosylation changes",
+      "type": "continuous"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+    {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission date",
+      "type": "ordinal"
+    },
+    {
+      "key": "epiweek",
+      "title": "Epiweek (CDC)",
+      "type": "ordinal"
+    },
+    {
+      "key": "year_month",
+      "title": "Year/month",
+      "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
+  },
+  "filters": [
+    "clade_membership",
+    "subclade",
+    "region",
+    "country",
+    "division",
+    "submitting_lab",
+    "recency",
+    "epiweek",
+    "year_month",
+    "tsne_cluster"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ]
+}

--- a/config/vic/ha/auspice_config.json
+++ b/config/vic/ha/auspice_config.json
@@ -1,0 +1,200 @@
+{
+  "title": "Real-time tracking of influenza B/Vic evolution",
+  "maintainers": [
+    {
+      "name": "Jennifer Chang",
+      "url": "https://bedford.io/team/jennifer-chang/"
+    },
+    {
+      "name": "Jover Lee",
+      "url": "https://bedford.io/team/jover-lee/"
+    },
+    {
+      "name": "John Huddleston",
+      "url": "https://bedford.io/team/john-huddleston/"
+    },
+    {
+      "name": "Richard Neher",
+      "url": "https://neherlab.org/richard-neher.html"
+    },
+    {
+      "name": "Trevor Bedford",
+      "url": "https://bedford.io/team/trevor-bedford/"
+    }
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "clade_membership",
+      "title": "Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade",
+      "title": "Subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "C.2",
+          "#4272CE"
+        ],
+        [
+          "C.3",
+          "#58A2AC"
+        ],
+        [
+          "C.5",
+          "#7DB877"
+        ],
+        [
+          "C.5.1",
+          "#AEBD50"
+        ],
+        [
+          "C.5.4",
+          "#D8AE3E"
+        ],
+        [
+          "C.5.6",
+          "#E67A32"
+        ],
+        [
+          "C.5.7",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
+      "key": "cTiter",
+      "title": "Antigenic advance (tree model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiterSub",
+      "title": "Antigenic advance (sub model)",
+      "type": "continuous"
+    },
+    {
+      "key": "cTiter_x",
+      "title": "HI antigenic novelty",
+      "type": "continuous"
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "glyc",
+      "title": "Glycosylation changes",
+      "type": "continuous"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission date",
+      "type": "ordinal"
+    },
+    {
+      "key": "epiweek",
+      "title": "Epiweek (CDC)",
+      "type": "ordinal"
+    },
+    {
+      "key": "year_month",
+      "title": "Year/month",
+      "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
+  },
+  "filters": [
+    "clade_membership",
+    "subclade",
+    "region",
+    "country",
+    "division",
+    "submitting_lab",
+    "recency",
+    "epiweek",
+    "year_month",
+    "tsne_cluster"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ]
+}

--- a/config/vic/na/auspice_config.json
+++ b/config/vic/na/auspice_config.json
@@ -1,0 +1,193 @@
+{
+  "title": "Real-time tracking of influenza B/Vic evolution",
+  "maintainers": [
+    {
+      "name": "Jennifer Chang",
+      "url": "https://bedford.io/team/jennifer-chang/"
+    },
+    {
+      "name": "Jover Lee",
+      "url": "https://bedford.io/team/jover-lee/"
+    },
+    {
+      "name": "John Huddleston",
+      "url": "https://bedford.io/team/john-huddleston/"
+    },
+    {
+      "name": "Richard Neher",
+      "url": "https://neherlab.org/richard-neher.html"
+    },
+    {
+      "name": "Trevor Bedford",
+      "url": "https://bedford.io/team/trevor-bedford/"
+    }
+  ],
+  "data_provenance": [
+    {
+      "name": "GISAID"
+    }
+  ],
+  "build_url": "https://github.com/nextstrain/seasonal-flu",
+  "colorings": [
+    {
+      "key": "gt",
+      "title": "Genotype",
+      "type": "categorical"
+    },
+    {
+      "key": "num_date",
+      "title": "Date",
+      "type": "continuous"
+    },
+    {
+      "key": "clade_membership",
+      "title": "Clade",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade",
+      "title": "Subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "B",
+          "#3E5DD0"
+        ],
+        [
+          "B.3",
+          "#4A8CC2"
+        ],
+        [
+          "B.5",
+          "#60AA9E"
+        ],
+        [
+          "B.6",
+          "#80B974"
+        ],
+        [
+          "B.7",
+          "#A6BE55"
+        ],
+        [
+          "B.7.1",
+          "#CBB742"
+        ],
+        [
+          "B.7.2",
+          "#E29D39"
+        ],
+        [
+          "B.7.3",
+          "#E56A2F"
+        ],
+        [
+          "B.8",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
+      "key": "lbi",
+      "title": "Local branching index",
+      "type": "continuous"
+    },
+    {
+      "key": "glyc",
+      "title": "Glycosylation changes",
+      "type": "continuous"
+    },
+    {
+      "key": "region",
+      "title": "Region",
+      "type": "categorical"
+    },
+    {
+      "key": "country",
+      "title": "Country",
+      "type": "categorical"
+    },
+     {
+      "key": "division",
+      "title": "Division",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_ha",
+      "title": "Accession (HA)",
+      "type": "categorical"
+    },
+    {
+      "key": "accession_na",
+      "title": "Accession (NA)",
+      "type": "categorical"
+    },
+    {
+      "key": "submitting_lab",
+      "title": "Submitting lab",
+      "type": "categorical"
+    },
+    {
+      "key": "originating_lab",
+      "title": "Originating lab",
+      "type": "categorical"
+    },
+    {
+      "key": "recency",
+      "title": "Submission date",
+      "type": "ordinal"
+    },
+    {
+      "key": "epiweek",
+      "title": "Epiweek (CDC)",
+      "type": "ordinal"
+    },
+    {
+      "key": "year_month",
+      "title": "Year/month",
+      "type": "categorical"
+    },
+    {
+      "key": "tsne_x",
+      "title": "t-SNE 1",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_y",
+      "title": "t-SNE 2",
+      "type": "continuous"
+    },
+    {
+      "key": "tsne_cluster",
+      "title": "t-SNE cluster",
+      "type": "categorical"
+    }
+  ],
+  "geo_resolutions": [
+    "division",
+    "country",
+    "region"
+  ],
+  "display_defaults": {
+    "map_triplicate": true,
+    "color_by": "clade_membership"
+  },
+  "filters": [
+    "clade_membership",
+    "subclade",
+    "region",
+    "country",
+    "division",
+    "submitting_lab",
+    "recency",
+    "epiweek",
+    "year_month",
+    "tsne_cluster"
+  ],
+  "panels": [
+    "tree",
+    "map",
+    "entropy",
+    "frequencies"
+  ]
+}

--- a/profiles/nextflu-private.yaml
+++ b/profiles/nextflu-private.yaml
@@ -169,101 +169,11 @@ builds:
         data: "data/vic/who_ferret_egg_hi_titers.tsv"
         prefix: egg_hi_
         title: "Egg-passaged HI titers from ferret sera"
-    subsamples: *titers-subsampling-scheme
-  # Define builds with representative sampling for cases when we need to
-  # minimize sampling bias (e.g., LBI, tree topology, frequencies, etc.).
-  h1n1pdm_2y:
-    lineage: "h1n1pdm"
-    reference: "config/h1n1pdm/{segment}/reference.fasta"
-    annotation: "config/h1n1pdm/{segment}/genemap.gff"
-    tree_exclude_sites: "config/h1n1pdm/{segment}/exclude-sites.txt"
-    clades: "config/h1n1pdm/ha/clades.tsv"
-    subclades: "config/h1n1pdm/{segment}/subclades.tsv"
-    auspice_config: "profiles/nextflu-private/h1n1pdm/{segment}/auspice_config.json"
-    vaccines: "config/h1n1pdm/vaccine.json"
-    enable_glycosylation: true
-    enable_lbi: true
-    enable_titer_models: true
-    enable_measurements: true
-    enable_embeddings: true
-    min_date: "2Y"
-    reference_min_date: "6Y"
-    max_date: "4W"
-    include: "config/h1n1pdm/reference_strains.txt"
-    exclude: "config/h1n1pdm/outliers.txt"
-    titer_collections:
-      - name: cell_hi
-        data: "data/h1n1pdm/who_ferret_cell_hi_titers.tsv"
-        prefix: cell_hi_
-        title: "Cell-passaged HI titers from ferret sera"
-    subsamples: &representative-subsampling-scheme
-      regions_except_europe:
-          filters: --query "(passage_category != 'egg') & (region != 'Europe') & (ha == True) & (na == True)" --group-by region year month --subsample-max-sequences 2700 --min-date {min_date} --exclude {exclude}
-          priorities: "titers"
-      europe:
-          filters: --query "(passage_category != 'egg') & (region == 'Europe') & (ha == True) & (na == True)" --group-by country year month --subsample-max-sequences 300 --min-date {min_date} --exclude {exclude}
-          priorities: "titers"
-      references:
-          filters: --query "(is_reference == True)" --min-date {reference_min_date}
-  h3n2_2y:
-    lineage: "h3n2"
-    reference: "config/h3n2/{segment}/reference.fasta"
-    annotation: "config/h3n2/{segment}/genemap.gff"
-    tree_exclude_sites: "config/h3n2/{segment}/exclude-sites.txt"
-    clades: "config/h3n2/ha/clades.tsv"
-    subclades: "config/h3n2/{segment}/subclades.tsv"
-    auspice_config: "profiles/nextflu-private/h3n2/{segment}/auspice_config.json"
-    vaccines: "config/h3n2/vaccine.json"
-    enable_glycosylation: true
-    enable_lbi: true
-    enable_forecasts: true
-    enable_titer_models: true
-    enable_measurements: true
-    enable_embeddings: true
-    min_date: "2Y"
-    reference_min_date: "6Y"
-    max_date: "4W"
-    include: "config/h3n2/reference_strains.txt"
-    exclude: "config/h3n2/outliers.txt"
-    titer_collections:
-      - name: cell_fra
-        data: "data/h3n2/who_ferret_cell_fra_titers.tsv"
-        prefix: cell_fra_
-        title: "Cell-passaged FRA titers from ferret sera"
-      - name: human_cell_fra
-        data: "data/h3n2/who_human_cell_fra_titers.tsv"
-        prefix: human_cell_fra_
-        title: "Cell-passaged FRA titers from pooled human sera"
-    subsamples: *representative-subsampling-scheme
-  vic_2y:
-    lineage: "vic"
-    reference: "config/vic/{segment}/reference.fasta"
-    annotation: "config/vic/{segment}/genemap.gff"
-    tree_exclude_sites: "config/vic/{segment}/exclude-sites.txt"
-    clades: "config/vic/ha/clades.tsv"
-    subclades: "config/vic/{segment}/subclades.tsv"
-    auspice_config: "profiles/nextflu-private/vic/{segment}/auspice_config.json"
-    vaccines: "config/vic/vaccine.json"
-    enable_glycosylation: true
-    enable_lbi: true
-    enable_titer_models: true
-    enable_measurements: true
-    enable_embeddings: true
-    min_date: "2Y"
-    reference_min_date: "6Y"
-    max_date: "4W"
-    include: "config/vic/reference_strains.txt"
-    exclude: "config/vic/outliers.txt"
-    titer_collections:
-      - name: cell_hi
-        data: "data/vic/who_ferret_cell_hi_titers.tsv"
-        prefix: cell_hi_
-        title: "Cell-passaged HI titers from ferret sera"
       - name: human_cell_hi
         data: "data/vic/who_human_cell_hi_titers.tsv"
         prefix: human_cell_hi_
         title: "Cell-passaged HI titers from pooled human sera"
-    subsamples: *representative-subsampling-scheme
+    subsamples: *titers-subsampling-scheme
 
 fitness_model:
   models:

--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -97,7 +97,24 @@ array-builds:
       resolution:
         - 2y
     build_name: "seasonal-flu_{lineage}_2y"
-    build_params: *shared-hi-build-params
+    build_params:
+      auspice_name: "seasonal-flu_{lineage}_{{segment}}_{resolution}"
+      reference: "config/{lineage}/{{segment}}/reference.fasta"
+      annotation: "config/{lineage}/{{segment}}/genemap.gff"
+      tree_exclude_sites: "config/{lineage}/{{segment}}/exclude-sites.txt"
+      clades: "config/{lineage}/ha/clades.tsv"
+      subclades: "config/{lineage}/{{segment}}/subclades.tsv"
+      auspice_config: "config/{lineage}/{{segment}}/auspice_config.json"
+      vaccines: "config/{lineage}/vaccine.json"
+      enable_glycosylation: true
+      enable_lbi: true
+      enable_titer_models: true
+      enable_embeddings: true
+      include: "'config/{lineage}/reference_strains.txt'"
+      exclude: "'config/{lineage}/outliers.txt'"
+      titer_collections:
+        - name: cdc_cell_hi
+          data: "data/{lineage}/cdc_ferret_cell_hi_titers.tsv"
     subsamples: *subsampling-scheme
   3Y-hi-builds:
     patterns:
@@ -188,7 +205,7 @@ array-builds:
       tree_exclude_sites: "config/{lineage}/{{segment}}/exclude-sites.txt"
       clades: "config/{lineage}/ha/clades.tsv"
       subclades: "config/{lineage}/{{segment}}/subclades.tsv"
-      auspice_config: "config/{lineage}/auspice_config.json"
+      auspice_config: "config/{lineage}/{{segment}}/auspice_config.json"
       vaccines: "config/{lineage}/vaccine.json"
       enable_glycosylation: true
       enable_lbi: true


### PR DESCRIPTION
## Description of proposed changes

Adds segment-specific Auspice config JSONs for 2y builds of H1N1pdm, H3N2, and Vic with custom color scales for subclades within each subtype and segment. These color scales match the scales used in the nextflu-private builds, allowing us to include the public trees in our monthly reports and easily switch between private and public trees without changing color schemes across builds.

With this change, we can remove the "representative" builds from the nextflu-private build config, since the public builds already provide equal geographic and temporal sampling.

## Related issue(s)

Closes #164

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
