### PR TITLE
Limit concurrent fauna connections to 2

### DIFF
--- a/workflow/snakemake_rules/download_from_fauna.smk
+++ b/workflow/snakemake_rules/download_from_fauna.smk
@@ -48,7 +48,6 @@ def _get_virus_passage_category(wildcards):
         return ""
 
 rule download_sequences:
-    message: "Downloading sequences from fauna"
     output:
         sequences = "data/{lineage}/raw_{segment}.fasta"
     params:

--- a/workflow/snakemake_rules/download_from_fauna.smk
+++ b/workflow/snakemake_rules/download_from_fauna.smk
@@ -9,6 +9,12 @@ titers = "data/{lineage}/{center}_{passage}_{assay}_titers.tsv"
 
 '''
 
+# Limit the number of concurrent fauna connections so that we are less likely
+# to overwhelm the rethinkdb server.
+# Inspired by the ncov's limit on concurrent deploy jobs
+# <https://github.com/nextstrain/ncov/blob/20f5fc3c7032f4575a99745cee3238ecbeebb6e0/workflow/snakemake_rules/export_for_nextstrain.smk#L340-L362>
+workflow.global_resources.setdefault("concurrent_fauna", 2)
+
 # fields that will be canonicized by augur parse (upper/lower casing etc)
 
 path_to_fauna = '../fauna'
@@ -47,6 +53,8 @@ rule download_sequences:
         sequences = "data/{lineage}/raw_{segment}.fasta"
     params:
         fasta_fields = config["fauna_fasta_fields"],
+    resources:
+        concurrent_fauna = 1
     conda: "../envs/nextstrain.yaml"
     benchmark:
         "benchmarks/download_sequences_{lineage}_{segment}.txt"
@@ -71,6 +79,8 @@ rule download_titers:
         dbs = _get_tdb_databases,
         assays = _get_tdb_assays,
         virus_passage_category=_get_virus_passage_category,
+    resources:
+        concurrent_fauna = 1
     conda: "../envs/nextstrain.yaml"
     benchmark:
         "benchmarks/download_titers_{lineage}_{center}_{passage}_{assay}.txt"


### PR DESCRIPTION
## Description of proposed changes
The latest upload workflow¹ seemed to overwhelm the rethinkdb server so limiting concurrent fauna connections to see if it would prevent the OOM error.

Use of Snakemake's `workflow.global_resources` inspired by the ncov use to limit concurrent deploy jobs.² Doing this instead of limiting the overall number of Snakemake jobs with `-j` because there are other rules in the workflow that can run without connections to fauna.

¹ <https://github.com/nextstrain/seasonal-flu/actions/runs/12715154181/job/35446799658> 
² <https://github.com/nextstrain/ncov/blob/20f5fc3c7032f4575a99745cee3238ecbeebb6e0/workflow/snakemake_rules/export_for_nextstrain.smk#L340-L362>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Upload workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/12717813013)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
