### PR TITLE
Add concurrency restriction to upload GH Action

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -37,6 +37,11 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}
+  # Only cancel in progress workflow if the workflow is running on the default branch
+  cancel-in-progress: ${{ github.ref_name == github.event.repository.default_branch }}
+
 jobs:
   upload:
     permissions:


### PR DESCRIPTION
## Description of proposed changes

Prevent multiple upload GH Action workflows from running so that they can't overwhelm Fauna. Cancels in progress workflow if the triggered workflow is running on the default branch to prioritize new uploads after manual ingest.

Prompted by recent back to back upload workflows [[1](https://github.com/nextstrain/seasonal-flu/actions/runs/12955578776), [2](https://github.com/nextstrain/seasonal-flu/actions/runs/12956817347)].

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
