### PR TITLE
Add trigger to run flu MLR models from upload

### DIFF
--- a/.github/workflows/upload.yaml
+++ b/.github/workflows/upload.yaml
@@ -20,6 +20,14 @@ on:
         description: "Specific container image to use for nextflu-private group builds"
         required: false
         type: string
+      triggerForecastsFlu:
+        description: "Trigger forecasts-flu models"
+        required: true
+        type: boolean
+      forecastsFluDockerImage:
+        description: "Specific container image to use for forecasts-flu models"
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -62,11 +70,17 @@ jobs:
       matrix:
         include:
           - trigger: ${{ inputs.triggerPublic }}
+            repo: seasonal-flu
             workflow: run-public-builds.yaml
             image: ${{ inputs.publicDockerImage }}
           - trigger: ${{ inputs.triggerNextfluPrivate }}
+            repo: seasonal-flu
             workflow: run-nextflu-private-builds.yaml
             image: ${{ inputs.nextfluPrivateDockerImage }}
+          - trigger: ${{ inputs.triggerForecastsFlu }}
+            repo: forecasts-flu
+            workflow: run-models.yaml
+            image: ${{ inputs.forecastsFluDockerImage }}
     runs-on: ubuntu-latest
     steps:
       - if: ${{ matrix.trigger }}
@@ -74,7 +88,7 @@ jobs:
         run: |
           gh workflow run \
             ${{ matrix.workflow }} \
-            --repo nextstrain/seasonal-flu \
+            --repo nextstrain/${{ matrix.repo }} \
             -f dockerImage=${{ matrix.image }}
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN_NEXTSTRAIN_BOT_WORKFLOW_DISPATCH }}


### PR DESCRIPTION
## Description of proposed changes

Adds a trigger to the upload workflow to run the forecasts-flu "run-models" workflow. Since this workflow lives in a different repository, this commit adds a "repo" variable to the trigger matrix to specify seasonal-flu or forecasts-flu repos.

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

Depends on https://github.com/nextstrain/forecasts-flu/pull/25
Closes https://github.com/nextstrain/forecasts-flu/issues/2

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
