### PR TITLE
Parameterize the local clock filter cutoff

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
 
+# 11 August 2025
+
+- Parameterize the local clock filter cutoff as a top-level build configuration option. This change allows users to effectively disable the threshold-based filtering on the z-score from the local clock filter by setting the cutoff to a high value or make the threshold more stringent. See [#245](https://github.com/nextstrain/seasonal-flu/pull/245) for details.
+
 # 8 August 2025
 
 - Parameterize frequencies options by adding a new build-level config parameter section `frequencies` which allows users to override parameters including `narrow_bandwidth`, `wide_bandwidth`, `proportion_wide`, `pivot_interval`, and `pivot_interval_units`. These parameters map to the corresponding command line arguments for `augur frequencies`. See [#243](https://github.com/nextstrain/seasonal-flu/pull/243) for details.

--- a/profiles/full-trees.yaml
+++ b/profiles/full-trees.yaml
@@ -17,6 +17,10 @@ tree:
   tree-builder-args: "'--pathogen-force -ninit 2 -n 2 --epsilon 0.05 -czb -T AUTO --redo'"
   override_default_args: true
 
+# Set a very high z-score cutoff for the local clock outlier pruning logic to
+# effectively disable filtering of outliers.
+prune_outliers_z_score_cutoff: 1000.0
+
 refine:
   # Disable the clock filter.
   clock_filter_iqd: 0

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -149,13 +149,14 @@ rule prune_outliers:
         outliers = build_dir + "/{build_name}/{segment}/outliers.tsv"
     params:
         keep_strains_argument=lambda wildcards: "--keep-strains " + config["builds"][wildcards.build_name]["include"] if "include" in config["builds"][wildcards.build_name] else "",
+        cutoff=config.get("prune_outliers_z_score_cutoff", 4.0),
     shell:
         """
         python3 scripts/flag_outliers.py \
             --tree {input.tree:q} \
             --aln {input.aln} \
             --dates {input.metadata} \
-            --cutoff 4.0 \
+            --cutoff {params.cutoff} \
             {params.keep_strains_argument} \
             --output-tree {output.tree:q} --output-outliers {output.outliers} 2>&1 | tee {log}
         """


### PR DESCRIPTION
## Description of proposed changes

Adds a top-level parameter to configure the local clock filter's z-score cutoff. Sets the cutoff to a very high value for the "full" builds to prevent most sequences from being dropped for this local clock reason.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
