### PR TITLE
Update profiles to be compatible with Snakemake v9

### DIFF
--- a/profiles/allflu/config.yaml
+++ b/profiles/allflu/config.yaml
@@ -5,5 +5,3 @@ cores: 8
 keep-going: False
 printshellcmds: True
 show-failed-logs: True
-reason: True
-stats: stats.json

--- a/profiles/example/config.yaml
+++ b/profiles/example/config.yaml
@@ -5,5 +5,3 @@ cores: 8
 keep-going: False
 printshellcmds: True
 show-failed-logs: True
-reason: True
-stats: stats.json

--- a/profiles/nextstrain/config.yaml
+++ b/profiles/nextstrain/config.yaml
@@ -5,5 +5,3 @@ cores: 8
 keep-going: True
 printshellcmds: True
 show-failed-logs: True
-reason: True
-stats: stats.json


### PR DESCRIPTION
## Description of proposed changes

Excludes the cluster profiles `hutch` and `scicore` because it's unclear what version of Snakemake is used for those clusters.

## Related issue(s)

Part of #238 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
