### PR TITLE
.github/workflows/ingest: Add option to run via aws-batch 

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -16,6 +16,13 @@ on:
         description: "Specific container image to use for build (will override the default of `nextstrain build`)"
         required: false
         type: string
+      runtime:
+        description: "Nextstrain runtime"
+        type: choice
+        default: "docker"
+        options:
+          - "docker"
+          - "aws-batch"
 
 jobs:
   ingest:
@@ -24,7 +31,7 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
     secrets: inherit
     with:
-      runtime: docker
+      runtime: ${{ inputs.runtime }}
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
       run: |


### PR DESCRIPTION


## Description of proposed changes

When re-running the workflow from scratch, the action ran into `No space left on device` error.¹ I tried running the workflow locally and saw that the total disk usage peaked ~25GB which is past the GH runner limits of 16GB.²

This commit adds the option to run the ingest workflow via aws-batch so that we can use it as necessary. I have not added any cpu or memory overrides, so it will just use the defaults set in our job definition.

¹ <https://github.com/nextstrain/seasonal-flu/pull/274#issuecomment-3644191318> 
² <https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories>

## Related issue(s)

Follow up to https://github.com/nextstrain/seasonal-flu/pull/274#issuecomment-3644191318

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] [Ingest action](https://github.com/nextstrain/seasonal-flu/actions/runs/20152160280)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
