### PR TITLE
Switch to ingest

### DIFF
--- a/ingest/build-configs/manual-upload/config.yaml
+++ b/ingest/build-configs/manual-upload/config.yaml
@@ -1,3 +1,2 @@
-# TODO: remove `trials/ingest/` after we switch to the ingest workflow
 # AWS S3 destination for the downloaded GISAID files
-s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu/trials/ingest/gisaid-downloads/unprocessed"
+s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu/gisaid-downloads/unprocessed"

--- a/ingest/build-configs/nextstrain-automation/config.yaml
+++ b/ingest/build-configs/nextstrain-automation/config.yaml
@@ -4,6 +4,5 @@ custom_rules:
   - build-configs/nextstrain-automation/fetch_from_s3.smk
   - build-configs/nextstrain-automation/upload.smk
 
-# TODO: remove `/trials/ingest` after we switch to the ingest workflow
-s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu/trials/ingest"
-s3_src: "s3://nextstrain-data-private/files/workflows/seasonal-flu/trials/ingest"
+s3_dst: "s3://nextstrain-data-private/files/workflows/seasonal-flu"
+s3_src: "s3://nextstrain-data-private/files/workflows/seasonal-flu"


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is based on https://github.com/nextstrain/seasonal-flu/pull/285. They should be merged together to fully switch to the ingest workflow.

## Description of proposed changes

Updates the S3 prefixes to drop `/trial/ingest` so that downstream workflows can use the new ingest outputs.

There's some clean up within the Snakemake workflow itself that I'll probably do _after_ the switch in case we need to fallback to the fauna workflow. 

## Related issue(s)

Part of https://github.com/nextstrain/seasonal-flu/issues/234

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
