### PR TITLE
Refine proposed subclades in Nextclade datasets

### DIFF
--- a/nextclade/config/auspice_config.json
+++ b/nextclade/config/auspice_config.json
@@ -25,7 +25,7 @@
       "type": "categorical"
     },
     {
-      "key": "proposed_clade",
+      "key": "proposed_subclade",
       "title": "Subclade proposals",
       "type": "categorical"
     },

--- a/nextclade/config/config_dict.yaml
+++ b/nextclade/config/config_dict.yaml
@@ -14,9 +14,9 @@ builds:
         subclade:
           url: "seasonal_A-H1N1pdm_HA/main/.auto-generated/subclades.tsv"
           key: "subclade"
-        proposed_clade:
+        proposed_subclade:
           url: "seasonal_A-H1N1pdm_HA/main/.auto-generated/subclade_proposals.tsv"
-          key: "proposed_clade"
+          key: "proposed_subclade"
       refs:
         CY121680: # exclude South Korean genomes because of sequencing artifacts close to the start of HA
           filter: "--min-date 2009 --probabilistic-sampling  --exclude-where country='south_korea' qc.overallStatus='bad' --group-by year --min-length 1500  --subsample-max-sequences 1500"
@@ -35,9 +35,9 @@ builds:
       clade_systems:
         clade:
           url: "seasonal_A-H1N1pdm_NA/main/.auto-generated/subclades.tsv"
-        proposed_clade:
+        proposed_subclade:
           url: "seasonal_A-H1N1pdm_NA/main/.auto-generated/subclade_proposals.tsv"
-          key: "proposed_clade"
+          key: "proposed_subclade"
       refs:
         MW626056:
           filter: "--min-date 2019 --probabilistic-sampling --group-by year region --min-length 1400 --subsample-max-sequences 2000"
@@ -57,9 +57,9 @@ builds:
         short-clade:
           url: "seasonal_A-H3N2_HA/main/.auto-generated/clades.tsv"
           key: "short-clade"
-        proposed_clade:
+        proposed_subclade:
           url: "seasonal_A-H3N2_HA/main/.auto-generated/subclade_proposals.tsv"
-          key: "proposed_clade"
+          key: "proposed_subclade"
       refs:
         EPI1857216:
           filter: "--min-date 2019 --probabilistic-sampling --group-by year region --min-length 1500 --subsample-max-sequences 2000"
@@ -78,9 +78,9 @@ builds:
       clade_systems:
         clade:
           url: "seasonal_A-H3N2_NA/main/.auto-generated/subclades.tsv"
-        proposed_clade:
+        proposed_subclade:
           url: "seasonal_A-H3N2_NA/main/.auto-generated/subclade_proposals.tsv"
-          key: "proposed_clade"
+          key: "proposed_subclade"
       refs:
         EPI1857215:
           filter: "--min-date 2019 --probabilistic-sampling --group-by year region --min-length 1400 --subsample-max-sequences 1500"
@@ -97,9 +97,9 @@ builds:
         subclade:
           url: "seasonal_B-Vic_HA/main/.auto-generated/subclades.tsv"
           key: "subclade"
-        proposed_clade:
+        proposed_subclade:
           url: "seasonal_B-Vic_HA/main/.auto-generated/subclade_proposals.tsv"
-          key: "proposed_clade"
+          key: "proposed_subclade"
       refs:
         KX058884:
           filter: "--min-date 2014 --probabilistic-sampling --group-by year --min-length 1500 --subsample-max-sequences 2000"
@@ -112,9 +112,9 @@ builds:
       clade_systems:
         clade:
           url: "seasonal_B-Vic_NA/main/.auto-generated/subclades.tsv"
-        proposed_clade:
+        proposed_subclade:
           url: "seasonal_B-Vic_NA/main/.auto-generated/subclade_proposals.tsv"
-          key: "proposed_clade"
+          key: "proposed_subclade"
       refs:
         CY073894:
           filter: "--min-date 2014 --probabilistic-sampling --group-by year region --min-length 1400 --subsample-max-sequences 2000"

--- a/nextclade/dataset_config/h1n1pdm/includes.txt
+++ b/nextclade/dataset_config/h1n1pdm/includes.txt
@@ -59,3 +59,4 @@ A/Helsinki/2430/2012
 A/Gansu-Ganzhou/SWL34/2012
 A/Brisbane/96/2012
 A/Minnesota/23/2014
+A/Nagano/2649/2018

--- a/nextclade/scripts/merge_jsons.py
+++ b/nextclade/scripts/merge_jsons.py
@@ -18,13 +18,12 @@ def get_clade_configs(name):
         "displayName": "Subclade",
         "description": "Experimental fine-grained subclade annotation."
     },
-    "proposed_clade": {
+    "proposed_subclade": {
         "name": "Subclade proposal",
         "displayName": "Subclade proposal",
         "description": "Includes proposals of new subclades. These can change anytime.",
         "hideInWeb": True
-        }
-    }.get(name, {'name':name, "displayName":name, "description":""})
+    }}.get(name, {'name':name, "displayName":name, "description":""})
 
 
 if __name__=="__main__":
@@ -73,4 +72,3 @@ if __name__=="__main__":
 
     with open(args.output_auspice, 'w') as fh:
         json.dump(auspice_json, fh, indent=2)
-


### PR DESCRIPTION
## Description of proposed changes

 - Adds a 6B.1A.4 strain to list of strains to be force included in the Nextclade datasets for H1 HA trees.
 - Renames `proposed_clade` to `proposed_subclade` to clarify that the values are consistent with the newer subclades. Uses the underscore delimiter to be consistent with most other annotations in the flu builds (e.g., `num_date`, `ne_star`, `submitting_lab`, etc.).

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Related to b09a5019316203ef2463a6da741db01cc7c2d140
Required for https://github.com/nextstrain/nextclade_data/pull/236
Required for #193 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
