### PR TITLE
Use assignment operator for tree builder args

### DIFF
--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -107,7 +107,7 @@ rule tree:
         "logs/tree_{build_name}_{segment}.txt"
     params:
         method = config.get("tree", {}).get("method", "iqtree"),
-        tree_builder_args = lambda wildcards: f"--tree-builder-args {config['tree']['tree-builder-args']}" if config.get("tree", {}).get("tree-builder-args") else "",
+        tree_builder_args = lambda wildcards: f"--tree-builder-args={config['tree']['tree-builder-args']}" if config.get("tree", {}).get("tree-builder-args") else "",
         override_default_args = lambda wildcards: "--override-default-args" if config.get("tree", {}).get("override_default_args", False) else "",
     threads: 8
     resources:


### PR DESCRIPTION
## Description of proposed changes

Fix a sharp edge in tree builder configuration where users needed to single-quote their custom tree builder args in the config YAML or get an error message from augur tree. Thanks to @jameshadfield for the catch!

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
