### PR TITLE
Add SH 2025 vaccine strains

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
 
+# 30 September 2025
+
+- Add new vaccine strains for H1N1pdm and H3N2 based on [the WHO recommendations for the Southern Hemisphere 2026](https://www.who.int/news/item/26-09-2025-recommendations-announced-for-influenza-vaccine-composition-for-the-2026-southern-hemisphere-influenza-season). See [#256](https://github.com/nextstrain/seasonal-flu/pull/256) for details.
+
 # 17 September 2025
 
 - Allow titer collections to define their own list of `genes` which get used for fitting titer models. For example, setting `genes: ["HA1"]` in a titer collection limits the titer substitution model to use only HA1 substitutions.

--- a/config/h1n1pdm/reference_strains.txt
+++ b/config/h1n1pdm/reference_strains.txt
@@ -120,6 +120,7 @@ A/Minnesota/32/2015
 A/Minnesota/34/2018
 A/Mississippi/10/2020-egg
 A/Missouri/11/2025
+A/Missouri/11/2025-egg
 A/Montana/50/2016
 A/Montana/50/2016-egg
 A/Navarra/1985/2017

--- a/config/h1n1pdm/vaccine.json
+++ b/config/h1n1pdm/vaccine.json
@@ -54,6 +54,16 @@
             "vaccine": {
                 "selection_date": "2023-02-24"
             }
+        },
+        "A/Missouri/11/2025": {
+            "vaccine": {
+                "selection_date": "2025-09-26"
+            }
+        },
+        "A/Missouri/11/2025-egg": {
+            "vaccine": {
+                "selection_date": "2025-09-26"
+            }
         }
     }
 }

--- a/config/h3n2/reference_strains.txt
+++ b/config/h3n2/reference_strains.txt
@@ -172,6 +172,8 @@ A/Sidney/7/2014
 A/Sidon/S0212/2022
 A/Sidon/S0213/2022
 A/Singapore/22/2012
+A/Singapore/GP20238/2024
+A/Singapore/GP20238/2024-egg
 A/Singapore/Infimh-16-0019/2016
 A/Singapore/Infimh-16-0019/2016-egg
 A/Singapore/MOH0334/2024
@@ -197,6 +199,7 @@ A/Switzerland/8060/2017-egg
 A/Switzerland/9715293/2013
 A/Switzerland/9715293/2013-egg
 A/Sydney/1304/2022
+A/Sydney/1359/2024
 A/Sydney/16/2025
 A/Sydney/22/2018
 A/Sydney/68/2025

--- a/config/h3n2/vaccine.json
+++ b/config/h3n2/vaccine.json
@@ -99,6 +99,16 @@
             "vaccine": {
                 "selection_date": "2024-09-27"
             }
+        },
+        "A/Sydney/1359/2024": {
+            "vaccine": {
+                "selection_date": "2025-09-26"
+            }
+        },
+        "A/Singapore/GP20238/2024-egg": {
+            "vaccine": {
+                "selection_date": "2025-09-26"
+            }
         }
     }
 }


### PR DESCRIPTION
## Description of proposed changes

Adds SH 2025 vaccine strains for H1 and H3 to the vaccines JSONs and reference strains list.

## Related issue(s)

Closes #255

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
