### PR TITLE
Add script and template to automate narratives

### DIFF
--- a/narratives_template/nextstrain-cdc.md.jinja
+++ b/narratives_template/nextstrain-cdc.md.jinja
@@ -61,7 +61,7 @@ The "delta frequency" is the change in frequency between the current frequency a
 {{h1n1pdm_haplotypes}}
 ```
 
-# [H1N1pdm antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h1n1pdm/2y/titers/ha?d=tree,measurements&f_year_month={{year_month_filter}}&label=clade:5a.2a&mf_proposed_subclade_reference=C.1.1&mf_proposed_subclade_reference=C.1.9&mf_proposed_subclade_reference=C.1.9.c&mf_proposed_subclade_reference=D.1&p=grid)
+# [H1N1pdm antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h1n1pdm/2y/titers/ha?d=tree,measurements&f_year_month={{year_month_filter}}&label=clade:5a.2a&p=grid)
 
 # [H1N1pdm antigenic advance](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h1n1pdm/2y/titers/ha?branchLabel=none&c=proposed_subclade&d=tree&f_year_month={{year_month_filter}}&l=scatter&label=clade:5a.2a&p=full&scatterX=proposed_subclade&scatterY=cell_hi_cTiterSub)
 
@@ -103,11 +103,11 @@ The "delta frequency" is the change in frequency between the current frequency a
 {{h3n2_haplotypes}}
 ```
 
-# [H3N2 antigenic distances by ferret cell FRA](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&label=clade:2a.3a.1&mf_proposed_subclade_reference=J.2&mf_proposed_subclade_reference=J.2.1&mf_proposed_subclade_reference=J.2.2&mf_proposed_subclade_reference=J.2.c&p=grid&f_year_month={{year_month_filter}})
+# [H3N2 antigenic distances by ferret cell FRA](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&label=clade:2a.3a.1&p=grid&f_year_month={{year_month_filter}})
 
 The measurements panel shows antigenic distances for test viruses grouped by subclade.
 
-# [H3N2 antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&label=clade:2a.3a.1&m_collection=cell_hi&mf_proposed_subclade_reference=J.2&mf_proposed_subclade_reference=J.2.1&mf_proposed_subclade_reference=J.2.2&mf_proposed_subclade_reference=J.2.c&mf_proposed_subclade_reference=J.2.d&p=grid&f_year_month={{year_month_filter}})
+# [H3N2 antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&label=clade:2a.3a.1&m_collection=cell_hi&p=grid&f_year_month={{year_month_filter}})
 
 The measurements panel shows antigenic distances for test viruses collected since May 2024 grouped by subclade.
 These HI data show similar pattern of coverage as the FRA measurements.
@@ -158,7 +158,7 @@ The "delta frequency" is the change in frequency between the current frequency a
 {{vic_haplotypes}}
 ```
 
-# [Vic antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/vic/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&f_year_month={{year_month_filter}}&label=Subclade:C.5&mf_proposed_subclade_reference=C&mf_proposed_subclade_reference=C.5.1&mf_proposed_subclade_reference=C.5.6&mf_proposed_subclade_reference=C.5.7&p=grid)
+# [Vic antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/vic/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&f_year_month={{year_month_filter}}&label=Subclade:C.5&p=grid)
 
 # [Vic antigenic advance](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/vic/2y/titers/ha?branchLabel=none&c=subclade&d=tree&f_year_month={{year_month_filter}}&l=scatter&label=Subclade:C.5&p=full&scatterX=subclade&scatterY=cell_hi_cTiterSub)
 

--- a/narratives_template/nextstrain-cdc.md.jinja
+++ b/narratives_template/nextstrain-cdc.md.jinja
@@ -1,0 +1,165 @@
+---
+title: "Nextstrain seasonal influenza report for {{long_month}} {{year}}"
+date: "{{long_month}} {{day}}, {{year}}"
+dataset: https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}}?branchLabel=proposed_subclade&c=proposed_subclade&d=tree&label=clade:5a.2a&p=full
+abstract: TKTK
+---
+
+# [Sequence counts for all lineages](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}})
+
+```auspiceMainDisplayMarkdown
+## Total genome sequence counts per lineage
+
+![Total genome sequence counts per lineage](../figures/total-sample-count-by-lineage.png)
+
+## H1N1pdm sequence counts per region
+
+![H1N1pdm genome sequence counts per region](../figures/total-sample-count_h1n1pdm.png)
+
+## H3N2 sequence counts per region
+
+![H3N2 genome sequence counts per region](../figures/total-sample-count_h3n2.png)
+
+## Vic sequence counts per region
+
+![Vic genome sequence counts per region](../figures/total-sample-count_vic.png)
+```
+
+# [Recent H1N1pdm submissions](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}}?branchLabel=proposed_subclade&c=proposed_subclade&d=tree,map&f_recency=last%20month,last%20week&label=clade:5a.2a&p=grid)
+
+Counts reflect all sequences submitted in the last month and with a Nextclade QC value better than "bad".
+
+{{h1n1pdm_clade_counts}}
+
+# [Global H1N1pdm circulation](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}}?branchLabel=proposed_subclade&c=proposed_subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&label=clade:5a.2a&p=grid)
+
+# [Location-specific H1N1pdm clade frequencies and growth advantages](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid&label=clade:5a.2a)
+
+```auspiceMainDisplayMarkdown
+## HA subclade frequencies per country
+
+![H1N1pdm HA clade frequencies](../../forecasts-flu/plots/h1n1pdm/region/freq/freq_by_location.png)
+
+Frequencies modeled with a multinomial logistic regression model.
+The solid lines show median frequencies per country and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
+
+## Growth advantages per location and overall (hierarchical)
+
+![H1N1pdm growth advantages](../../forecasts-flu/plots/h1n1pdm/region/ga/ga_by_location.png)
+
+```
+
+# [Recent H1N1pdm haplotypes](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&label=clade:5a.2a&p=grid)
+
+The table shows derived haplotypes and reference viruses from the same haplotype that have titer data.
+Haplotypes are sorted by their current frequency in descending order and annotated by the change in frequency in the previous month.
+Frequencies reflect all available data with a Nextclade QC of "good" or "mediocre".
+The "current frequency" represents an estimate from 4 weeks prior to the date of this report, to minimize effects of submission delays on estimates.
+The "delta frequency" is the change in frequency between the current frequency and 4 weeks before that.
+
+```auspiceMainDisplayMarkdown
+{{h1n1pdm_haplotypes}}
+```
+
+# [H1N1pdm antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h1n1pdm/2y/titers/ha?d=tree,measurements&f_year_month={{year_month_filter}}&label=clade:5a.2a&mf_proposed_subclade_reference=C.1.1&mf_proposed_subclade_reference=C.1.9&mf_proposed_subclade_reference=C.1.9.c&mf_proposed_subclade_reference=D.1&p=grid)
+
+# [H1N1pdm antigenic advance](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h1n1pdm/2y/titers/ha?branchLabel=none&c=proposed_subclade&d=tree&f_year_month={{year_month_filter}}&l=scatter&label=clade:5a.2a&p=full&scatterX=proposed_subclade&scatterY=cell_hi_cTiterSub)
+
+# [H1N1pdm local branching index](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}}:/seasonal-flu/h1n1pdm/na/2y@{{date}}?branchLabel=aa&c=lbi&d=tree&f_year_month={{year_month_filter}}&label=clade:5a.2a&p=full&transmissions=hide&m=div)
+
+# [Recent H3N2 submissions](https://nextstrain.org/seasonal-flu/h3n2/ha/2y@{{date}}?branchLabel=proposed_subclade&c=proposed_subclade&d=tree,map&f_recency=last%20month,last%20week&label=clade:2a.3a&p=grid)
+
+Counts reflect all sequences submitted in the last month and with a Nextclade QC value better than "bad".
+
+{{h3n2_clade_counts}}
+
+# [Global H3N2 circulation](https://nextstrain.org/seasonal-flu/h3n2/ha/2y@{{date}}?branchLabel=proposed_subclade&c=proposed_subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&label=clade:2a.3a&p=grid)
+
+# [Location-specific H3N2 clade frequencies and growth advantages](https://nextstrain.org/seasonal-flu/h3n2/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid)
+
+```auspiceMainDisplayMarkdown
+## HA subclade frequencies per country
+
+![H3N2 HA clade frequencies](../../forecasts-flu/plots/h3n2/region/freq/freq_by_location.png)
+
+Frequencies modeled with a multinomial logistic regression model.
+The solid lines show median frequencies per country and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
+
+## Growth advantages per location and overall (hierarchical)
+
+![H3N2 growth advantages](../../forecasts-flu/plots/h3n2/region/ga/ga_by_location.png)
+
+```
+
+# [Recent H3N2 haplotypes](https://nextstrain.org/seasonal-flu/h3n2/ha/2y@{{date}}?branchLabel=Emerging%20subclade&c=c=emerging_subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&label=clade:2a.3a&p=grid)
+
+The table shows derived haplotypes and reference viruses from the same haplotype that have titer data.
+Haplotypes are sorted by their current frequency in descending order and annotated by the change in frequency in the previous month.
+Frequencies reflect all available data with a Nextclade QC of "good" or "mediocre".
+The "current frequency" represents an estimate from 4 weeks prior to the date of this report, to minimize effects of submission delays on estimates.
+The "delta frequency" is the change in frequency between the current frequency and 4 weeks before that.
+
+```auspiceMainDisplayMarkdown
+{{h3n2_haplotypes}}
+```
+
+# [H3N2 antigenic distances by ferret cell FRA](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&label=clade:2a.3a.1&mf_proposed_subclade_reference=J.2&mf_proposed_subclade_reference=J.2.1&mf_proposed_subclade_reference=J.2.2&mf_proposed_subclade_reference=J.2.c&p=grid&f_year_month={{year_month_filter}})
+
+The measurements panel shows antigenic distances for test viruses grouped by subclade.
+
+# [H3N2 antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&label=clade:2a.3a.1&m_collection=cell_hi&mf_proposed_subclade_reference=J.2&mf_proposed_subclade_reference=J.2.1&mf_proposed_subclade_reference=J.2.2&mf_proposed_subclade_reference=J.2.c&mf_proposed_subclade_reference=J.2.d&p=grid&f_year_month={{year_month_filter}})
+
+The measurements panel shows antigenic distances for test viruses collected since May 2024 grouped by subclade.
+These HI data show similar pattern of coverage as the FRA measurements.
+
+# [H3N2 ferret-based antigenic advance from cell-based FRA data](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?d=tree&f_year_month={{year_month_filter}}&l=scatter&label=Subclade:J.2&scatterX=proposed_subclade&scatterY=cell_fra_cTiterSub)
+
+# [H3N2 ferret-based antigenic advance from cell-based HI data](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?d=tree&f_year_month={{year_month_filter}}&l=scatter&label=Subclade:J.2&scatterX=proposed_subclade&scatterY=cell_hi_cTiterSub)
+
+# [H3N2 local branching index](https://nextstrain.org/seasonal-flu/h3n2/ha/2y@{{date}}:/seasonal-flu/h3n2/na/2y@{{date}}?branchLabel=aa&c=lbi&d=tree&f_year_month={{year_month_filter}}&label=clade:2a.3a&p=full&transmissions=hide&m=div)
+
+# [H3N2 forecasts for ferret antigenic model and LBI model](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=Emerging%20subclade&c=emerging_subclade&d=tree&l=scatter&label=clade:2a.3a.1&p=full&p=full&regression=show&scatterX=weighted_distance_to_future_by_cell_fra_cTiter_x-ne_star&scatterY=weighted_distance_to_future_by_ne_star-lbi)
+
+# [H3N2 forecasts for human antigenic model and LBI model](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/h3n2/2y/titers/ha?branchLabel=Emerging%20subclade&c=emerging_subclade&d=tree&l=scatter&label=clade:2a.3a.1&p=full&p=full&regression=show&scatterX=weighted_distance_to_future_by_human_cell_fra_cTiter_x-ne_star&scatterY=weighted_distance_to_future_by_ne_star-lbi)
+
+# [Recent Vic submissions](https://nextstrain.org/seasonal-flu/vic/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map&f_recency=last%20month,last%20week&label=clade:V1A.3&p=grid)
+
+Counts reflect all sequences submitted in the last month and with a Nextclade QC value better than "bad".
+
+{{vic_clade_counts}}
+
+# [Global Vic circulation](https://nextstrain.org/seasonal-flu/vic/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid&label=clade:V1A.3a.2)
+
+# [Location-specific Vic clade frequencies and growth advantages](https://nextstrain.org/seasonal-flu/vic/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid&label=clade:V1A.3a.2)
+
+```auspiceMainDisplayMarkdown
+## HA subclade frequencies per country
+
+![Vic HA clade frequencies](../../forecasts-flu/plots/vic/region/freq/freq_by_location.png)
+
+Frequencies modeled with a multinomial logistic regression model.
+The solid lines show median frequencies per country and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
+
+## Growth advantages per location and overall (hierarchical)
+
+![Vic growth advantages](../../forecasts-flu/plots/vic/region/ga/ga_by_location.png)
+
+```
+
+# [Recent Vic haplotypes](https://nextstrain.org/seasonal-flu/vic/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid&label=clade:V1A.3a.2)
+
+The table shows derived haplotypes and reference viruses from the same haplotype that have titer data.
+Haplotypes are sorted by their current frequency in descending order and annotated by the change in frequency in the previous month.
+Frequencies reflect all available data with a Nextclade QC of "good" or "mediocre".
+The "current frequency" represents an estimate from 4 weeks prior to the date of this report, to minimize effects of submission delays on estimates.
+The "delta frequency" is the change in frequency between the current frequency and 4 weeks before that.
+
+```auspiceMainDisplayMarkdown
+{{vic_haplotypes}}
+```
+
+# [Vic antigenic distances by ferret cell HI](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/vic/2y/titers/ha?branchLabel=proposed_subclade&d=tree,measurements&f_year_month={{year_month_filter}}&label=Subclade:C.5&mf_proposed_subclade_reference=C&mf_proposed_subclade_reference=C.5.1&mf_proposed_subclade_reference=C.5.6&mf_proposed_subclade_reference=C.5.7&p=grid)
+
+# [Vic antigenic advance](https://nextstrain.org/groups/nextflu-private/flu/seasonal/{{date}}/vic/2y/titers/ha?branchLabel=none&c=subclade&d=tree&f_year_month={{year_month_filter}}&l=scatter&label=Subclade:C.5&p=full&scatterX=subclade&scatterY=cell_hi_cTiterSub)
+
+# [Vic local branching index](https://nextstrain.org/seasonal-flu/vic/ha/2y@{{date}}:/seasonal-flu/vic/na/2y@{{date}}?branchLabel=aa&c=lbi&d=tree&f_year_month={{year_month_filter}}&label=Subclade:C.5&p=full&transmissions=hide&m=div)

--- a/narratives_template/nextstrain-cdc.md.jinja
+++ b/narratives_template/nextstrain-cdc.md.jinja
@@ -36,12 +36,12 @@ Counts reflect all sequences submitted in the last month and with a Nextclade QC
 # [Location-specific H1N1pdm clade frequencies and growth advantages](https://nextstrain.org/seasonal-flu/h1n1pdm/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid&label=clade:5a.2a)
 
 ```auspiceMainDisplayMarkdown
-## HA subclade frequencies per country
+## HA subclade frequencies per location
 
 ![H1N1pdm HA clade frequencies](../../forecasts-flu/plots/h1n1pdm/region/freq/freq_by_location.png)
 
 Frequencies modeled with a multinomial logistic regression model.
-The solid lines show median frequencies per country and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
+The solid lines show median frequencies per location and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
 
 ## Growth advantages per location and overall (hierarchical)
 
@@ -78,12 +78,12 @@ Counts reflect all sequences submitted in the last month and with a Nextclade QC
 # [Location-specific H3N2 clade frequencies and growth advantages](https://nextstrain.org/seasonal-flu/h3n2/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid)
 
 ```auspiceMainDisplayMarkdown
-## HA subclade frequencies per country
+## HA subclade frequencies per location
 
 ![H3N2 HA clade frequencies](../../forecasts-flu/plots/h3n2/region/freq/freq_by_location.png)
 
 Frequencies modeled with a multinomial logistic regression model.
-The solid lines show median frequencies per country and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
+The solid lines show median frequencies per location and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
 
 ## Growth advantages per location and overall (hierarchical)
 
@@ -133,12 +133,12 @@ Counts reflect all sequences submitted in the last month and with a Nextclade QC
 # [Location-specific Vic clade frequencies and growth advantages](https://nextstrain.org/seasonal-flu/vic/ha/2y@{{date}}?branchLabel=Subclade&c=subclade&d=tree,map,frequencies&f_year_month={{year_month_filter}}&p=grid&label=clade:V1A.3a.2)
 
 ```auspiceMainDisplayMarkdown
-## HA subclade frequencies per country
+## HA subclade frequencies per location
 
 ![Vic HA clade frequencies](../../forecasts-flu/plots/vic/region/freq/freq_by_location.png)
 
 Frequencies modeled with a multinomial logistic regression model.
-The solid lines show median frequencies per country and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
+The solid lines show median frequencies per location and clade while the shading shows lower and upper 95% highest posterior density intervals for the median.
 
 ## Growth advantages per location and overall (hierarchical)
 

--- a/scripts/create_narrative.py
+++ b/scripts/create_narrative.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+import argparse
+import datetime
+import sys
+
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+import pandas as pd
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--template", required=True, help="Template of Markdown narrative in Jinja2 format.")
+    parser.add_argument("--earliest-date", help="Earliest date in format of YYYY-MM-DD to use for year/month filters in Nextstrain views. Defaults to 6 months before the given report date.")
+    parser.add_argument("--date", help="Date in the format of YYYY-MM-DD to use for the report. Defaults to the current date.")
+    parser.add_argument("--markdown-includes", nargs="+", help="One or more key/value pairs of variable name and path to a Markdown file to be included in the template environment in the format of 'variable_name=path_to_markdown_file.md'.")
+    parser.add_argument("--output", required=True, help="Rendered Markdown narrative.")
+
+    args = parser.parse_args()
+
+    env = Environment(
+        loader=FileSystemLoader("."),
+        autoescape=select_autoescape()
+    )
+
+    template = env.get_template(args.template)
+
+    if args.date:
+        date = datetime.datetime.strptime(args.date, "%Y-%m-%d")
+        date_string = args.date
+    else:
+        date = datetime.datetime.today()
+        date_string = date.strftime("%Y-%m-%d")
+
+    # Build year/month filters for Nextstrain views based on the current report
+    # date and the earliest date requested. If no earliest date is given,
+    # default to a fixed number of months in the past. This dynamic construction
+    # of the date filters ensures that we always include the most recent month
+    # in the filters.
+    if args.earliest_date:
+        earliest_date_string = args.earliest_date
+    else:
+        earliest_date = date - pd.DateOffset(months=6)
+        earliest_date_string = earliest_date.strftime("%Y-%m-01")
+
+    year_month_periods = pd.period_range(
+        earliest_date_string,
+        date_string,
+        freq="M",
+    )
+    year_month_filter = ",".join(
+        str(period)
+        for period in year_month_periods
+    )
+
+    # Setup variables that the template always expects to find.
+    variables = {
+        "date": date_string,
+        "long_month": date.strftime("%B"),
+        "day": date.strftime("%d"),
+        "year": date.strftime("%Y"),
+        "year_month_filter": year_month_filter,
+    }
+
+    # Include the contents of additional Markdown files that have been generated
+    # by the workflow.
+    markdown_includes = args.markdown_includes
+    if markdown_includes is None:
+        markdown_includes = []
+
+    for markdown_include in markdown_includes:
+        variable_name, markdown_path = markdown_include.split("=")
+        if variable_name in variables:
+            print(
+                f"Warning: Overwriting a variable of name '{variable_name}' that already exists in the template's environment.",
+                file=sys.stderr
+            )
+
+        with open(markdown_path, "r", encoding="utf-8") as fh:
+            variables[variable_name] = fh.read()
+
+    with open(args.output, "w", encoding="utf-8") as oh:
+        print(template.render(**variables), file=oh)

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -3,12 +3,10 @@ channels:
   - conda-forge
   - bioconda
 dependencies:
-  - augur=26.0.0
+  - augur=29.0.0
   - awscli=1.27.9
   - epiweeks=2.1.2
-  - iqtree=2.2.0_beta
-  - mafft=7.526
-  - nextclade=3.8.2
+  - nextclade=3.10.2
   - python=3.11.*
   - seaborn>=0.11*
   - seqkit=2.2.0

--- a/workflow/envs/nextstrain.yaml
+++ b/workflow/envs/nextstrain.yaml
@@ -18,5 +18,6 @@ dependencies:
   - xlrd=1.*
   - pip=23.0.1
   - pathogen-embed=3.1.0
+  - jinja2=3.1.2
   - pip:
     - rethinkdb==2.3.0.post6


### PR DESCRIPTION
## Description of proposed changes

Adds a script to load a Markdown template written in [Jinja2 syntax](https://jinja.palletsprojects.com/en/stable/templates/) and write out a narrative stub with the correct dates in the narrative frontmatter and the Nextstrain URLs. The included Markdown template assumes that the narrative will be written to a `narratives/path.md` path with images in the same repo's `figures/` directory.

This PR also adds a rule to run this script from the workflow to automate narrative creation during the nextflu-private builds. We could optionally upload the narrative stub to the desired Nextstrain Group, in the future, but for now this implementation will allow us to quickly get a new report going without manually updating dates or markdown tables.

Note that Jinja2 is available in the base Nextstrain environments as a dependency for [Snakemake's own reporting functionality](https://snakemake.readthedocs.io/en/stable/snakefiles/reporting.html).

## Related issue(s)

Closes #163

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
