### PR TITLE
Update DistrictofColumbia/27 to DistrictOfColumbia/27

### DIFF
--- a/config/h3n2/reference_strains.txt
+++ b/config/h3n2/reference_strains.txt
@@ -47,7 +47,7 @@ A/Darwin/9/2021
 A/Darwin/9/2021-egg
 A/Delaware/32/2016
 A/Delaware/39/2019
-A/DistrictofColumbia/27/2023
+A/DistrictOfColumbia/27/2023
 A/England/214191723/2021
 A/Fiji/2/2015
 A/Florida/23/2017

--- a/config/h3n2/vaccine.json
+++ b/config/h3n2/vaccine.json
@@ -90,7 +90,7 @@
                 "selection_date": "2023-09-29"
             }
         },
-        "A/DistrictofColumbia/27/2023": {
+        "A/DistrictOfColumbia/27/2023": {
             "vaccine": {
                 "selection_date": "2024-09-27"
             }

--- a/config/references_for_titer_plots/h3n2/cell_fra.txt
+++ b/config/references_for_titer_plots/h3n2/cell_fra.txt
@@ -7,7 +7,6 @@ A/Nevada/32/2023 # J.2
 A/Croatia/10136/RV/2023 # J.2:145N, vaccine strain
 A/Croatia/10136RV/2023 # J.2:145N, vaccine strain
 A/DistrictOfColumbia/27/2023 # J.2:145N, vaccine strain
-A/DistrictofColumbia/27/2023 # J.2:145N, vaccine strain
 A/Victoria/2997/2023 # J.2:145N
 A/Oklahoma/5/2024 # J.2:158K
 A/Victoria/488/2024 # J.2:158K,207R,227S

--- a/config/references_for_titer_plots/h3n2/cell_hi.txt
+++ b/config/references_for_titer_plots/h3n2/cell_hi.txt
@@ -8,7 +8,6 @@ A/Victoria/2997/2023 # J.2:145N
 A/Croatia/10136/RV/2023 # J.2:145N, vaccine strain
 A/Croatia/10136RV/2023 # J.2:145N, vaccine strain
 A/DistrictOfColumbia/27/2023 # J.2:145N, vaccine strain
-A/DistrictofColumbia/27/2023 # J.2:145N, vaccine strain
 A/Victoria/488/2024 # J.2:158K,207R,227S
 A/Colorado/6/2024 # J.2.1
 A/Switzerland/47775/2024 # J.2.1:309I,63K,189R,208I


### PR DESCRIPTION
## Description of proposed changes

As part of clean up in https://github.com/nextstrain/fauna/issues/174, the strain name "A/DistrictofColumbia/27/2023" has been updated to "A/DistrictOfColumbia/27/2023" to follow our standard capitalization of DC in strain names.

Removed the now duplicate entries from references_for_titer_plots.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
