### PR TITLE
.github/workflows: Exclude `auspice/` from artifact paths for private builds

### DIFF
--- a/.github/workflows/run-nextflu-private-builds.yaml
+++ b/.github/workflows/run-nextflu-private-builds.yaml
@@ -33,3 +33,6 @@ jobs:
           all_report_outputs \
           -p \
           --configfile profiles/nextflu-private.yaml
+      # Specifically exclude auspice directory since these are private builds
+      artifact-paths: |
+        !auspice/

--- a/.github/workflows/run-private-nextflu-builds.yaml
+++ b/.github/workflows/run-private-nextflu-builds.yaml
@@ -35,7 +35,10 @@ jobs:
           all_who \
           -p \
           --configfile profiles/private.nextflu.org.yaml
-
+      # Specifically exclude auspice directory since these are private builds
+      artifact-paths: |
+        !auspice/
+        
   deploy-private-nextflu:
     needs: [run-build]
     runs-on: ubuntu-latest


### PR DESCRIPTION
Ensuring we don't include private builds in public GH Action artifacts in anticipation of https://github.com/nextstrain/.github/pull/164

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
