### PR TITLE
Add Nextclade extension to public builds

### DIFF
--- a/config/h1n1pdm/auspice_config.json
+++ b/config/h1n1pdm/auspice_config.json
@@ -158,5 +158,16 @@
   "metadata_columns": [
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/h1n1pdm/ha/auspice_config.json
+++ b/config/h1n1pdm/ha/auspice_config.json
@@ -263,5 +263,16 @@
     "gisaid_strain",
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/h1n1pdm/na/auspice_config.json
+++ b/config/h1n1pdm/na/auspice_config.json
@@ -196,5 +196,16 @@
     "gisaid_strain",
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/h3n2/auspice_config.json
+++ b/config/h3n2/auspice_config.json
@@ -168,5 +168,16 @@
   "metadata_columns": [
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -253,5 +253,16 @@
     "gisaid_strain",
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/h3n2/na/auspice_config.json
+++ b/config/h3n2/na/auspice_config.json
@@ -209,5 +209,16 @@
     "gisaid_strain",
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/vic/auspice_config.json
+++ b/config/vic/auspice_config.json
@@ -143,5 +143,16 @@
   "metadata_columns": [
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/vic/ha/auspice_config.json
+++ b/config/vic/ha/auspice_config.json
@@ -228,5 +228,16 @@
     "gisaid_strain",
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/config/vic/na/auspice_config.json
+++ b/config/vic/na/auspice_config.json
@@ -221,5 +221,16 @@
     "gisaid_strain",
     "accession_ha",
     "accession_na"
-  ]
+  ],
+  "extensions": {
+    "nextclade": {
+      "clade_node_attrs": [
+        {
+          "name": "subclade",
+          "displayName": "Subclade",
+          "description": "Experimental fine-grained subclade annotation."
+        }
+      ]
+    }
+  }
 }

--- a/profiles/ci/builds.yaml
+++ b/profiles/ci/builds.yaml
@@ -50,6 +50,7 @@ builds:
       annotation: "config/h3n2/{segment}/genemap.gff"
       tree_exclude_sites: "config/h3n2/{segment}/exclude-sites.txt"
       clades: "config/h3n2/ha/clades.tsv"
+      subclades: "config/h3n2/{segment}/subclades.tsv"
       min_date: "12Y"
       auspice_config: "config/h3n2/auspice_config.json"
       enable_titer_models: true


### PR DESCRIPTION
## Description of proposed changes

Adds Nextclade extension with "subclade" annotation to Auspice config for all public builds, allowing users to get these subclade annotations from Nextclade for any public tree.

To test this functionality, I added subclade annotations to the CI build and confirmed that the extension worked as expected by uploading [the CI Auspice JSON to the staging server](https://nextstrain.org/staging/ci/build/ha) before and after I included the extension in the JSON.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Confirm that Nextclade annotations from CI build on staging show subclade

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
