### PR TITLE
Run Nextclade in GHA for uploads

### DIFF
--- a/.github/workflows/run-nextclade.yaml
+++ b/.github/workflows/run-nextclade.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
   workflow_call:
+    inputs:
+      artifact-name:
+        description: "Name to use for final artifact uploaded by this action"
+        required: false
+        type: string
 
 jobs:
   run-build:
@@ -16,6 +21,7 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
     secrets: inherit
     with:
+      artifact-name: ${{ inputs.artifact-name }}
       runtime: aws-batch
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}

--- a/.github/workflows/run-nextclade.yaml
+++ b/.github/workflows/run-nextclade.yaml
@@ -7,6 +7,7 @@ on:
         description: "Specific container image to use for build (will override the default of `nextstrain build`)"
         required: false
         type: string
+  workflow_call:
 
 jobs:
   run-build:

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -58,7 +58,7 @@ jobs:
     needs: [upload]
     permissions:
       id-token: write
-    uses: nextstrain/seasonal-flu/.github/workflows/run-nextclade.yaml
+    uses: nextstrain/seasonal-flu/.github/workflows/run-nextclade.yaml@master
     secrets: inherit
 
   trigger:

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -28,14 +28,6 @@ on:
         description: "Specific container image to use for nextflu-private group builds"
         required: false
         type: string
-      triggerNextclade:
-        description: "Trigger run-nextclade workflow"
-        required: true
-        type: boolean
-      nextcladeDockerImage:
-        description: "Specific container image to use for the Nextclade workflow"
-        required: false
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -62,8 +54,15 @@ jobs:
           upload_all_metadata \
           --configfile profiles/upload.yaml
 
-  trigger:
+  run-nextclade:
     needs: [upload]
+    permissions:
+      id-token: write
+    uses: nextstrain/seasonal-flu/.github/workflows/run-nextclade.yaml
+    secrets: inherit
+
+  trigger:
+    needs: [upload, run-nextclade]
     strategy:
       matrix:
         include:
@@ -76,9 +75,6 @@ jobs:
           - trigger: ${{ inputs.triggerNextfluPrivate }}
             workflow: run-nextflu-private-builds.yaml
             image: ${{ inputs.nextfluPrivateDockerImage }}
-          - trigger: ${{ inputs.triggerNextclade }}
-            workflow: run-nextclade.yaml
-            image: ${{ inputs.nextcladeDockerImage }}
     runs-on: ubuntu-latest
     steps:
       - if: ${{ matrix.trigger }}

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -41,6 +41,7 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
     secrets: inherit
     with:
+      artifact-name: build-outputs-upload
       runtime: docker
       run: |
         nextstrain build \
@@ -59,6 +60,8 @@ jobs:
     permissions:
       id-token: write
     uses: ./.github/workflows/run-nextclade.yaml
+    with:
+      artifact-name: build-outputs-nextclade
     secrets: inherit
 
   trigger:

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -58,7 +58,7 @@ jobs:
     needs: [upload]
     permissions:
       id-token: write
-    uses: nextstrain/seasonal-flu/.github/workflows/run-nextclade.yaml@master
+    uses: ./.github/workflows/run-nextclade.yaml
     secrets: inherit
 
   trigger:


### PR DESCRIPTION
## Description of proposed changes

Adds a job to the upload GitHub Action to run Nextclade on all sequences before triggering downstream workflows. This change ensures that Nextclade annotations in S3 reflect the latest data when other workflows run. This commit removes the option to trigger the separate Nextclade GHA from the upload action. Thanks to @tsibley, this implementation reuses the Nextclade GHA, so we can still manually trigger just that action later when we need to.

<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
