### PR TITLE
Ingest updates

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -57,6 +57,7 @@ curate:
     Host: host
   gisaid_subtype_field: "Subtype"
   gisaid_lineage_field: "Lineage"
+  gisaid_note_field: "Note"
   new_type_field: "vtype"
   new_subtype_field: "subtype"
   new_lineage_field: "lineage"

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -56,6 +56,7 @@ rule curate:
         field_map=format_field_map(config["curate"]["field_map"]),
         gisaid_subtype_field=config["curate"]["gisaid_subtype_field"],
         gisaid_lineage_field=config["curate"]["gisaid_lineage_field"],
+        gisaid_note_field=config["curate"]["gisaid_note_field"],
         new_type_field=config["curate"]["new_type_field"],
         new_subtype_field=config["curate"]["new_subtype_field"],
         new_lineage_field=config["curate"]["new_lineage_field"],
@@ -89,6 +90,7 @@ rule curate:
             | ./scripts/standardize-lineage \
                 --subtype-field {params.gisaid_subtype_field:q} \
                 --lineage-field {params.gisaid_lineage_field:q} \
+                --note-field {params.gisaid_note_field:q} \
                 --new-type-field {params.new_type_field:q} \
                 --new-subtype-field {params.new_subtype_field:q} \
                 --new-lineage-field {params.new_lineage_field:q} \

--- a/ingest/scripts/parse-gisaid-location
+++ b/ingest/scripts/parse-gisaid-location
@@ -91,13 +91,6 @@ def parse_locations(records: Iterable,
                 # and append it to the location values to output
                 if len(split_locations) < expected_num_locations:
                     split_locations.append(strain_location)
-                else:
-                    # Otherwise warn that the strain_location does not match
-                    # the metadata location values.
-                    print_err(
-                        f"Strain location {strain_location!r} does not match",
-                        f"any of the geolocation values {split_locations!r}"
-                    )
 
         for index, field in enumerate(LOCATION_FIELDS):
             record[field] = split_locations[index] if len(split_locations) > index else DEFAULT_UNKNOWN_VALUE

--- a/ingest/scripts/standardize-lineage
+++ b/ingest/scripts/standardize-lineage
@@ -3,6 +3,7 @@
 Standardize lineage based on GISAID's subtype and lineage.
 """
 import argparse
+import re
 from sys import stdin
 from typing import Iterable
 from augur.io.json import dump_ndjson, load_ndjson
@@ -43,6 +44,7 @@ TBD_TYPE = "tbd"
 def standardize_record_lineage(records: Iterable[dict],
                                subtype_field: str,
                                lineage_field: str,
+                               note_field: str,
                                new_type_field: str,
                                new_subtype_field: str,
                                new_lineage_field: str) -> Iterable:
@@ -60,12 +62,16 @@ def standardize_record_lineage(records: Iterable[dict],
     for record in records:
         gisaid_subtype = record.get(subtype_field)
         gisaid_lineage = record.get(lineage_field)
+        gisaid_note = record.get(note_field)
 
         if gisaid_subtype is None:
             raise Exception(f"Records must have the expected GISAID subtype field: {subtype_field!r}")
 
         if gisaid_lineage is None:
             raise Exception(f"Records must have the expected GISAID lineage field: {lineage_field!r}")
+
+        if not gisaid_lineage.strip() and gisaid_note:
+            gisaid_lineage = parse_lineage_from_note(gisaid_note)
 
         gisaid_types = (gisaid_subtype.lower(), gisaid_lineage.lower())
         lineage_match = GISAID_LINEAGE_MAP.get(gisaid_types)
@@ -89,6 +95,30 @@ def standardize_record_lineage(records: Iterable[dict],
         )
 
 
+def parse_lineage_from_note(note: str) -> str:
+    """
+    Parse known patterns in the *note* value that are used to annotate lineages.
+
+    If the *note* matches a pattern, then returns the expected lineage from GISAID,
+    i.e. the key in the `GISAID_LINEAGE_MAP`.
+    """
+    note = note.strip()
+    H1N1PDM_PATTERNS = re.compile(r"^H1N1pdm09$|lineage: A\(H1N1\)pdm09|Influenza A\(H1N1\) pandemic", re.IGNORECASE)
+    VIC_PATTERNS = re.compile(r"^Victoria$|B/Vic|type: Vic|Victoria lineage|lineage: Victoria", re.IGNORECASE)
+    YAM_PATTERNS = re.compile(r"^Yamagata$|B/Yam|type: Yam|Yamagata lineage|lineage: Yamagata", re.IGNORECASE)
+
+    if re.match(H1N1PDM_PATTERNS, note):
+        return "pdm09"
+
+    if re.match(VIC_PATTERNS, note):
+        return "victoria"
+
+    if re.match(YAM_PATTERNS, note):
+        return "yamagata"
+
+    return ""
+
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description=__doc__)
 
@@ -96,6 +126,8 @@ if __name__ == '__main__':
         help="The record field containing the GISAID subtype")
     parser.add_argument("--lineage-field", default="Lineage",
         help="The record field containing the GISAID lineage")
+    parser.add_argument("--note-field", default="Note",
+        help="The record field containing free text note that could be the lineage")
     parser.add_argument("--new-type-field", default="vtype",
         help="The name of the new field to add to the record with the type, " + \
              f"e.g. a or b. If type is undetermined, will default to {TBD_TYPE!r}")
@@ -113,6 +145,7 @@ if __name__ == '__main__':
         records,
         args.subtype_field,
         args.lineage_field,
+        args.note_field,
         args.new_type_field,
         args.new_subtype_field,
         args.new_lineage_field)

--- a/ingest/scripts/standardize-strain-names
+++ b/ingest/scripts/standardize-strain-names
@@ -61,7 +61,7 @@ def standardize_record_strains(records: Iterable,
         if influenza_type is not None and str(influenza_type).lower() in EXPECTED_TYPES:
             strain_type = new_strain.split("/")[0]
             if strain_type.lower() != influenza_type.lower():
-                new_strain = re.sub(re.escape(strain_type), influenza_type.upper(), new_strain)
+                new_strain = re.sub("^" + re.escape(strain_type), influenza_type.upper(), new_strain)
 
         record[new_strain_field] = new_strain
 


### PR DESCRIPTION
## Description of proposed changes

Updates to the ingest workflow that I made as I compared the trial outputs with the fauna metadata.
There are still geolocation updates that need to be made that I will address separately. 

One missing chunk of data are B types that are missing "Lineage" from GISAID, so they cannot be classified as vic or yam. I'm not sure how they were originally labelled as vic or yam in fauna. This might be a future improvement where we run Nextclade in the ingest workflow to classify them rather than rely on the GISAID labels. 


## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] [Trial run](https://github.com/nextstrain/seasonal-flu/actions/runs/15329196985)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
