### PR TITLE
Update h1n1pdm/reference_strains.txt

### DIFF
--- a/config/h1n1pdm/reference_strains.txt
+++ b/config/h1n1pdm/reference_strains.txt
@@ -134,6 +134,7 @@ A/Victoria/2455/2019
 A/Victoria/2570/2019
 A/Victoria/2570/2019-egg
 A/Victoria/367/2012
+A/Victoria/4897/2022
 A/Victoria/4897/2022-egg
 A/Victoria/503/2016
 A/Washington/19/2020


### PR DESCRIPTION
## Description of proposed changes

Originally brought up by @huddlej on [Slack](https://bedfordlab.slack.com/archives/C03KWDET9/p1738239966102509) that the titer data was missing in the private builds. 

Adding A/Victoria/4897/2022 to make sure that it's titer data gets included in builds even though the strain no longer passes the minimum date cutoff of 2 years.

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
