### PR TITLE
Rename metadata column from `isolate_id` to `gisaid_epi_isl`

### DIFF
--- a/nextclade/Snakefile
+++ b/nextclade/Snakefile
@@ -415,7 +415,7 @@ rule export:
         date=datetime.datetime.utcnow().strftime("%Y-%m-%d"),
     shell:
         """
-        tsv-select -H -f {params.select_fields} {input.metadata} > {input.metadata}.tmp 
+        tsv-select -H -f {params.select_fields} {input.metadata} > {input.metadata}.tmp
         augur export v2 \
             --tree {input.tree} \
             --metadata {input.metadata}.tmp \
@@ -494,4 +494,3 @@ rule clean_all:
         rm -rf datasets
         rm -rf data/
         """
-

--- a/profiles/upload.yaml
+++ b/profiles/upload.yaml
@@ -25,7 +25,7 @@ fasta_fields:
   - strain
   - virus
   - segment
-  - isolate_id
+  - gisaid_epi_isl
   - accession
   - date
   - date_submitted


### PR DESCRIPTION
## Description of proposed changes

The fields to export in acknowledgements is hardcoded in Auspice¹ so the
metadata field needs to be named `gisaid_epi_isl` to be included in
the acknowledgements for the seasonal flu builds. Renaming the column
in our upload config to avoid having to rename it as part of the
phylogenetic workflow.

¹ <https://github.com/nextstrain/auspice/blob/dae78e74d5e06303d901387adf9fe7550a7d4aa9/src/components/download/helperFunctions.js#L326>

## Related issue(s)

First step for https://github.com/nextstrain/seasonal-flu/issues/178

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
