### PR TITLE
[ingest] handle zst compressed ndjsons

### DIFF
--- a/ingest/rules/prepare_ndjson.smk
+++ b/ingest/rules/prepare_ndjson.smk
@@ -73,7 +73,7 @@ rule concatenate_gisaid_ndjsons:
     log: "logs/concatenate_gisaid_ndjsons.txt"
     shell:
         r"""
-        (cat {input.ndjsons:q} \
+        (zstdcat {input.ndjsons:q} \
             | ./scripts/dedup-by-gisaid-id \
                 --id-field {params.gisaid_id_field:q} \
             > {output.ndjson:q}) 2> {log:q}


### PR DESCRIPTION
All files collected by `aggregate_gisaid_ndjsons` are now .zst files

I ran into this running `snakemake --cores 2 --notemp --config gisaid_pairs='["gisaid_cache"]' -pf data/gisaid.ndjson`  today from current master 107844bb. Maybe there's something your `cat` can do that my OSX one can't?