### PR TITLE
ingest/annotate-with-passage-category: Fix mismatch due to casing

### DIFF
--- a/ingest/scripts/annotate-with-passage-category
+++ b/ingest/scripts/annotate-with-passage-category
@@ -51,6 +51,7 @@ def get_passage_category(passage: str) -> str:
     Patterns with the comment "# McWhite" seem to have been taken from
     McWhite et al. 2016 <https://doi.org/10.1093/ve/vew026>
     """
+    passage = passage.upper()
     passage_category = DEFAULT_PASSAGE_CATEGORY
     if re.search(r'AM[1-9]|E[1-9]|AMNIOTIC|EGG|EX|AM_[1-9]', passage):   # McWhite
         passage_category = "egg"


### PR DESCRIPTION
## Description of proposed changes

Somehow missed the line in the fauna code that used the uppercase for passage.

<https://github.com/nextstrain/fauna/blob/fbdc393581b1859ac817403d8f43e114d7edbc60/vdb/flu_upload.py#L417>


## Related issue(s)

Follow up on https://github.com/nextstrain/seasonal-flu/pull/218

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/seasonal-flu/actions/runs/14933398964)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
