### PR TITLE
Include original GISAID strain name in metadata

### DIFF
--- a/config/h1n1pdm/ha/auspice_config.json
+++ b/config/h1n1pdm/ha/auspice_config.json
@@ -210,7 +210,8 @@
   ],
   "display_defaults": {
     "map_triplicate": true,
-    "color_by": "clade_membership"
+    "color_by": "clade_membership",
+    "tip_label": "gisaid_strain"
   },
   "filters": [
     "clade_membership",

--- a/config/h1n1pdm/ha/auspice_config.json
+++ b/config/h1n1pdm/ha/auspice_config.json
@@ -231,6 +231,7 @@
     "frequencies"
   ],
   "metadata_columns": [
+    "gisaid_strain",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h1n1pdm/na/auspice_config.json
+++ b/config/h1n1pdm/na/auspice_config.json
@@ -175,7 +175,8 @@
   ],
   "display_defaults": {
     "map_triplicate": true,
-    "color_by": "clade_membership"
+    "color_by": "clade_membership",
+    "tip_label": "gisaid_strain"
   },
   "filters": [
     "clade_membership",

--- a/config/h1n1pdm/na/auspice_config.json
+++ b/config/h1n1pdm/na/auspice_config.json
@@ -196,6 +196,7 @@
     "frequencies"
   ],
   "metadata_columns": [
+    "gisaid_strain",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -248,6 +248,7 @@
     "frequencies"
   ],
   "metadata_columns": [
+    "gisaid_strain",
     "accession_ha",
     "accession_na"
   ]

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -227,7 +227,8 @@
   ],
   "display_defaults": {
     "map_triplicate": true,
-    "color_by": "clade_membership"
+    "color_by": "clade_membership",
+    "tip_label": "gisaid_strain"
   },
   "filters": [
     "clade_membership",

--- a/config/h3n2/na/auspice_config.json
+++ b/config/h3n2/na/auspice_config.json
@@ -160,7 +160,8 @@
   ],
   "display_defaults": {
     "map_triplicate": true,
-    "color_by": "clade_membership"
+    "color_by": "clade_membership",
+    "tip_label": "gisaid_strain"
   },
   "filters": [
     "clade_membership",

--- a/config/h3n2/na/auspice_config.json
+++ b/config/h3n2/na/auspice_config.json
@@ -181,6 +181,7 @@
     "frequencies"
   ],
   "metadata_columns": [
+    "gisaid_strain",
     "accession_ha",
     "accession_na"
   ]

--- a/config/vic/ha/auspice_config.json
+++ b/config/vic/ha/auspice_config.json
@@ -167,7 +167,8 @@
   ],
   "display_defaults": {
     "map_triplicate": true,
-    "color_by": "clade_membership"
+    "color_by": "clade_membership",
+    "tip_label": "gisaid_strain"
   },
   "filters": [
     "clade_membership",

--- a/config/vic/ha/auspice_config.json
+++ b/config/vic/ha/auspice_config.json
@@ -188,6 +188,7 @@
     "frequencies"
   ],
   "metadata_columns": [
+    "gisaid_strain",
     "accession_ha",
     "accession_na"
   ]

--- a/config/vic/na/auspice_config.json
+++ b/config/vic/na/auspice_config.json
@@ -160,7 +160,8 @@
   ],
   "display_defaults": {
     "map_triplicate": true,
-    "color_by": "clade_membership"
+    "color_by": "clade_membership",
+    "tip_label": "gisaid_strain"
   },
   "filters": [
     "clade_membership",

--- a/config/vic/na/auspice_config.json
+++ b/config/vic/na/auspice_config.json
@@ -181,6 +181,7 @@
     "frequencies"
   ],
   "metadata_columns": [
+    "gisaid_strain",
     "accession_ha",
     "accession_na"
   ]

--- a/profiles/nextflu-private-forecasts.yaml
+++ b/profiles/nextflu-private-forecasts.yaml
@@ -4,30 +4,6 @@ custom_rules:
   - profiles/nextflu-private-forecasts/zoltar.smk
   - profiles/nextflu-private-forecasts/rename.smk
 
-fasta_fields:
-  - strain
-  - virus
-  - segment
-  - accession
-  - date
-  - date_submitted
-  - region
-  - country
-  - division
-  - location
-  - passage_category
-  - originating_lab
-  - submitting_lab
-  - age
-  - gender
-prettify_fields:
-  - region
-  - country
-  - division
-  - location
-  - originating_lab
-  - submitting_lab
-
 lat-longs: "config/lat_longs.tsv"
 
 segments:

--- a/profiles/nextflu-private.yaml
+++ b/profiles/nextflu-private.yaml
@@ -7,30 +7,6 @@ custom_rules:
 # URL for auto-deploying builds
 deploy_url: https://nextstrain.org/groups/nextflu-private/
 
-fasta_fields:
-  - strain
-  - virus
-  - segment
-  - accession
-  - date
-  - date_submitted
-  - region
-  - country
-  - division
-  - location
-  - passage_category
-  - originating_lab
-  - submitting_lab
-  - age
-  - gender
-prettify_fields:
-  - region
-  - country
-  - division
-  - location
-  - originating_lab
-  - submitting_lab
-
 lat-longs: "config/lat_longs.tsv"
 
 segments:

--- a/profiles/nextflu-private/h1n1pdm/ha/auspice_config.json
+++ b/profiles/nextflu-private/h1n1pdm/ha/auspice_config.json
@@ -461,5 +461,10 @@
     "map",
     "entropy",
     "frequencies"
+  ],
+  "metadata_columns": [
+    "gisaid_strain",
+    "accession_ha",
+    "accession_na"
   ]
 }

--- a/profiles/nextflu-private/h1n1pdm/na/auspice_config.json
+++ b/profiles/nextflu-private/h1n1pdm/na/auspice_config.json
@@ -202,5 +202,10 @@
     "map",
     "entropy",
     "frequencies"
+  ],
+  "metadata_columns": [
+    "gisaid_strain",
+    "accession_ha",
+    "accession_na"
   ]
 }

--- a/profiles/nextflu-private/h3n2/ha/auspice_config.json
+++ b/profiles/nextflu-private/h3n2/ha/auspice_config.json
@@ -593,5 +593,10 @@
     "map",
     "entropy",
     "frequencies"
+  ],
+  "metadata_columns": [
+    "gisaid_strain",
+    "accession_ha",
+    "accession_na"
   ]
 }

--- a/profiles/nextflu-private/h3n2/na/auspice_config.json
+++ b/profiles/nextflu-private/h3n2/na/auspice_config.json
@@ -236,5 +236,10 @@
     "map",
     "entropy",
     "frequencies"
+  ],
+  "metadata_columns": [
+    "gisaid_strain",
+    "accession_ha",
+    "accession_na"
   ]
 }

--- a/profiles/nextflu-private/vic/ha/auspice_config.json
+++ b/profiles/nextflu-private/vic/ha/auspice_config.json
@@ -303,5 +303,10 @@
     "map",
     "entropy",
     "frequencies"
+  ],
+  "metadata_columns": [
+    "gisaid_strain",
+    "accession_ha",
+    "accession_na"
   ]
 }

--- a/profiles/nextflu-private/vic/na/auspice_config.json
+++ b/profiles/nextflu-private/vic/na/auspice_config.json
@@ -180,5 +180,10 @@
     "map",
     "entropy",
     "frequencies"
+  ],
+  "metadata_columns": [
+    "gisaid_strain",
+    "accession_ha",
+    "accession_na"
   ]
 }

--- a/profiles/nextstrain-public-yamagata.yaml
+++ b/profiles/nextstrain-public-yamagata.yaml
@@ -6,30 +6,6 @@ custom_rules:
 # URL for auto-deploying builds
 deploy_url: s3://nextstrain-data
 
-fasta_fields:
-  - strain
-  - virus
-  - segment
-  - accession
-  - date
-  - date_submitted
-  - region
-  - country
-  - division
-  - location
-  - passage_category
-  - originating_lab
-  - submitting_lab
-  - age
-  - gender
-prettify_fields:
-  - region
-  - country
-  - division
-  - location
-  - originating_lab
-  - submitting_lab
-
 lat-longs: "config/lat_longs.tsv"
 
 segments:

--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -6,30 +6,6 @@ custom_rules:
 # URL for auto-deploying builds
 deploy_url: s3://nextstrain-data
 
-fasta_fields:
-  - strain
-  - virus
-  - segment
-  - accession
-  - date
-  - date_submitted
-  - region
-  - country
-  - division
-  - location
-  - passage_category
-  - originating_lab
-  - submitting_lab
-  - age
-  - gender
-prettify_fields:
-  - region
-  - country
-  - division
-  - location
-  - originating_lab
-  - submitting_lab
-
 lat-longs: "config/lat_longs.tsv"
 
 segments:

--- a/profiles/private.nextflu.org.yaml
+++ b/profiles/private.nextflu.org.yaml
@@ -2,30 +2,6 @@ custom_rules:
   - workflow/snakemake_rules/download_from_s3.smk
   - profiles/private.nextflu.org/export.smk
 
-fasta_fields:
-  - strain
-  - virus
-  - segment
-  - accession
-  - date
-  - date_submitted
-  - region
-  - country
-  - division
-  - location
-  - passage_category
-  - originating_lab
-  - submitting_lab
-  - age
-  - gender
-prettify_fields:
-  - region
-  - country
-  - division
-  - location
-  - originating_lab
-  - submitting_lab
-
 lat-longs: "config/lat_longs.tsv"
 
 segments:

--- a/profiles/upload.yaml
+++ b/profiles/upload.yaml
@@ -21,6 +21,7 @@ fauna_fasta_fields:
   - submitting_lab
   - age
   - gender
+  - gisaid_strain
 fasta_fields:
   - strain
   - virus
@@ -38,6 +39,7 @@ fasta_fields:
   - submitting_lab
   - age
   - gender
+  - gisaid_strain
 prettify_fields:
   - region
   - country


### PR DESCRIPTION
## Description of proposed changes

 - [x] Add the GISAID strain name to list of fields to fetch from fauna in and parse from the raw sequences FASTA in the "upload" workflow. This change will include these original names in the metadata in S3.
 - [x] Export GISAID strain names as a metadata column in Auspice JSONs
 - [x] Set GISAID strain names as default tip label

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
