### PR TITLE
WIP - fuzzy strain name matching

### DIFF
--- a/ingest/build-configs/strain-name-matching/README.md
+++ b/ingest/build-configs/strain-name-matching/README.md
@@ -1,0 +1,82 @@
+# Strain name matching
+
+With our move away from fauna and to a curated all-influenza ingest pipeline we have introduced a number of strain name changes. This immediately presents a problem as we have myriad lists of hardcoded strain names, such as outliers-to-drop and force-include-lists. This workflow (which is rather ad-hoc!) attempts to match up the old (i.e. fauna) strain names with their updated strain names.
+
+We use a combination of fuzzy-matching and, where possible a hardcoded map of fauna strain names to new strain names.
+
+## How to run
+
+```
+cd ingest
+snakemake --cores 4 --snakefile build-configs/strain-name-matching/Snakefile -pf -n
+```
+
+## What files you'll need
+
+* The original fauna metadata files e.g. (from the base directory) `aws s3 cp s3://nextstrain-data-private/files/workflows/seasonal-flu/h1n1pdm/metadata.tsv.xz - | xz -c -d > data/h1n1pdm/metadata.tsv`. Note that this file won't represent fauna data forever!
+
+* A number of files from the normal ingest pipeline. `snakemake --cores 2 --config gisaid_pairs='["gisaid_cache"]' -pf data/curated_gisaid.ndjson data/avian-flu/curated_gisaid.ndjson results/h3n2/metadata.tsv results/h1n1pdm/metadata.tsv results/vic/metadata.tsv results/yam/metadata.tsv`
+
+
+## Hardcoded strain maps
+
+For seasonal-flu datasets we can query the EPI_ISLs of the fauna data against the curated data to create lookups. 
+This table reports how many of the fauna strain names have matches in our data. For avian-flu it's a little tricker so we leverage the existing diff-avian-flu script to create lookups.
+
+
+| Dataset  | Updated | Missing | Unchanged |
+| -------- | ------- | -- | -- |
+| H1N1pdm  | 1,729    | 1,659 | 149,143
+| H3N2  | 2,125    | 2,674 | 177,009
+| vic  | 1,338    | 286 | 66,283
+| yam  | 367    | 10 | 21,946
+| avian-flu | 34,426 | 1,531 | 26,754
+
+
+
+## TITERS _WIP!
+
+
+
+```
+cat ../builds/seasonal-flu_h3n2_3y/all_titers.tsv | cut -f 1 | sort | uniq > results/strain-name-matching/h3n2/titers_virus_strain.txt
+cat ../builds/seasonal-flu_h3n2_3y/all_titers.tsv | cut -f 2 | sort | uniq > results/strain-name-matching/h3n2/titers_serum_strain.txt
+
+./scripts/strain-name-fuzzer.py --curated-strains results/strain-name-matching/h3n2/metadata.txt --query-strains results/strain-name-matching/h3n2/titers_serum_strain.txt --strain-map results/strain-name-matching/h3n2/strain-name-map.tsv > /dev/null
+
+./scripts/strain-name-fuzzer.py --curated-strains results/strain-name-matching/h3n2/metadata.txt --query-strains results/strain-name-matching/h3n2/titers_virus_strain.txt --strain-map results/strain-name-matching/h3n2/strain-name-map.tsv > /dev/null
+```
+
+
+```
+cd data/titers/
+aws s3 cp --exclude "*" --include "*.tsv.gz" --recursive s3://nextstrain-data-private/files/workflows/seasonal-flu/ .
+```
+
+```
+for x in data/titers/*/*.tsv.gz; do
+    echo ${x}
+    gzcat ${x} | csvtk -t cut -f virus_strain | sort | uniq > ${x%.tsv.gz}_virus-strain.txt
+    gzcat ${x} | csvtk -t cut -f serum_strain | sort | uniq > ${x%.tsv.gz}_serum-strain.txt
+done
+```
+
+Following is too slow, so....
+```
+for x in data/titers/h3n2/*.txt; do
+    echo ${x}
+    ./scripts/strain-name-fuzzer.py \
+        --curated-strains results/strain-name-matching/h3n2/metadata.txt \
+        --query-strains ${x} \
+        --strain-map results/strain-name-matching/h3n2/strain-name-map.tsv \
+        > /dev/null
+done
+```
+
+cat data/titers/h3n2/*.txt | sort | uniq > data/titers/h3n2.all-strains.txt
+
+./scripts/strain-name-fuzzer.py \
+    --curated-strains results/strain-name-matching/h3n2/metadata.txt \
+    --query-strains data/titers/h3n2.all-strains.txt \
+    --strain-map results/strain-name-matching/h3n2/strain-name-map.tsv \
+    > /dev/null

--- a/ingest/build-configs/strain-name-matching/Snakefile
+++ b/ingest/build-configs/strain-name-matching/Snakefile
@@ -1,0 +1,83 @@
+include: "../../rules/remote_files.smk"
+
+import os
+configfile: os.path.join(workflow.basedir, "config.yaml")
+
+print(f"{config=}")
+
+rule all:
+    input:
+        files = [f"results/strain-name-matching/{d}/{f}" for d in config['strain-lists'] for f in config['strain-lists'][d]]
+
+
+rule metadata_strains:
+    input:
+        "results/{dataset}/metadata.tsv",
+    output:
+        "results/strain-name-matching/{dataset}/metadata.txt"
+    run:
+        from augur.io import read_metadata
+        m = read_metadata(input[0])
+        with open(output[0], 'w') as fh:
+            print("\n".join(m.index.tolist()), file=fh)
+
+rule compute_strain_maps_via_epi_isl_lookup:
+    """
+    Computes maps of (old) fauna strain names to (new) curated strain names, where possible.
+    Fauna inputs via (e.g.) "aws s3 cp s3://nextstrain-data-private/files/workflows/seasonal-flu/vic/metadata.tsv
+.xz - | xz -c -d > data/vic/metadata.tsv"
+    """
+    input:
+        fauna=lambda w: config['strain-maps'][w.dataset],
+        curated="data/curated_gisaid.ndjson",   # hardcoded
+    output:
+        tsv = "results/strain-name-matching/{dataset}/strain-name-map.tsv"
+    wildcard_constraints:
+        dataset= "h3n2|h1n1pdm|vic|yam"
+    shell:
+        """
+        ./scripts/match-strain-names.py \
+            --original-metadata {input.fauna} \
+            --new-metadata {input.curated} \
+            --changed {output.tsv}
+        """
+
+rule compute_strain_maps_via_avian_flu_diff:
+    """
+    Computes maps of (old) fauna strain names to (new) curated strain names, where possible.
+    """
+    input:
+        fauna=lambda w: config['strain-maps'][w.dataset],
+        curated="data/avian-flu/curated_gisaid.ndjson",   # hardcoded
+    output:
+        tsv = "results/strain-name-matching/{dataset}/strain-name-map.tsv"
+    wildcard_constraints:
+        dataset= "avian-flu"
+    shell:
+        """
+        ./scripts/diff-avian-flu.py \
+            --truth {input.fauna} \
+            --query {input.curated} \
+            --output-strain-map {output.tsv}
+        """
+
+def strain_map(wildcards):
+    if config['strain-maps'].get(wildcards.dataset, False):
+        return "results/strain-name-matching/{dataset}/strain-name-map.tsv"
+    return []   
+
+rule match_strains:
+    input:
+        metadata="results/strain-name-matching/{dataset}/metadata.txt",
+        strains=lambda w: path_or_url(config['strain-lists'][w.dataset][w.file_type]),
+        strain_map_tsv=strain_map,
+    output:
+        strains="results/strain-name-matching/{dataset}/{file_type}",
+    shell:
+        """
+        ./scripts/strain-name-fuzzer.py \
+            --curated-strains {input.metadata:q} \
+            --query-strains {input.strains:q} \
+            --strain-map {input.strain_map_tsv:q} \
+            > {output.strains:q}
+        """

--- a/ingest/build-configs/strain-name-matching/config.yaml
+++ b/ingest/build-configs/strain-name-matching/config.yaml
@@ -1,0 +1,42 @@
+
+strain-maps:
+    # The value here points to the FAUNA data
+    h1n1pdm: "../data/{dataset}/metadata.tsv"
+    h3n2: "../data/{dataset}/metadata.tsv"
+    vic: "../data/{dataset}/metadata.tsv"
+    yam: "../data/{dataset}/metadata.tsv"
+    avian-flu: "targets/avian-flu-fauna-ha.tsv"
+
+
+strain-lists:
+    h3n2:
+        "outliers.txt": "../config/h3n2/outliers.txt"
+        "reference_strains.txt": "../config/h3n2/reference_strains.txt"
+        "ha_prioritised_seqs_file.tsv": "../config/h3n2/ha/prioritized_seqs_file.tsv"
+
+    vic:
+        "outliers.txt": "../config/vic/outliers.txt"
+        "reference_strains.txt": "../config/vic/reference_strains.txt"
+
+    yam:
+        "outliers.txt": "../config/yam/outliers.txt"
+        "reference_strains.txt": "../config/yam/reference_strains.txt"
+
+    h1n1pdm:
+        "outliers.txt": "../config/h1n1pdm/outliers.txt"
+        "reference_strains.txt": "../config/h1n1pdm/reference_strains.txt"
+
+    avian-flu:
+        h5n1_dropped_strains_h5n1.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5n1/dropped_strains_h5n1.txt
+        h5n1_include_strains_h5n1_2y.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5n1/include_strains_h5n1_2y.txt
+        h5n1_include_strains_h5n1_all-time.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5n1/include_strains_h5n1_all-time.txt
+
+        h5nx_dropped_strains_h5nx.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5nx/dropped_strains_h5nx.txt
+        h5nx_include_strains_h5nx_2y.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5nx/include_strains_h5nx_2y.txt
+        h5nx_include_strains_h5nx_all-time.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5nx/include_strains_h5nx_all-time.txt
+
+        h7n9_dropped_strains_h7n9.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h7n9/dropped_strains_h7n9.txt
+        h7n9_include_strains_h7n9_all-time.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h7n9/include_strains_h7n9_all-time.txt
+
+        h9n2_dropped_strains_h9n2.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h9n2/dropped_strains_h9n2.txt
+        h9n2_include_strains_h9n2_all-time.txt: https://raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h9n2/include_strains_h9n2_all-time.txt

--- a/ingest/build-configs/titer-matching/README.md
+++ b/ingest/build-configs/titer-matching/README.md
@@ -1,0 +1,26 @@
+
+
+
+1. Get the titers TSVs (gzipped) from S3 and store them in `data/titers/<subtype>/`
+```
+aws s3 cp --exclude "*" --include "*.tsv.gz" --recursive --dryrun s3://nextstrain-data-private/files/workflows/seasonal-flu/ .
+```
+
+2. Get the fauna metadata (will get some extra that we don't need but that's ok)
+```
+mkdir data/fauna-metadata
+cd data/fauna-metadata/
+
+aws s3 cp --exclude "*" --include "metadata.tsv.xz" --recursive --dryrun s3://nextstrain-data-private/files/workflows/seasonal-flu/ .
+
+rm -rf trials
+```
+
+3. Curate (ingest) data as per our new snakemake pipeline
+this gets files like `results/h3n2/metadata.tsv`
+
+4. Run script
+```
+./scripts/titer-strain-matching.py --titers data/titers/ --fauna data/fauna-metadata/ --curated results/ --output results/titer-matching.png && open results/titer-matching.png
+```
+

--- a/ingest/scripts/match-strain-names.py
+++ b/ingest/scripts/match-strain-names.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Provides a fauna strain name -> ndjson (curated) strain name mapping
+by matching records on EPI ISL.
+"""
+import argparse
+import sys
+from augur.io import read_metadata
+from augur.io.json import load_ndjson
+
+type EpiIsl = str
+type StrainName = str
+
+def parse_existing_metadata(fname: str) -> dict[EpiIsl, StrainName]:
+    df = read_metadata(fname)
+    return dict(zip(df['gisaid_epi_isl'], df.index))
+
+def parse_ndjson(fname: str) -> dict[EpiIsl, StrainName]:
+    with open(fname) as fh:
+        records = load_ndjson(fh)
+        return {record['gisaid_epi_isl']:record['strain'] for record in records}
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--original-metadata", required=True, help="Original (fauna) metadata TSV with 'strain' and 'gisaid_epi_isl' columns")
+    parser.add_argument("--new-metadata", required=True, help="Curated NDJSON")
+    parser.add_argument("--changed", required=True, help="TSV of strain names which have changed. Map is FAUNA -> NEW")
+    args = parser.parse_args()
+
+    fauna = parse_existing_metadata(args.original_metadata)
+    curated = parse_ndjson(args.new_metadata)
+    changed_fh = open(args.changed, 'w')
+    print("FAUNA_STRAIN\tCURATED_STRAIN", file=changed_fh)
+
+    [unchanged, changed, missing] = [0,0,0]
+    for epi_isl, fauna_name in fauna.items():
+        new_name = curated.get(epi_isl, None)
+        if new_name is None:
+            missing+=1
+            continue
+        if fauna_name == new_name:
+            unchanged+=1
+        else:
+            changed+=1
+            print(f"{fauna_name}\t{new_name}", file=changed_fh)
+
+    print(f"Using {args.original_metadata} as source of truth...", file=sys.stderr)
+    print(f"{missing=:,}")
+    print(f"{changed=:,}")
+    print(f"{unchanged=:,}")
+    changed_fh.close()

--- a/ingest/scripts/strain-name-fuzzer.py
+++ b/ingest/scripts/strain-name-fuzzer.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""
+Provided with two lists of strain names we want to match all query strains
+against the list of curated strains using fuzzy matching.
+
+"""
+import argparse
+import difflib
+import sys
+
+def read_strains(fname:str)->list[str]:
+    strains = list()
+    with open(fname, 'r', newline='') as fh:
+        for line in fh:
+            contents = line.strip()
+            if not contents or contents.startswith('#'):
+                continue
+            strains.append(contents)
+    return strains
+
+
+def read_text_file(fname:str)->list[str]:
+    with open(fname, 'r', newline='') as fh:
+        lines = [line for line in fh]
+    return lines
+
+def normalize_for_matching(s: str) -> str:
+    """Normalize string: remove hyphens and convert to lowercase."""
+    return s.replace('-', '').lower()
+
+
+def extract_digits(s: str) -> str:
+    """Extract all digits from a string in order."""
+    return ''.join(c for c in s if c.isdigit())
+
+def no_zeros(s: str) -> str:
+    return ''.join(c for c in s if c!='0')
+
+
+def calculate_similarity(query_norm: str, target_norm: str) -> float:
+    """
+    Calculate similarity score that:
+    - Ignores hyphens and case differences
+    - Heavily penalizes digit mismatches
+    """
+    # passage mismatch is a non-starter
+    if (query_norm.endswith("egg") and not target_norm.endswith("egg")) or (target_norm.endswith("egg") and not query_norm.endswith("egg")):
+         return 0.0
+
+    # Extract and compare digits
+    query_digits = extract_digits(query_norm)
+    target_digits = extract_digits(target_norm)
+
+    # numbers cannot be different _EXCEPT FOR_ dropped zeros
+    if no_zeros(query_digits)!=no_zeros(target_digits):
+        return 0.0
+
+    # Get base similarity on normalized strings
+    base_similarity = difflib.SequenceMatcher(None, query_norm, target_norm).ratio()
+
+    final_score = max(0.0, base_similarity)
+
+    return final_score
+
+def find_highest(similarities: list[tuple[str, float]]) -> tuple[str, float]:
+    h:float = 0
+    s = ""
+    for (strain, score) in similarities:
+        if score>h:
+            s = strain
+            h = score
+    return (s, h)
+
+
+
+def extract_strain(line: str, is_tsv: bool) -> str|None:
+    if line.startswith('#') or line.strip()=='':
+        return None
+    if not is_tsv:
+        return line.strip()
+    # assume it's the first column, and ignore any subtlety in splitting TSVs for now
+    return line.split('\t')[0].strip()
+
+def replace_strain(new_strain:str, old_strain:str, line: str) -> str:
+    return line.replace(old_strain, new_strain)
+
+def print_everywhere(*args) -> None:
+    print(*args, file=sys.stderr)
+    print(*args)
+
+def parse_strain_map(fname:str|None) -> dict[str,str]:
+    if not fname:
+        return {}
+    with open(fname[0]) as fh:
+        return dict([line.strip().split() for line in fh])
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--curated-strains", required=True, help="Text file with curated strain names")
+    parser.add_argument("--query-strains", required=True, help="Text file with query strain names (e.g. include.txt)")
+    parser.add_argument("--strain-map", required=False, nargs='*', help="Hardcoded map of query strain (fauna) to new curated strain")
+    parser.add_argument("--no-fuzz", required=False,action='store_true', help="Skip fuzzing for efficiency reasons")
+
+    args = parser.parse_args()
+
+    direct_matches: int = 0
+    normalized_match: int = 0
+    fuzzy_matches: int = 0
+    no_matches: int = 0
+    query_strains: int = 0
+    strain_map_hit: int = 0
+
+    curated_strains = read_strains(args.curated_strains)
+    curated_strains_set = set(curated_strains)
+    curated_strains_normalized = [normalize_for_matching(w) for w in curated_strains]
+    curated_strains_normalized_set = set(curated_strains_normalized)
+    query_lines = read_text_file(args.query_strains)
+    strain_map = parse_strain_map(args.strain_map)
+    is_tsv = args.query_strains.endswith(".tsv")
+
+    # STDOUT is the new strains text file
+    print(f"# Strains list generated via fuzzy matching")
+    print(f"# Original file: {args.query_strains!r}")
+    print(f"")
+
+
+    for idx, line in enumerate(query_lines):
+        if idx%100==0:
+            print(f"{idx:,}/{len(query_lines):,}", file=sys.stderr)
+
+        # strain can be thought of as fauna strain
+        strain = extract_strain(line, is_tsv)
+
+        if strain is None or (strain=='strain' and is_tsv):
+            print(line, end="")
+            continue
+
+        query_strains+=1
+
+        if strain in strain_map:
+            print(replace_strain(strain_map[strain], strain, line), end="")
+            strain_map_hit+=1
+            continue
+
+        if strain in curated_strains_set: # direct match - just echo back the original line
+            print(line, end="")
+            direct_matches += 1
+            continue
+        
+        query_norm = normalize_for_matching(strain)
+
+        # Check if the normalized string exists, and call it a normalized match
+        if query_norm in curated_strains_normalized_set:
+            print(replace_strain(query_norm, strain, line), end="")
+            normalized_match+=1
+        
+        if args.no_fuzz:
+            print()
+            print("# TODO XXX Couldn't find a matching strain for the following line:")
+            print(line, end="")
+            no_matches+=1
+            continue
+
+
+        # Loop over the curated strains to calculate similarities
+        similarities = [similarity for similarity in 
+            [(curated, calculate_similarity(query_norm, curated_norm))
+            for (curated, curated_norm) in zip(curated_strains, curated_strains_normalized)]
+            if similarity[1] >= 0.8 # TODO XXX
+        ]
+        if len(similarities)==0:
+            print()
+            print("# TODO XXX Couldn't find a matching strain for the following line:")
+            print(line, end="")
+            no_matches += 1
+            continue
+
+        best = find_highest(similarities)
+
+        if best[1]==1: 
+            print(replace_strain(best[0], strain, line), end="")
+            normalized_match+=1
+        elif best[1]>0.9:
+            print(f"# Following strain was close match ({best[1]:.3f}) to original strain {strain!r}")
+            print(replace_strain(best[0], strain, line), end="")
+            fuzzy_matches += 1
+        else:
+            print()
+            print("# TODO XXX Couldn't find a matching strain for the following line:")
+            print(line, end="")
+            no_matches += 1
+
+    if query_strains:
+        print_everywhere(f"\n# === Summary {args.query_strains} ===")
+        print_everywhere(f"# Direct matches:         {direct_matches:,} / {query_strains:,} ({100*direct_matches/query_strains:.1f}%)")
+        print_everywhere(f"# Changed via lookup:     {strain_map_hit:,} / {query_strains:,} ({100*strain_map_hit/query_strains:.1f}%)")
+        print_everywhere(f"# Normalized matches:     {normalized_match:,} / {query_strains:,} ({100*normalized_match/query_strains:.1f}%)")
+        print_everywhere(f"# Fuzzy matches:          {fuzzy_matches:,} / {query_strains:,} ({100*fuzzy_matches/query_strains:.1f}%)")
+        print_everywhere(f"# No matches:             {no_matches:,} / {query_strains:,} ({100*no_matches/query_strains:.1f}%)")
+        
+
+    

--- a/ingest/scripts/titer-strain-matching.py
+++ b/ingest/scripts/titer-strain-matching.py
@@ -1,0 +1,371 @@
+#!/usr/bin/env python3
+
+"""
+TKTK
+"""
+
+
+import argparse
+import sys
+import zstandard as zstd
+import gzip
+import lzma
+from collections import defaultdict
+import io
+import csv
+import glob
+import os
+from augur.io import read_metadata
+import matplotlib.pyplot as plt
+import matplotlib
+
+SUBTYPES = ['h3n2', 'h1n1pdm', 'vic', 'yam']
+
+# SUBTYPES = ['h3n2']
+UNKNOWN_YEAR = 'unknown'
+
+type Subtype = str
+type Contrib = str
+type Strains = set[str]
+type Year = str # '2014' etc, with 'unknown' the null
+type TiterInfo = defaultdict[Subtype, defaultdict[Contrib, defaultdict[Year, Strains]]]
+type MatchInfo = tuple[int, int] # match count, total number strains
+type TiterMatches = defaultdict[Subtype, defaultdict[Contrib, defaultdict[Year, MatchInfo]]]
+
+
+def open_file(file_path: str):
+    """
+    Open a file, decompressing if needed.
+    Supports .zst, .gz, and .xz files.
+    Returns a text-mode file handle.
+    """
+    if file_path.endswith('.zst'):
+        dctx = zstd.ZstdDecompressor()
+        fh = open(file_path, 'rb')
+        reader = dctx.stream_reader(fh)
+        # Wrap in TextIOWrapper to get text mode
+        return io.TextIOWrapper(reader, encoding='utf-8')
+    elif file_path.endswith('.gz'):
+        return gzip.open(file_path, 'rt', encoding='utf-8')
+
+    elif file_path.endswith('.xz'):
+        return lzma.open(file_path, 'rt', encoding='utf-8')
+    else:
+        return open(file_path, 'r')
+
+
+def read_titer_file(fname: str) -> list[tuple[str,str]]:
+    virus_serum_tuples: list[tuple[str,str]] = []
+    with open_file(fname) as f:
+        reader = csv.DictReader(f, delimiter='\t')
+        for row in reader:
+            virus_serum_tuples.append((row['virus_strain'], row['serum_strain']))
+
+    return virus_serum_tuples
+
+def extract_year(strain:str) -> str:
+    try:
+        year = strain.split('/')[-1]
+        year = year.replace('-egg', '')
+        if int(year) < 1960 or int(year)>2026:
+            # don't bother logging, I've checked and they're not solvable.
+            # BUT! If we cross-reference with fauna they might be?
+            return UNKNOWN_YEAR
+        return year
+    except:
+        print("Unknown strain year", strain, file=sys.stderr)
+        return UNKNOWN_YEAR
+
+def read_titers(dir: str)-> TiterInfo:
+    """
+    Read all the titers files and collapse them to a simple set of unique strains
+    for each subtype, for each collaborating center.
+    Don't differentiate between virus strain and serum strain.
+    """
+    data: TiterInfo = defaultdict(lambda: defaultdict(lambda: defaultdict(set)))
+    for subtype in SUBTYPES:
+        for file in glob.glob(os.path.join(dir, subtype, '*.tsv.gz')):
+            contributor = file.split(subtype)[1].replace('/', '').split('_')[0]
+            pairs = read_titer_file(file)
+            for pair in pairs:
+                for el in pair:
+                    data[subtype][contributor][extract_year(el)].add(el)
+    print("-------------- titers ---------------", file=sys.stderr)
+    for subtype in SUBTYPES:
+        for contrib,strains_per_year in data[subtype].items():
+            num_strains = sum([len(strains) for strains in strains_per_year.values()])
+            years = sorted(list(strains_per_year.keys()))
+            print(f"{subtype:<10}{contrib:<8} n(unique strains)={num_strains:,}", file=sys.stderr)
+    return data
+
+
+def parse_metadata(name: str, dir: str, filename: str, epi_isl_key:str = "gisaid_epi_isl") -> defaultdict[Subtype, list[tuple[str,str]]]:
+    data: defaultdict[Subtype, list[tuple[str,str]]] = defaultdict(list)
+    for subtype in SUBTYPES:
+        df = read_metadata(os.path.join(dir, subtype, filename))
+        data[subtype] = list(zip(df.index, df[epi_isl_key]))
+    print(f"------ parsing {name} metadata  ------", file=sys.stderr)
+    for subtype in SUBTYPES:
+        print(f"{subtype:<10} n(strains/epi-isls)={len(data[subtype]):,}", file=sys.stderr)
+    return data
+
+def strain_set(tuple_data: defaultdict[Subtype, list[tuple[str,str]]]) -> defaultdict[Subtype, Strains]:
+    data: defaultdict[Subtype, Strains] = defaultdict(set)
+    for subtype in SUBTYPES:
+        data[subtype] = set([pair[0]for pair in tuple_data[subtype]])
+    return data
+
+
+
+def compute_simple_matches(name: str,
+        strain_data: defaultdict[Subtype, Strains],
+        titers: TiterInfo) -> TiterMatches:
+    print(f"------ {name} metadata vs titers (simple) matching --------", file=sys.stderr)
+    data: TiterMatches = defaultdict(lambda: defaultdict(lambda: defaultdict()))
+    for subtype in SUBTYPES:
+        metadata_strains = strain_data[subtype]
+        for contrib in titers[subtype]:
+            for year, titer_strains in titers[subtype][contrib].items():
+                num_matches = len(titer_strains & metadata_strains)
+                num_titer_strains = len(titer_strains)
+                data[subtype][contrib][year] = (num_matches, num_titer_strains)
+                print(f"{subtype:<10}{contrib:<8}{year:<9} {num_matches:,}/{num_titer_strains:,} ({int(num_matches*100/num_titer_strains)}%)", file=sys.stderr)
+    return data
+
+punctuation = ['/','_', '(', ')', ',', '-', ' ', ';', '.']
+def simplify_strain(s: str) -> str:
+    """Normalize string for more fuzzy-like matching"""
+    s = s.lower()
+    for char in punctuation:
+        s = s.replace(char, '')
+    s = s.replace("a/a/", "a/")
+    return s
+
+def compute_complex_matches(
+        curated_metadata: defaultdict[Subtype, list[tuple[str,str]]],
+        fauna_metadata: defaultdict[Subtype, list[tuple[str,str]]],
+        titers: TiterInfo) -> TiterMatches:
+    print(f"------ curated metadata vs titers (complex) matching --------", file=sys.stderr)
+    data: TiterMatches = defaultdict(lambda: defaultdict(lambda: defaultdict()))
+    for subtype in SUBTYPES:
+        curated_metadata_strains   = set([pair[0]for pair in curated_metadata[subtype]])
+        fauna_strain_to_epi_isl    = dict(fauna_metadata[subtype])
+        epi_isl_to_curated_strain  = dict([[x[1],x[0]] for x in curated_metadata[subtype]])
+        normalized_curated_strains = {simplify_strain(s) for s in curated_metadata_strains}
+
+        for contrib in titers[subtype]:
+            for year, titer_strains in titers[subtype][contrib].items():
+                num_titer_strains = len(titer_strains)
+                num_matches:int = 0
+                for titer_strain in titer_strains:
+                    # first do the same as the simple matching
+                    if titer_strain in curated_metadata_strains:
+                        num_matches+=1
+                        continue
+
+                    # If it's a fauna match & we can use EPI ISL linkage then do so
+                    if epi_isl:=fauna_strain_to_epi_isl.get(titer_strain, None):
+                        if curated_strain:=epi_isl_to_curated_strain.get(epi_isl, None):
+                            num_matches+=1
+                            continue
+                    
+                    # Normalize
+                    if simplify_strain(titer_strain) in normalized_curated_strains:
+                        num_matches+=1
+                        continue
+
+                data[subtype][contrib][year] = (num_matches, num_titer_strains)
+                print(f"{subtype:<10}{contrib:<8}{year:<9} {num_matches:,}/{num_titer_strains:,} ({int(num_matches*100/num_titer_strains)}%)", file=sys.stderr)
+    return data
+
+
+def plot_matches(fauna_matches: TiterMatches,
+                 curated_matches: TiterMatches,
+                 curated_matches_complex: TiterMatches,
+                 output_file: str):
+    """
+    Create small-multiples visualization of fauna matching percentages over time.
+
+    Creates one subplot per subtype, with each contributor as a separate line.
+    Two rows: fauna matches (top) and curated matches (bottom)
+    X-axis: years
+    Y-axis: percentage of strains matched (a/b*100)
+    """
+    # Set up the figure with 3 rows and columns for each subtype
+    n_subtypes = len(SUBTYPES)
+    fig, axes = plt.subplots(3, n_subtypes, figsize=(5*n_subtypes, 12), squeeze=False)
+
+    # Collect all unique contributors across all subtypes and both datasets
+    _all_contributors: set[str] = set()
+    for subtype in SUBTYPES:
+        _all_contributors.update(fauna_matches[subtype].keys())
+        _all_contributors.update(curated_matches[subtype].keys())
+    all_contributors: list[str] = sorted(_all_contributors)
+
+    n_contributors = len(all_contributors)
+    cmap = plt.cm.tab10
+    contributor_colors = {contrib: cmap(i % cmap.N)
+                         for i, contrib in enumerate(all_contributors)}
+
+    # Plot both fauna and curated matches
+    datasets = [
+        (0, fauna_matches, "Fauna metadata - titers match %"),
+        (1, curated_matches, "Curated metadata - titers match %"),
+        (2, curated_matches_complex, "Curated metadata - titers match %\nwith remapping layer"),
+    ]
+
+    for row_idx, match_data, y_label in datasets:
+        for col_idx, subtype in enumerate(SUBTYPES):
+            ax = axes[row_idx, col_idx]
+
+            # Get data for this subtype
+            subtype_data = match_data[subtype]
+
+            # Collect all unique years across all contributors for this subtype
+            all_years_set: set[str] = set()
+            for year_data in subtype_data.values():
+                all_years_set.update(year_data.keys())
+
+            # Sort years, ensuring 'unknown' comes at the end
+            numeric_years = sorted([y for y in all_years_set if y != UNKNOWN_YEAR])
+            all_years = numeric_years + ([UNKNOWN_YEAR] if UNKNOWN_YEAR in all_years_set else [])
+
+            # Track overall percentages for y-axis ticks
+            overall_percentages = []
+            overall_colors = []
+            overall_contributors = []
+
+            # Plot each contributor as a separate line
+            for contributor, year_data in subtype_data.items():
+                # Calculate percentages and totals only for years where this contributor has data
+                contributor_years = []
+                percentages = []
+                totals = []
+                for year in all_years:
+                    if year in year_data:
+                        matches, total = year_data[year]
+                        contributor_years.append(year)
+                        if total > 0:
+                            percentages.append((matches / total) * 100)
+                        else:
+                            percentages.append(0)
+                        totals.append(total)
+
+                if not contributor_years:
+                    continue
+
+                # Calculate overall percentage across all years (including unknown)
+                total_matches = sum(year_data[year][0] for year in year_data.keys())
+                total_strains = sum(year_data[year][1] for year in year_data.keys())
+                overall_pct = (total_matches / total_strains * 100) if total_strains > 0 else 0
+
+                # Get the predefined color for this contributor
+                line_color = contributor_colors[contributor]
+
+                # Plot the line without markers
+                line = ax.plot(contributor_years, percentages, label=contributor,
+                              linewidth=0.5, color=line_color)
+
+                # Store overall percentage, color, and contributor name for y-axis ticks
+                overall_percentages.append(overall_pct)
+                overall_colors.append(line_color)
+                overall_contributors.append(contributor)
+
+                # Add scatter points with sizes proportional to total strains
+                # Scale the marker size: base size + proportional to total
+                marker_sizes = [t / 10 for t in totals]  # Adjust divisor to scale appropriately
+                ax.scatter(contributor_years, percentages, s=marker_sizes, color=line_color,
+                          alpha=0.7, zorder=5)
+
+            # Customize the subplot
+            # Only show title on the top row
+            if row_idx == 0:
+                ax.set_title(f'{subtype.upper()}', fontsize=14, fontweight='bold')
+            # Only show y-axis label on the first (leftmost) subplot of each row
+            if col_idx == 0:
+                ax.set_ylabel(y_label, fontsize=12)
+            ax.set_ylim(0, 100)
+
+            # Get the default y-ticks that matplotlib would use (for grid lines)
+            existing_yticks = list(ax.get_yticks())
+
+            # Draw grid at the original tick positions (both x and y)
+            ax.grid(True, alpha=0.3)
+
+            # Now add overall percentage ticks as minor ticks (won't create grid lines)
+            # First, keep the major ticks as they were
+            ax.set_yticks(existing_yticks)
+            # Add overall percentages as minor ticks (tick marks only)
+            ax.set_yticks(overall_percentages, minor=True)
+            # Don't show labels on the minor ticks themselves
+            ax.yaxis.set_tick_params(which='minor', labelleft=False)
+
+            # Add custom text labels for overall percentages positioned to the right of the y-axis
+            for contributor, overall_pct, color in zip(overall_contributors, overall_percentages, overall_colors):
+                # Position text just to the right of the y-axis (inside the plot area)
+                ax.text(0.01, overall_pct, f'{contributor} = {overall_pct:.1f}%',
+                       transform=ax.get_yaxis_transform(),
+                       ha='left', va='center',
+                       color=color, fontweight='bold',
+                       fontsize=9)
+
+            # Set the x-axis limits and tick positions
+            # This ensures the categorical axis follows our year ordering
+            ax.set_xlim(-0.5, len(all_years) - 0.5)
+
+            # Set x-axis to only show every 5th year
+            # Build tick list ensuring 'unknown' is at the end if it exists
+            tick_positions = []
+            tick_labels = []
+            for idx, year in enumerate(all_years):
+                if year == UNKNOWN_YEAR or (year != UNKNOWN_YEAR and int(year) % 5 == 0):
+                    tick_positions.append(idx)
+                    tick_labels.append(year)
+
+            ax.set_xticks(tick_positions)
+            ax.set_xticklabels(tick_labels)
+
+            # Rotate x-axis labels for better readability
+            plt.setp(ax.xaxis.get_majorticklabels(), rotation=45, ha='right')
+
+    # Adjust layout to prevent overlap
+    plt.tight_layout()
+
+    # Save as high-resolution PNG
+    plt.savefig(output_file, dpi=300, bbox_inches='tight')
+    print(f"\nFigure saved to {output_file}", file=sys.stderr)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--titers", required=True, metavar='DIR',
+                        help="Folder which is expected to have subfolders 'h3n2' etc each with titers TSVs in them")
+    parser.add_argument("--fauna", required=True, metavar='DIR',
+                        help="Folder which is expected to have subfolders 'h3n2' etc each with a fauna `metadata.tsv.xz`")
+    parser.add_argument("--curated", required=True, metavar='DIR',
+                        help="Folder which is expected to have subfolders 'h3n2' etc each with a fauna `metadata.tsv.xz`")
+    parser.add_argument("--output", default="fauna_matches.png",
+                        help="Output file for the visualization (default: fauna_matches.png)")
+    # parser.add_argument("--query-strains", required=True, help="Text file with query strain names (e.g. include.txt)")
+    # parser.add_argument("--strain-map", required=False, nargs='*', help="Hardcoded map of query strain (fauna) to new curated strain")
+    # parser.add_argument("--no-fuzz", required=False,action='store_true', help="Skip fuzzing for efficiency reasons")
+
+    args = parser.parse_args()
+
+    titers = read_titers(args.titers)
+
+    fauna = parse_metadata("fauna", args.fauna, "metadata.tsv.xz")
+    curated = parse_metadata("curated", args.curated, "metadata.tsv")
+    fauna_strains = strain_set(fauna)
+    curated_strains = strain_set(curated)
+
+    # simple (identical) matching
+    fauna_matches = compute_simple_matches("fauna", fauna_strains, titers)
+    curated_matches = compute_simple_matches("curated", curated_strains, titers)
+
+    # complex matching 
+    curated_matches_complex = compute_complex_matches(curated, fauna, titers)
+
+    plot_matches(fauna_matches, curated_matches, curated_matches_complex, args.output)
+
+


### PR DESCRIPTION
With our move away from fauna and to a curated all-influenza ingest pipeline we have introduced a number of strain name changes. This immediately presents a problem as we have myriad lists of hardcoded strain names, such as outliers-to-drop and force-include-lists. This workflow (which is rather ad-hoc!) attempts to match up the old (i.e. fauna) strain names with their updated strain names.

We use a combination of fuzzy-matching and a hardcoded map of fauna strain names to new strain names.

See added readme for how to run (not very user friendly at the moment!)

## Hardcoded strain maps

For seasonal-flu datasets we can query the EPI_ISLs of the fauna data against the curated data to create lookups. 
This table reports how many of the fauna strain names have matches in our data. For avian-flu it's a little tricker so we leverage the existing diff-avian-flu script to create lookups.


| Dataset  | Updated | Missing | Unchanged |
| -------- | ------- | -- | -- |
| H1N1pdm  | 1,729    | 1,659 | 149,143
| H3N2  | 2,125    | 2,674 | 177,009
| vic  | 1,338    | 286 | 66,283
| yam  | 367    | 10 | 21,946
| avian-flu | 34,426 | 1,531 | 26,754

## Example results

Not able to be matched:
  * Fauna strain name `A/Environment/InnerMongolia/23285/2019` is now `A/Environment/Neimenggu/23285/2019` (the location change is via [this fauna TSV](https://github.com/nextstrain/fauna/blob/ecc9bf7dbc64daf1ee7926de993facf7967d2733/source-data/flu_fix_location_label.tsv#L344).

Automatically matched:
  * Fauna `A/Indiana/08/2012` remapped to `A/Indiana/8/2012` via fuzzy matching (this looks right)
  * Fauna `A/India/3/2019` remapped to `A/Indiana/3/2019` via fuzzy matching (this is wrong!)


## Full Results

```console
$ grep '=== Summary' -A 6 results/strain-name-matching/*/*
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5n1/dropped_strains_h5n1.txt ===
Direct matches:         0 / 40 (0.0%)
Changed via lookoup:    34 / 40 (85.0%)
Perfect fuzzy matches:  1 / 40 (2.5%)
Fuzzy matches:          0 / 40 (0.0%)
No matches:             5 / 40 (12.5%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5n1/include_strains_h5n1_2y.txt ===
Direct matches:         0 / 382 (0.0%)
Changed via lookoup:    347 / 382 (90.8%)
Perfect fuzzy matches:  3 / 382 (0.8%)
Fuzzy matches:          7 / 382 (1.8%)
No matches:             25 / 382 (6.5%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5n1/include_strains_h5n1_all-time.txt ===
Direct matches:         1 / 66 (1.5%)
Changed via lookoup:    56 / 66 (84.8%)
Perfect fuzzy matches:  0 / 66 (0.0%)
Fuzzy matches:          1 / 66 (1.5%)
No matches:             8 / 66 (12.1%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5nx/dropped_strains_h5nx.txt ===
Direct matches:         0 / 55 (0.0%)
Changed via lookoup:    45 / 55 (81.8%)
Perfect fuzzy matches:  2 / 55 (3.6%)
Fuzzy matches:          0 / 55 (0.0%)
No matches:             8 / 55 (14.5%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5nx/include_strains_h5nx_2y.txt ===
Direct matches:         0 / 386 (0.0%)
Changed via lookoup:    348 / 386 (90.2%)
Perfect fuzzy matches:  3 / 386 (0.8%)
Fuzzy matches:          10 / 386 (2.6%)
No matches:             25 / 386 (6.5%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h5nx/include_strains_h5nx_all-time.txt ===
Direct matches:         1 / 56 (1.8%)
Changed via lookoup:    46 / 56 (82.1%)
Perfect fuzzy matches:  0 / 56 (0.0%)
Fuzzy matches:          1 / 56 (1.8%)
No matches:             8 / 56 (14.3%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h7n9/dropped_strains_h7n9.txt ===
Direct matches:         0 / 63 (0.0%)
Changed via lookoup:    2 / 63 (3.2%)
Perfect fuzzy matches:  0 / 63 (0.0%)
Fuzzy matches:          0 / 63 (0.0%)
No matches:             61 / 63 (96.8%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h7n9/include_strains_h7n9_all-time.txt ===
Direct matches:         2 / 2 (100.0%)
Changed via lookoup:    0 / 2 (0.0%)
Perfect fuzzy matches:  0 / 2 (0.0%)
Fuzzy matches:          0 / 2 (0.0%)
No matches:             0 / 2 (0.0%)
--
=== Summary .snakemake/storage/http/raw.githubusercontent.com/nextstrain/avian-flu/refs/heads/master/config/h9n2/dropped_strains_h9n2.txt ===
Direct matches:         0 / 8 (0.0%)
Changed via lookoup:    3 / 8 (37.5%)
Perfect fuzzy matches:  0 / 8 (0.0%)
Fuzzy matches:          0 / 8 (0.0%)
No matches:             5 / 8 (62.5%)
--
=== Summary ../config/h1n1pdm/outliers.txt ===
Direct matches:         145 / 168 (86.3%)
Changed via lookoup:    6 / 168 (3.6%)
Perfect fuzzy matches:  0 / 168 (0.0%)
Fuzzy matches:          0 / 168 (0.0%)
No matches:             17 / 168 (10.1%)
--
=== Summary ../config/h1n1pdm/reference_strains.txt ===
Direct matches:         176 / 219 (80.4%)
Changed via lookoup:    37 / 219 (16.9%)
Perfect fuzzy matches:  0 / 219 (0.0%)
Fuzzy matches:          0 / 219 (0.0%)
No matches:             6 / 219 (2.7%)
--
=== Summary ../config/h3n2/ha/prioritized_seqs_file.tsv ===
Direct matches:         2 / 4 (50.0%)
Changed via lookoup:    2 / 4 (50.0%)
Perfect fuzzy matches:  0 / 4 (0.0%)
Fuzzy matches:          0 / 4 (0.0%)
No matches:             0 / 4 (0.0%)
--
=== Summary ../config/h3n2/outliers.txt ===
Direct matches:         511 / 566 (90.3%)
Changed via lookoup:    27 / 566 (4.8%)
Perfect fuzzy matches:  1 / 566 (0.2%)
Fuzzy matches:          6 / 566 (1.1%)
No matches:             21 / 566 (3.7%)
--
=== Summary ../config/h3n2/reference_strains.txt ===
Direct matches:         215 / 254 (84.6%)
Changed via lookoup:    33 / 254 (13.0%)
Perfect fuzzy matches:  0 / 254 (0.0%)
Fuzzy matches:          0 / 254 (0.0%)
No matches:             6 / 254 (2.4%)
--
=== Summary ../config/vic/outliers.txt ===
Direct matches:         54 / 60 (90.0%)
Changed via lookoup:    1 / 60 (1.7%)
Perfect fuzzy matches:  0 / 60 (0.0%)
Fuzzy matches:          2 / 60 (3.3%)
No matches:             3 / 60 (5.0%)
--
=== Summary ../config/vic/reference_strains.txt ===
Direct matches:         182 / 209 (87.1%)
Changed via lookoup:    25 / 209 (12.0%)
Perfect fuzzy matches:  0 / 209 (0.0%)
Fuzzy matches:          1 / 209 (0.5%)
No matches:             1 / 209 (0.5%)
--
=== Summary ../config/yam/outliers.txt ===
Direct matches:         15 / 15 (100.0%)
Changed via lookoup:    0 / 15 (0.0%)
Perfect fuzzy matches:  0 / 15 (0.0%)
Fuzzy matches:          0 / 15 (0.0%)
No matches:             0 / 15 (0.0%)
--
=== Summary ../config/yam/reference_strains.txt ===
Direct matches:         29 / 33 (87.9%)
Changed via lookoup:    3 / 33 (9.1%)
Perfect fuzzy matches:  0 / 33 (0.0%)
Fuzzy matches:          0 / 33 (0.0%)
No matches:             1 / 33 (3.0%)
```


cc @joverlee521 - you may want to adapt this for titers matching?
