### PR TITLE
fix(nextclade): fix mutation label map placement

### DIFF
--- a/nextclade/dataset_config/h1n1pdm/ha/CY121680/pathogen.json
+++ b/nextclade/dataset_config/h1n1pdm/ha/CY121680/pathogen.json
@@ -1,6 +1,4 @@
 {
-    "nucMutLabelMap": {},
-    "nucMutLabelMapReverse": {},
     "shortcuts": [
       "flu_h1n1pdm_ha_broad",
       "nextstrain/flu/h1n1pdm/ha/california-7-2009"

--- a/nextclade/dataset_config/h1n1pdm/ha/MW626062/pathogen.json
+++ b/nextclade/dataset_config/h1n1pdm/ha/MW626062/pathogen.json
@@ -1,6 +1,4 @@
 {
-    "nucMutLabelMap": {},
-    "nucMutLabelMapReverse": {},
     "shortcuts": [
       "flu_h1n1pdm_ha",
       "nextstrain/flu/h1n1pdm",

--- a/nextclade/dataset_config/h3n2/ha/CY163680/pathogen.json
+++ b/nextclade/dataset_config/h3n2/ha/CY163680/pathogen.json
@@ -1,6 +1,4 @@
 {
-    "nucMutLabelMap": {},
-    "nucMutLabelMapReverse": {},
     "shortcuts": [
       "flu_h3n2_ha_broad",
       "nextstrain/flu/h3n2/ha/wisconsin-67-2005"

--- a/nextclade/dataset_config/h3n2/ha/EPI1857216/pathogen.json
+++ b/nextclade/dataset_config/h3n2/ha/EPI1857216/pathogen.json
@@ -1,6 +1,4 @@
 {
-  "nucMutLabelMap": {},
-  "nucMutLabelMapReverse": {},
   "shortcuts": [
     "flu_h3n2_ha",
     "nextstrain/flu/h3n2",

--- a/nextclade/dataset_config/h3n2/na/EPI1857215/pathogen.json
+++ b/nextclade/dataset_config/h3n2/na/EPI1857215/pathogen.json
@@ -57,7 +57,7 @@
         ]
       }
     ],
-    "mutLabelMap":{
+    "mutLabels":{
       "aaMutLabelMap":{
         "NA:119":["NAI"],
         "NA:136":["NAI"],

--- a/nextclade/dataset_config/vic/ha/KX058884/pathogen.json
+++ b/nextclade/dataset_config/vic/ha/KX058884/pathogen.json
@@ -1,6 +1,4 @@
 {
-    "nucMutLabelMap": {},
-    "nucMutLabelMapReverse": {},
     "shortcuts": [
       "flu_vic_ha",
       "nextstrain/flu/vic",

--- a/nextclade/dataset_config/vic/na/CY073894/pathogen.json
+++ b/nextclade/dataset_config/vic/na/CY073894/pathogen.json
@@ -1,6 +1,4 @@
 {
-    "nucMutLabelMap": {},
-    "nucMutLabelMapReverse": {},
     "shortcuts": [
       "flu_vic_na",
       "nextstrain/flu/vic/na",

--- a/nextclade/dataset_config/yam/ha/JN993010/pathogen.json
+++ b/nextclade/dataset_config/yam/ha/JN993010/pathogen.json
@@ -1,6 +1,4 @@
 {
-    "nucMutLabelMap": {},
-    "nucMutLabelMapReverse": {},
     "shortcuts": [
       "flu_yam_ha",
       "nextstrain/flu/yam",


### PR DESCRIPTION
Fix mutation label map issues in Nextclade dataset config files.

**Issue 1:** `nucMutLabelMap: {}` and `nucMutLabelMapReverse: {}` placed at root level in 7 HA dataset configs. These empty maps should not be at root level (the schema expects them under `mutLabels`). Since they are empty, they are removed entirely.

**Issue 2:** `mutLabelMap` (wrong key name) used instead of `mutLabels` in h3n2/na/EPI1857215. The NAI resistance markers inside were not being read by Nextclade.

**Issue 3:** `nucMutLabelMapReverse` is a legacy v2 field. Nextclade v3 computes the reverse mapping at runtime. Removed from all 7 files.

- [x] Remove empty `nucMutLabelMap` and legacy `nucMutLabelMapReverse` from 7 HA dataset configs
- [x] Rename `mutLabelMap` to `mutLabels` in h3n2/na/EPI1857215

> :warning: The existing datasets in `nextclade_data` are already patched in nextstrain/nextclade_data#419, so no immediate resubmission is needed. But without this upstream fix, the issues will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) for the `LabelledMutationsConfig` definition (the `mutLabels` section).

1. Related to: nextstrain/nextclade_data#419