### PR TITLE
Export Nextclade subclade columns for all segments to build metadata

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
 
+# 9 March 2026
+
+- Export Nextclade subclade columns for each segment to the build metadata (e.g., `subclade_nextclade_ha`, `subclade_nextclade_na`, etc.), allowing any segment's tree to color tips by any other segment's clade annotation. See [#258](https://github.com/nextstrain/seasonal-flu/pull/258) for details.
+
 # 18 December 2025
 
 - Updated quickstart guide for working with GISAID data. See [#282](https://github.com/nextstrain/seasonal-flu/pull/282) for details.

--- a/config/h1n1pdm/ha/auspice_config.json
+++ b/config/h1n1pdm/ha/auspice_config.json
@@ -80,6 +80,16 @@
       ]
     },
     {
+      "key": "subclade_nextclade_ha",
+      "title": "HA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade_nextclade_na",
+      "title": "NA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
       "key": "emerging_haplotype",
       "title": "Emerging haplotype",
       "type": "categorical",

--- a/config/h1n1pdm/na/auspice_config.json
+++ b/config/h1n1pdm/na/auspice_config.json
@@ -68,6 +68,16 @@
       ]
     },
     {
+      "key": "subclade_nextclade_ha",
+      "title": "HA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade_nextclade_na",
+      "title": "NA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
       "key": "haplotype",
       "title": "Derived haplotype",
       "type": "categorical"

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -80,6 +80,16 @@
       ]
     },
     {
+      "key": "subclade_nextclade_ha",
+      "title": "HA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade_nextclade_na",
+      "title": "NA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
       "key": "emerging_haplotype",
       "title": "Emerging haplotype",
       "type": "categorical",

--- a/config/h3n2/na/auspice_config.json
+++ b/config/h3n2/na/auspice_config.json
@@ -84,6 +84,16 @@
       ]
     },
     {
+      "key": "subclade_nextclade_ha",
+      "title": "HA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade_nextclade_na",
+      "title": "NA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
       "key": "haplotype",
       "title": "Derived haplotype",
       "type": "categorical"

--- a/config/vic/ha/auspice_config.json
+++ b/config/vic/ha/auspice_config.json
@@ -84,6 +84,16 @@
       ]
     },
     {
+      "key": "subclade_nextclade_ha",
+      "title": "HA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade_nextclade_na",
+      "title": "NA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
       "key": "emerging_haplotype",
       "title": "Emerging haplotype",
       "type": "categorical",

--- a/config/vic/na/auspice_config.json
+++ b/config/vic/na/auspice_config.json
@@ -84,43 +84,14 @@
       ]
     },
     {
-      "key": "proposed_subclade",
-      "title": "Proposed subclade",
-      "type": "categorical",
-      "scale": [
-        [
-          "B",
-          "#4068CF"
-        ],
-        [
-          "B.3",
-          "#5098B9"
-        ],
-        [
-          "B.5",
-          "#6CB28C"
-        ],
-        [
-          "B.7",
-          "#94BD62"
-        ],
-        [
-          "B.7.1",
-          "#BFBB47"
-        ],
-        [
-          "B.7.2",
-          "#DFA53B"
-        ],
-        [
-          "B.7.3",
-          "#E67131"
-        ],
-        [
-          "B.8",
-          "#DB2823"
-        ]
-      ]
+      "key": "subclade_nextclade_ha",
+      "title": "HA subclade (Nextclade)",
+      "type": "categorical"
+    },
+    {
+      "key": "subclade_nextclade_na",
+      "title": "NA subclade (Nextclade)",
+      "type": "categorical"
     },
     {
       "key": "lbi",

--- a/workflow/snakemake_rules/select_strains.smk
+++ b/workflow/snakemake_rules/select_strains.smk
@@ -278,15 +278,53 @@ def get_metadata_for_nextclade_merge(wildcards):
 def get_nextclade_for_subsampling(wildcards):
     return f"data/{config['builds'][wildcards.build_name]['lineage']}/ha/nextclade.tsv.xz"
 
-rule merge_nextclade_with_metadata:
+rule get_nextclade_subclade:
+    input:
+        nextclade="data/{lineage}/{segment}/nextclade.tsv.xz",
+    output:
+        nextclade_subclade="data/{lineage}/{segment}/nextclade_subclades.tsv",
+    shell:
+        r"""
+        xz -c -d {input.nextclade} \
+            | tsv-select -H -f seqName,clade \
+            | csvtk rename -t -f seqName,clade -n strain,'subclade_nextclade_{wildcards.segment}' > {output.nextclade_subclade}
+        """
+
+def get_nextclade_subclades(wildcards):
+    return [f"data/{config['builds'][wildcards.build_name]['lineage']}/{segment}/nextclade_subclades.tsv" for segment in config["segments"]]
+
+rule merge_nextclade_subclades_with_metadata:
     """
     Nextclade data is either merged with regular metadata (1) or titered metadata (2), see functions above
     """
     input:
+        # augur merge requires 2 or more input files, so merging metadata with 1
+        # or more Nextclade files per segment should always work.
         metadata=get_metadata_for_nextclade_merge,
+        nextclade_subclades=get_nextclade_subclades,
+    output:
+        merged = "builds/{build_name}/metadata_with_nextclade_subclades.tsv",
+    params:
+        # augur merge requires named inputs, so we name each path by the segment.
+        nextclade_subclades_named=lambda wildcards, input: [f"{segment}={segment_path}" for segment, segment_path in zip(config["segments"], input.nextclade_subclades)],
+    conda: "../envs/nextstrain.yaml"
+    log:
+        "logs/{build_name}/merge_nextclade_with_metadata.txt"
+    shell:
+        r"""
+        augur merge \
+           --metadata \
+             metadata={input.metadata} \
+             {params.nextclade_subclades_named} \
+           --output-metadata {output.merged} 2> {log}
+        """
+
+rule merge_nextclade_with_metadata:
+    input:
+        metadata="builds/{build_name}/metadata_with_nextclade_subclades.tsv",
         nextclade=get_nextclade_for_subsampling,
     output:
-        merged = "{build_dir}/{build_name}/metadata_with_nextclade.tsv"
+        merged = "{build_dir}/{build_name}/metadata_with_nextclade.tsv",
     params:
         metadata_id="strain",
         nextclade_id="seqName",


### PR DESCRIPTION
## Description of proposed changes

Annotates metadata with the subclade column from each segment's Nextclade annotations (e.g., "subclade_nextclade_ha") and exposes these new columns through the Auspice config JSONs for the HA/NA public
builds. Depending on the composition of the input sequences, augur clades' subclade annotations can be incorrect. In contrast, Nextclade's clade annotations do not depend on the collective composition of the input sequences. This implementation does not fully resolve the issue with augur clades' subclade annotations, since I have not annotated clades for internal nodes or handled branch labels. However, this approach should allow us to doublecheck augur clades annotations.

As part of the new Auspice config colorings, I chose to include both HA and NA clade colorings in both HA and NA Auspice config JSONs. This inclusion allows users to visualize potential reassortment events from a single HA or NA tree by either coloring the tree by the other segment's clade or by scatterplotting the HA and NA clades on the x and y axes.

Below is an example scatterplot for a subset of recent H1N1pdm samples showing HA and NA clades from Nextclade on x and y axis.

<img width="1141" height="650" alt="image" src="https://github.com/user-attachments/assets/6faa47c9-3dd6-4b97-900f-819f0c3177a3" />

This view shows:

 1. reassortment within HA clade D.3.1 (to NA clades D.1 and D.2)
 2. misannotation of a HA D.3.1 sample as D.4 by `augur clades` (gray dot in the bottom left)
 3. misannotation of a HA D.3.1.1 sample as D.3.1 by Nextclade (orange dot in the D.3.1 column on the left)

This approach could be a first step toward the complete replacement of `augur clades` with Nextclade as described in #131. However, Nextclade's own annotations can have their own issues (as shown above) and samples from monophyletic clades can appear in polyphyletic groups in the tree complicating assignment of unique branch labels.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Related to #254
Related to #131

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Test with GISAID quickstart with HA only
- [x] Test with quickstart builds for all three lineages and HA/NA
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
