### PR TITLE
Update private nextflu GH Action workflows

### DIFF
--- a/.github/workflows/run-private-nextflu-builds.yaml
+++ b/.github/workflows/run-private-nextflu-builds.yaml
@@ -1,6 +1,11 @@
 name: Run the private Nextflu builds
 
 on:
+  schedule:
+    # Scheduled to run at 5pm UTC (9am PST/10am PDT) on the first Friday of the month
+    # cron hack based on <https://blog.healthchecks.io/2022/09/schedule-cron-job-the-funky-way/>
+    - cron: '0 17 */100,1-7 * FRI'
+
   workflow_dispatch:
     inputs:
       dockerImage:

--- a/.github/workflows/run-private-nextflu-builds.yaml
+++ b/.github/workflows/run-private-nextflu-builds.yaml
@@ -27,3 +27,17 @@ jobs:
           all_who \
           -p \
           --configfile profiles/private.nextflu.org.yaml
+
+  deploy-private-nextflu:
+    needs: [run-build]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger deploy-private-nextflu
+        run: |
+          gh workflow run \
+            deploy-private-nextflu.yaml \
+            --repo nextstrain/seasonal-flu \
+            -f aws_batch_job_id=${{ needs.run-build.outputs.aws-batch-job-id }} \
+            -f deploy_to_staging=false
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -12,14 +12,6 @@ on:
         description: "Specific container image to use for Nextstrain public builds"
         required: false
         type: string
-      triggerPrivateNextflu:
-        description: "Trigger private Nextflu builds"
-        required: true
-        type: boolean
-      privateNextfluDockerImage:
-        description: "Specific container image to use for private Nextflu builds"
-        required: false
-        type: string
       triggerNextfluPrivate:
         description: "Trigger nextflu-private group builds"
         required: true
@@ -72,9 +64,6 @@ jobs:
           - trigger: ${{ inputs.triggerPublic }}
             workflow: run-public-builds.yaml
             image: ${{ inputs.publicDockerImage }}
-          - trigger: ${{ inputs.triggerPrivateNextflu }}
-            workflow: run-private-nextflu-builds.yaml
-            image: ${{ inputs.privateNextfluDockerImage }}
           - trigger: ${{ inputs.triggerNextfluPrivate }}
             workflow: run-nextflu-private-builds.yaml
             image: ${{ inputs.nextfluPrivateDockerImage }}


### PR DESCRIPTION
## Description of proposed changes

Per discussion in meeting and on [Slack](https://bedfordlab.slack.com/archives/C03KWDET9/p1747948591822409), we are moving to updating private.nextflu.org only once a month. Added schedule to run the workflow on the first Friday of the month since we usually do ingest on Thursdays. 

## Related issue(s)

Resolves <https://github.com/nextstrain/seasonal-flu/issues/159>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
