### PR TITLE
Run Nextclade on all 8 genes for H1 and H3

### DIFF
--- a/profiles/nextclade.yaml
+++ b/profiles/nextclade.yaml
@@ -7,6 +7,12 @@ s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu"
 segments:
   - ha
   - na
+  - pb2
+  - pb1
+  - pa
+  - np
+  - mp
+  - ns
 
 builds:
   h1n1pdm:
@@ -15,3 +21,6 @@ builds:
     lineage: h3n2
   vic:
     lineage: vic
+    segments:
+      - ha
+      - na

--- a/profiles/nextclade/run-nextclade.smk
+++ b/profiles/nextclade/run-nextclade.smk
@@ -4,7 +4,7 @@ rule upload_all_nextclade_files:
             "data/upload/s3/{filetype}_{lineage}_{segment}.done".format(filetype=filetype, lineage=build["lineage"], segment=segment)
             for filetype in ("alignment", "nextclade")
             for build in config["builds"].values()
-            for segment in config["segments"]
+            for segment in build.get("segments", config["segments"])
         ]
 
 rule get_nextclade_dataset_for_lineage_and_segment:

--- a/profiles/nextclade/run-nextclade.smk
+++ b/profiles/nextclade/run-nextclade.smk
@@ -13,7 +13,7 @@ rule get_nextclade_dataset_for_lineage_and_segment:
     shell:
         """
         nextclade3 dataset get \
-            -n flu_{wildcards.lineage}_{wildcards.segment} \
+            -n 'nextstrain/flu/{wildcards.lineage}/{wildcards.segment}' \
             --output-dir {output.nextclade_dir}
         """
 


### PR DESCRIPTION
## Description of proposed changes

Adds remaining gene segments to the default list of segments to process with Nextclade. Since B/Vic only has HA and NA Nextclades datasets right now, this commit modifies the logic of the workflow to look for a build-specific list of segments and defines that list for the Vic build.

## Related issue(s)

Follows from #183

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Test GitHub Action from this branch](https://github.com/nextstrain/seasonal-flu/actions/runs/11351557827)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
