### PR TITLE
Explicitly root raw tree before pruning reference

### DIFF
--- a/scripts/prune_reference.py
+++ b/scripts/prune_reference.py
@@ -32,6 +32,7 @@ if __name__ == '__main__':
         T = Phylo.read(args.tree, "newick")
         references = [c for c in T.find_clades(terminal=True) if c.name == reference_name]
         if references:
+            T.root_with_outgroup(references[0])
             T.prune(references[0])
 
         Phylo.write(T, args.output, "newick")


### PR DESCRIPTION
## Description of proposed changes

The current workflow never explicitly roots the raw tree but instead relies on the default behavior of IQ-TREE which implicitly roots the tree on the first sequence in the input alignment. We modified the workflow to force the reference sequence to be the first in the alignment to get the rooting we want.

However, not all methods of tree inference will root the tree with the reference sequence like we've assumed so far. For example, the CMAPLE algorithm in IQ-TREE tries to find the best root in the alignment. This PR modifies the `prune_reference` script to explicitly root the raw tree with the reference node before pruning that node. This approach mirrors the newer feature in `augur refine` that accomplishes the same functionality. Some day we may be able to switch to that `augur refine` approach, but we currently have intermediate steps between divergence tree inference and time tree inference that prevent us from using that approach.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
