### PR TITLE
profiles/nexstrain-public: Remove filter `--exclude-where passage=egg`

### DIFF
--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -55,13 +55,13 @@ array-builds:
           data: "data/{lineage}/cdc_ferret_cell_hi_titers.tsv"
     subsamples: &subsampling-scheme
       regions_except_europe:
-          filters: --query "(passage_category != 'egg') & (region != 'Europe') & (ha == True) & (na == True)" --group-by region year month --subsample-max-sequences 2700 --min-date {min_date} --exclude {exclude} --exclude-where passage=egg
+          filters: --query "(passage_category != 'egg') & (region != 'Europe') & (ha == True) & (na == True)" --group-by region year month --subsample-max-sequences 2700 --min-date {min_date} --exclude {exclude}
           priorities: "titers"
       europe:
-          filters: --query "(passage_category != 'egg') & (region == 'Europe') & (ha == True) & (na == True)" --group-by country year month --subsample-max-sequences 300 --min-date {min_date} --exclude {exclude} --exclude-where passage=egg
+          filters: --query "(passage_category != 'egg') & (region == 'Europe') & (ha == True) & (na == True)" --group-by country year month --subsample-max-sequences 300 --min-date {min_date} --exclude {exclude}
           priorities: "titers"
       references:
-          filters: --query "(is_reference == True)" --min-date {reference_min_date} --exclude-where passage=egg
+          filters: --query "(is_reference == True)" --min-date {reference_min_date}
   2Y-hi-builds:
     patterns:
       lineage:


### PR DESCRIPTION
## Description of proposed changes

Noticed by @j23414 during testing with the new ingest results that there were warnings about the `passage` column not existing in the metadata.

Turns out this is a warning we also see in the prod builds because we do no have a `passage` column in our current metadata.

<https://github.com/nextstrain/seasonal-flu/actions/runs/14648450833/job/41108380205#step:5:2695>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
