### PR TITLE
ingest: keep gisaid.ndjson uncompressed

### DIFF
--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -3,7 +3,7 @@ This part of the workflow handles the curation of data from GISAID.
 
 REQUIRED INPUTS:
 
-    ndjson      = data/gisaid.ndjson.zst
+    ndjson      = data/gisaid.ndjson
 
 OUTPUTS:
 
@@ -41,7 +41,7 @@ def format_field_map(field_map: dict[str, str]) -> str:
 
 rule curate:
     input:
-        sequences_ndjson="data/gisaid.ndjson.zst",
+        sequences_ndjson="data/gisaid.ndjson",
         lineage_annotations=config["curate"]["lineage_annotations"],
         strain_replacements_seasonal="data/fauna-source-data/flu_strain_name_fix.tsv",
         strain_replacements_avian="data/fauna-source-data/avian_flu_strain_name_fix.tsv",
@@ -86,7 +86,7 @@ rule curate:
         host_field=config["curate"]["host_field"],
     shell:
         r"""
-        (zstdcat {input.sequences_ndjson:q} \
+        (cat {input.sequences_ndjson:q} \
             | augur curate rename \
                 --field-map {params.field_map} \
             | augur curate normalize-strings \

--- a/ingest/rules/prepare_ndjson.smk
+++ b/ingest/rules/prepare_ndjson.smk
@@ -12,7 +12,7 @@ INPUTS:
 
 OUTPUTS:
 
-    ndjson      = data/gisaid.ndjson.zst
+    ndjson      = data/gisaid.ndjson
 
 """
 
@@ -67,14 +67,14 @@ rule concatenate_gisaid_ndjsons:
     input:
         ndjsons=aggregate_gisaid_ndjsons,
     output:
-        ndjson=temp("data/gisaid.ndjson.zst"),
+        ndjson=temp("data/gisaid.ndjson"),
     params:
         gisaid_id_field=config["gisaid_id_field"],
     log: "logs/concatenate_gisaid_ndjsons.txt"
     shell:
         r"""
-        (zstdcat {input.ndjsons:q} \
+        (cat {input.ndjsons:q} \
             | ./scripts/dedup-by-gisaid-id \
                 --id-field {params.gisaid_id_field:q} \
-            | zstd -T0 -c > {output.ndjson:q}) 2> {log:q}
+            > {output.ndjson:q}) 2> {log:q}
         """


### PR DESCRIPTION
## Description of proposed changes

Follow up to <https://github.com/nextstrain/seasonal-flu/pull/277/files#r2621286544>

Partially reverts 98b34c97274f1c25d3c85d451ad3cb1c6c50c173 to keep the intermediate data/gisaid.ndjson file uncompressed. This is necessary to upload the file with `upload-to-s3` because the script does not support uploading compressed files yet. The file size is reasonable to deal with for now (~8GB), but we should pursue adding compressed file support to `upload-to-s3` and keep the intermediates compressed soon!  

Alternatives that I considered but did not pursue:
1. Upload the file with a plain `aws s3 cp` command. We would lose the additional metadata sha256sum and record count and the abililty to skip uploads if the files are identical.
2. Decompress the file right before upload. This would require the same disk space as just keeping the file decompressed, so I decided against the extra decompression step.

## Related issue(s)

Follow up to https://github.com/nextstrain/seasonal-flu/pull/277
Related to https://github.com/nextstrain/shared/issues/66
## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
