### PR TITLE
Add citations for epitope or map sites

### DIFF
--- a/config/distance_maps/README.md
+++ b/config/distance_maps/README.md
@@ -1,0 +1,30 @@
+# Distance Maps
+
+This folder contains auxillary files for distance maps. Key positions were pulled from the following publications to create the different map files.
+
+## H1N1pdm
+
+| map file | citation |
+|:-- | :-- |
+| [canton.json](./h1n1pdm/ha/canton.json)&ast; | [Caton et al. 1982](https://doi.org/10.1016/0092-8674(82)90135-0) |
+
+&ast; “Canton” (should be “Caton”) originally copied from [Igarashi et al. 2010](https://doi.org/10.1371/journal.pone.0008553).
+
+## H3N2
+
+### HA
+
+| map file | citation |
+|:-- | :-- |
+| [wolf.json](./h3n2/ha/wolf.json) | [Wolf et al. 2006](https://doi.org/10.1186/1745-6150-1-34) |
+| [shih.json](./h3n2/ha/shih.json) | [Shih et al. 2007](https://doi.org/10.1073/pnas.0701396104) |
+| [koel.json](./h3n2/ha/koel.json) | [Koel et al. 2013](https://doi.org/10.1126/science.1244730) |
+| [luksza.json](./h3n2/ha/luksza.json) | [Luksza and Lassig 2014](https://doi.org/10.1038/nature13087) |
+| [welsh_epitope_sites.json](./h3n2/ha/welsh_epitope_sites.json) | [Welsh et al. 2024](https://doi.org/10.1016/j.chom.2024.06.015) |
+
+### NA
+
+| map file | citation |
+|:-- | :-- |
+| [munoz.json](./h3n2/na/munoz.json) | [Munoz et al. 2004](https://doi.org/10.1016/j.vaccine.2004.08.028) |
+| [bhatt.json](./h3n2/na/bhatt.json) | [Bhatt et al. 2011](https://doi.org/10.1093/molbev/msr044) |


### PR DESCRIPTION
## Description of proposed changes

Add citations for the epitope of map sites in a top-level README file, listed in chronological order of publication. I put them in a table, split by type and gene, but feel free to reword or suggest a different format.

Eventually, based on [a slack thread](https://bedfordlab.slack.com/archives/C03KWDET9/p1743617647803209?thread_ts=1743617294.221779&cid=C03KWDET9), we may want to switch to adding these as DOI keys in the top-level JSON.

I wasn't confident I could safely add new keys to the JSON files without breaking something in the workflow, hence the README docs for now.

## Related issue(s)


## Checklist

- [ ] Checks pass
