### PR TITLE
Add emerging subclades to nextflu-private builds

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -48,6 +48,21 @@ subclade_url_by_lineage_and_segment = {
     }
 }
 
+emerging_subclade_url_by_lineage_and_segment = {
+    "h1n1pdm": {
+        "ha": "https://raw.githubusercontent.com/influenza-clade-nomenclature/seasonal_A-H1N1pdm_HA/main/.auto-generated/subclades.tsv",
+        "na": "https://raw.githubusercontent.com/influenza-clade-nomenclature/seasonal_A-H1N1pdm_NA/main/.auto-generated/subclades.tsv",
+    },
+    "h3n2": {
+        "ha": "https://raw.githubusercontent.com/influenza-clade-nomenclature/seasonal_A-H3N2_HA/emerging/.auto-generated/subclades.tsv",
+        "na": "https://raw.githubusercontent.com/influenza-clade-nomenclature/seasonal_A-H3N2_NA/main/.auto-generated/subclades.tsv",
+    },
+    "vic": {
+        "ha": "https://raw.githubusercontent.com/influenza-clade-nomenclature/seasonal_B-Vic_HA/main/.auto-generated/subclades.tsv",
+        "na": "https://raw.githubusercontent.com/influenza-clade-nomenclature/seasonal_B-Vic_NA/main/.auto-generated/subclades.tsv",
+    }
+}
+
 if "data_source" in config and config["data_source"]=='fauna':
     include: "workflow/snakemake_rules/download_from_fauna.smk"
 

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -76,6 +76,45 @@
       ]
     },
     {
+      "key": "emerging_subclade",
+      "title": "Emerging subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "J",
+          "#4068CF"
+        ],
+        [
+          "J.1",
+          "#5098B9"
+        ],
+        [
+          "J.1.1",
+          "#6CB28C"
+        ],
+        [
+          "J.2",
+          "#94BD62"
+        ],
+        [
+          "J.2.1",
+          "#BFBB47"
+        ],
+        [
+          "J.2.2",
+          "#DFA53B"
+        ],
+        [
+          "J.3",
+          "#E67131"
+        ],
+        [
+          "J.4",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
       "key": "haplotype",
       "title": "Derived haplotype",
       "type": "categorical"

--- a/nextclade/config/config_dict.yaml
+++ b/nextclade/config/config_dict.yaml
@@ -51,6 +51,9 @@ builds:
         short-clade:
           url: "seasonal_A-H3N2_HA/main/.auto-generated/clades.tsv"
           key: "short-clade"
+        emerging_subclade:
+          url: "seasonal_A-H3N2_HA/emerging/.auto-generated/subclades.tsv"
+          key: "emerging_subclade"
       refs:
         EPI1857216:
           filter: "--min-date 2019 --probabilistic-sampling --group-by year region --min-length 1500 --subsample-max-sequences 2000"

--- a/profiles/nextflu-private-forecasts.yaml
+++ b/profiles/nextflu-private-forecasts.yaml
@@ -57,6 +57,7 @@ array-builds:
       tree_exclude_sites: "config/h3n2/{{segment}}/exclude-sites.txt"
       clades: "config/h3n2/ha/clades.tsv"
       subclades: "config/h3n2/ha/subclades.tsv"
+      emerging_subclades: "config/h3n2/ha/emerging_subclades.tsv"
       auspice_config: "profiles/nextflu-private/h3n2/ha/auspice_config.json"
       vaccines: "config/h3n2/vaccine.json"
       enable_titer_models: true

--- a/profiles/nextflu-private.yaml
+++ b/profiles/nextflu-private.yaml
@@ -56,6 +56,7 @@ builds:
     tree_exclude_sites: "config/h1n1pdm/{segment}/exclude-sites.txt"
     clades: "config/h1n1pdm/ha/clades.tsv"
     subclades: "config/h1n1pdm/{segment}/subclades.tsv"
+    emerging_subclades: "config/h1n1pdm/{segment}/emerging_subclades.tsv"
     auspice_config: "profiles/nextflu-private/h1n1pdm/{segment}/auspice_config.json"
     min_date: "2Y"
     reference_min_date: "6Y"
@@ -104,6 +105,7 @@ builds:
     tree_exclude_sites: "config/h3n2/{segment}/exclude-sites.txt"
     clades: "config/h3n2/ha/clades.tsv"
     subclades: "config/h3n2/{segment}/subclades.tsv"
+    emerging_subclades: "config/h3n2/{segment}/emerging_subclades.tsv"
     auspice_config: "profiles/nextflu-private/h3n2/{segment}/auspice_config.json"
     vaccines: "config/h3n2/vaccine.json"
     enable_glycosylation: true
@@ -149,6 +151,7 @@ builds:
     tree_exclude_sites: "config/vic/{segment}/exclude-sites.txt"
     clades: "profiles/nextflu-private/vic/ha/clades.tsv"
     subclades: "config/vic/{segment}/subclades.tsv"
+    emerging_subclades: "config/h3n2/{segment}/emerging_subclades.tsv"
     auspice_config: "profiles/nextflu-private/vic/{segment}/auspice_config.json"
     min_date: "2Y"
     reference_min_date: "6Y"

--- a/profiles/nextflu-private/h1n1pdm/ha/auspice_config.json
+++ b/profiles/nextflu-private/h1n1pdm/ha/auspice_config.json
@@ -130,6 +130,69 @@
       ]
     },
     {
+      "key": "emerging_subclade",
+      "title": "Emerging subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "C.1",
+          "#492AB5"
+        ],
+        [
+          "C.1.1",
+          "#3F4CCB"
+        ],
+        [
+          "C.1.2",
+          "#4271CE"
+        ],
+        [
+          "C.1.5",
+          "#4C8FC0"
+        ],
+        [
+          "C.1.7",
+          "#5AA5A8"
+        ],
+        [
+          "C.1.7.1",
+          "#6DB38A"
+        ],
+        [
+          "C.1.7.2",
+          "#85BA6F"
+        ],
+        [
+          "C.1.8",
+          "#A0BE59"
+        ],
+        [
+          "C.1.9",
+          "#BBBC49"
+        ],
+        [
+          "D",
+          "#D2B340"
+        ],
+        [
+          "D.1",
+          "#E19F3A"
+        ],
+        [
+          "D.2",
+          "#E68033"
+        ],
+        [
+          "D.3",
+          "#E2562B"
+        ],
+        [
+          "D.4",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
       "key": "haplotype",
       "title": "Derived haplotype",
       "type": "categorical"

--- a/profiles/nextflu-private/h3n2/ha/auspice_config.json
+++ b/profiles/nextflu-private/h3n2/ha/auspice_config.json
@@ -142,6 +142,45 @@
       ]
     },
     {
+      "key": "emerging_subclade",
+      "title": "Emerging subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "J",
+          "#4068CF"
+        ],
+        [
+          "J.1",
+          "#5098B9"
+        ],
+        [
+          "J.1.1",
+          "#6CB28C"
+        ],
+        [
+          "J.2",
+          "#94BD62"
+        ],
+        [
+          "J.2.1",
+          "#BFBB47"
+        ],
+        [
+          "J.2.2",
+          "#DFA53B"
+        ],
+        [
+          "J.3",
+          "#E67131"
+        ],
+        [
+          "J.4",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
       "key": "haplotype",
       "title": "Derived haplotype",
       "type": "categorical"

--- a/profiles/nextflu-private/vic/ha/auspice_config.json
+++ b/profiles/nextflu-private/vic/ha/auspice_config.json
@@ -80,6 +80,41 @@
       ]
     },
     {
+      "key": "emerging_subclade",
+      "title": "Emerging subclade",
+      "type": "categorical",
+      "scale": [
+        [
+          "C.2",
+          "#4272CE"
+        ],
+        [
+          "C.3",
+          "#58A2AC"
+        ],
+        [
+          "C.5",
+          "#7DB877"
+        ],
+        [
+          "C.5.1",
+          "#AEBD50"
+        ],
+        [
+          "C.5.4",
+          "#D8AE3E"
+        ],
+        [
+          "C.5.6",
+          "#E67A32"
+        ],
+        [
+          "C.5.7",
+          "#DB2823"
+        ]
+      ]
+    },
+    {
       "key": "haplotype",
       "title": "Derived haplotype",
       "type": "categorical"

--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -205,6 +205,7 @@ array-builds:
       tree_exclude_sites: "config/{lineage}/{{segment}}/exclude-sites.txt"
       clades: "config/{lineage}/ha/clades.tsv"
       subclades: "config/{lineage}/{{segment}}/subclades.tsv"
+      emerging_subclades: "config/h3n2/{{segment}}/emerging_subclades.tsv"
       auspice_config: "config/{lineage}/{{segment}}/auspice_config.json"
       vaccines: "config/{lineage}/vaccine.json"
       enable_glycosylation: true

--- a/workflow/snakemake_rules/export.smk
+++ b/workflow/snakemake_rules/export.smk
@@ -23,6 +23,9 @@ def _get_node_data_by_wildcards(wildcards):
     if config["builds"][wildcards.build_name].get('subclades', False):
         inputs.append(rules.subclades.output.node_data)
 
+    if config["builds"][wildcards.build_name].get('emerging_subclades', False):
+        inputs.append(rules.emerging_subclades.output.node_data)
+
     if config["builds"][wildcards.build_name].get('enable_titer_models', False) and wildcards.segment == 'ha':
         for collection in config["builds"][wildcards.build_name]["titer_collections"]:
             inputs.append(rules.titers_sub.output.titers_model.format(titer_collection=collection["name"], **wildcards_dict))

--- a/workflow/snakemake_rules/fitness.smk
+++ b/workflow/snakemake_rules/fitness.smk
@@ -380,6 +380,8 @@ rule forecast_tips:
         "benchmarks/forecast_tips_{build_name}_{segment}_{model}.txt"
     log:
         "logs/forecast_tips_{build_name}_{segment}_{model}.txt"
+    resources:
+        mem_mb=8000,
     shell:
         """
         python3 flu-forecasting/src/forecast_model.py \


### PR DESCRIPTION
## Description of proposed changes

Adds rules and configs to annotate emerging subclades to nextflu-private builds, paving the way for any builds that define the `emerging_subclade` path in their config to use the same clade definitions. Most of these emerging subclades map directly to the main branch in the corresponding influenza nomenclature repos. H3N2 HA is an exception where the definitions come from a branch called `emerging`.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
