### PR TITLE
Support test public builds

### DIFF
--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -14,6 +14,14 @@ on:
           If set, builds will be deployed to s3://nextstrain-staging/seasonal-flu_trials_<trial_name>_*
         required: false
         type: string
+      sequences_url:
+        description: "S3 URL for sequences.fasta.xz, must contain the {lineage} and {segment} wildcards."
+        required: false
+        type: string
+      metadata_url:
+        description: "S3 URL for metadata.tsv.xz, must contain the {lineage} wildcard."
+        required: false
+        type: string
 
 jobs:
   run-build:
@@ -26,11 +34,21 @@ jobs:
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
         TRIAL_NAME: ${{ inputs.trial_name }}
+        METADATA_URL: ${{ inputs.metadata_url }}
+        SEQUENCES_URL: ${{ inputs.sequences_url }}
       run: |
         declare -a config
 
         if [[ "$TRIAL_NAME" ]]; then
           config+=("deploy_url=s3://nextstrain-staging/seasonal-flu_trials_${TRIAL_NAME}_")
+        fi
+
+        if [[ "$METADATA_URL" ]]; then
+          config+=("metadata_url=${METADATA_URL}")
+        fi
+
+        if [[ "$SEQUENCES_URL" ]]; then
+          config+=("sequences_url=${SEQUENCES_URL}")
         fi
 
         nextstrain build \

--- a/.github/workflows/run-public-builds.yaml
+++ b/.github/workflows/run-public-builds.yaml
@@ -7,6 +7,13 @@ on:
         description: "Specific container image to use for build (will override the default of `nextstrain build`)"
         required: false
         type: string
+      trial_name:
+        description: |
+          Trial name for deploying builds.
+          If not set, builds will overwrite existing builds at s3://nextstrain-data/seasonal_flu*
+          If set, builds will be deployed to s3://nextstrain-staging/seasonal-flu_trials_<trial_name>_*
+        required: false
+        type: string
 
 jobs:
   run-build:
@@ -18,7 +25,14 @@ jobs:
       runtime: aws-batch
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
+        TRIAL_NAME: ${{ inputs.trial_name }}
       run: |
+        declare -a config
+
+        if [[ "$TRIAL_NAME" ]]; then
+          config+=("deploy_url=s3://nextstrain-staging/seasonal-flu_trials_${TRIAL_NAME}_")
+        fi
+
         nextstrain build \
           --detach \
           --cpus 36 \
@@ -26,4 +40,5 @@ jobs:
           . \
           deploy_all \
           -p \
-          --configfile profiles/nextstrain-public.yaml
+          --configfile profiles/nextstrain-public.yaml \
+          --config "${config[@]}"


### PR DESCRIPTION
## Description of proposed changes

As part of testing the new ingest workflow, I wanted to be able to create test builds with the trial ingest results. This PR adds the ability to configure the S3 paths for `download_from_s3` and create trial builds with the GH Action workflow for the public builds that deploy to staging.

I ran a [trial build](https://github.com/nextstrain/seasonal-flu/actions/runs/14918370149) yesterday that used the trial ingest results. The trial builds were deployed to `https://nextstrain.org/staging/seasonal-flu/trials/ingest/seasonal-flu/*`

- https://nextstrain.org/staging/seasonal-flu/trials/ingest/seasonal-flu/h1n1pdm/ha/2y
- https://nextstrain.org/staging/seasonal-flu/trials/ingest/seasonal-flu/h3n2/ha/2y
- https://nextstrain.org/staging/seasonal-flu/trials/ingest/seasonal-flu/vic/ha/2y

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass


<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
