### PR TITLE
Remove `gisaid_epi_isl` from auspice_config JSONs

### DIFF
--- a/config/h1n1pdm/auspice_config.json
+++ b/config/h1n1pdm/auspice_config.json
@@ -156,7 +156,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h1n1pdm/ha/auspice_config.json
+++ b/config/h1n1pdm/ha/auspice_config.json
@@ -231,7 +231,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h1n1pdm/na/auspice_config.json
+++ b/config/h1n1pdm/na/auspice_config.json
@@ -196,7 +196,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h3n2/auspice_config.json
+++ b/config/h3n2/auspice_config.json
@@ -166,7 +166,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h3n2/auspice_config_fitness.json
+++ b/config/h3n2/auspice_config_fitness.json
@@ -154,7 +154,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -248,7 +248,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h3n2/na/auspice_config.json
+++ b/config/h3n2/na/auspice_config.json
@@ -181,7 +181,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/vic/auspice_config.json
+++ b/config/vic/auspice_config.json
@@ -141,7 +141,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/vic/ha/auspice_config.json
+++ b/config/vic/ha/auspice_config.json
@@ -188,7 +188,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/vic/na/auspice_config.json
+++ b/config/vic/na/auspice_config.json
@@ -181,7 +181,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]

--- a/config/yam/auspice_config.json
+++ b/config/yam/auspice_config.json
@@ -119,7 +119,6 @@
     "frequencies"
   ],
   "metadata_columns": [
-    "gisaid_epi_isl",
     "accession_ha",
     "accession_na"
   ]


### PR DESCRIPTION
## Description of proposed changes

Temporarily dropping `gisaid_epi_isl` after discussion on Slack¹ about the duplicate accessions we are seeing with cell/egg passaged sequences. Once we update the data model to accurately link virus record and sequence record, we can add it back.

¹ <https://bedfordlab.slack.com/archives/C03KWDET9/p1729271930916079>


## Related issue(s)

Follow up to https://github.com/nextstrain/seasonal-flu/pull/180
Related to https://github.com/nextstrain/fauna/issues/165

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Run public builds on this branch](https://github.com/nextstrain/seasonal-flu/actions/runs/11410905690)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
