### PR TITLE
Ingest: More Nextclade runs

### DIFF
--- a/.github/workflows/ingest.yaml
+++ b/.github/workflows/ingest.yaml
@@ -16,13 +16,6 @@ on:
         description: "Specific container image to use for build (will override the default of `nextstrain build`)"
         required: false
         type: string
-      runtime:
-        description: "Nextstrain runtime"
-        type: choice
-        default: "docker"
-        options:
-          - "docker"
-          - "aws-batch"
       triggerAvianFlu:
         description: "Trigger nextstrain/avian-flu GenoFLU workflow"
         type: boolean
@@ -52,7 +45,7 @@ jobs:
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
     secrets: inherit
     with:
-      runtime: ${{ inputs.runtime }}
+      runtime: aws-batch
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
         SLACK_CHANNELS: ${{ vars.SLACK_CHANNELS }}
@@ -61,8 +54,12 @@ jobs:
         nextstrain build \
           --env SLACK_CHANNELS \
           --env SLACK_TOKEN \
+          --detach \
+          --cpus 36 \
+          --memory 64gib \
           ingest \
           upload_all \
+          --set-threads run_nextclade=12 \
           --configfile build-configs/nextstrain-automation/config.yaml
       artifact-name: ${{ inputs.artifact-name }}
       # Explicitly excluding `ingest/data` and `ingest/fauna/data`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
 
+# 29 April 2026
+
+- The default ingest config produces metadata with multiple segment QC columns,
+  e.g. `qc.overallStatus_ha`. If you are using the ingest workflow metadata output
+  for filtering, make sure to update your filter query columns to match the new QC columns.
+
 # 21 April 2026
 
 - The ingest workflow now supports starting from a subset of segments defined by the `segments` config param.

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -269,13 +269,14 @@ nextclade:
       field_map:
         seqName: seqName
         clade: subclade_nextclade_ha
-        qc.overallStatus: qc.overallStatus
+        qc.overallStatus: qc.overallStatus_ha
     na:
       dataset_name: nextstrain/flu/h3n2/na
       id_field: seqName
       field_map:
         seqName: seqName
         clade: subclade_nextclade_na
+        qc.overallStatus: qc.overallStatus_na
   h1n1pdm:
     ha:
       dataset_name: nextstrain/flu/h1n1pdm/ha
@@ -293,13 +294,14 @@ nextclade:
       field_map:
         seqName: seqName
         clade: subclade_nextclade_ha
-        qc.overallStatus: qc.overallStatus
+        qc.overallStatus: qc.overallStatus_ha
     na:
       dataset_name: nextstrain/flu/h1n1pdm/na
       id_field: seqName
       field_map:
         seqName: seqName
         clade: subclade_nextclade_na
+        qc.overallStatus: qc.overallStatus_na
   vic:
     ha:
       dataset_name: nextstrain/flu/vic/ha
@@ -317,10 +319,11 @@ nextclade:
       field_map:
         seqName: seqName
         clade: subclade_nextclade_ha
-        qc.overallStatus: qc.overallStatus
+        qc.overallStatus: qc.overallStatus_ha
     na:
       dataset_name: nextstrain/flu/vic/na
       id_field: seqName
       field_map:
         seqName: seqName
         clade: subclade_nextclade_na
+        qc.overallStatus: qc.overallStatus_na

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -435,3 +435,161 @@ nextclade:
       field_map:
         seqName: seqName
         qc.overallStatus: qc.overallStatus_ns
+  yam:
+    ha:
+      dataset_name: nextstrain/flu/yam/ha
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        clade: clade_nextclade_ha
+        qc.overallStatus: qc.overallStatus_ha
+  b:
+    ha:
+      dataset_name: nextstrain/flu/b/ha
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        lineage: lineage_nextclade_ha
+        clade: subclade_nextclade_ha
+        qc.overallStatus: qc.overallStatus_ha
+    na:
+      dataset_name: nextstrain/flu/b/na
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        clade: subclade_nextclade_na
+        qc.overallStatus: qc.overallStatus_na
+    pb2:
+      dataset_name: nextstrain/flu/b/pb2
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb2
+    pb1:
+      dataset_name: nextstrain/flu/b/pb1
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb1
+    pa:
+      dataset_name: nextstrain/flu/b/pa
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pa
+    np:
+      dataset_name: nextstrain/flu/b/np
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_np
+    mp:
+      dataset_name: nextstrain/flu/b/mp
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_mp
+    ns:
+      dataset_name: nextstrain/flu/b/ns
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ns
+  h1n1:
+    ha:
+      dataset_name: nextstrain/flu/h1n1/ha
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ha
+    na:
+      dataset_name: nextstrain/flu/h1n1/na
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_na
+    pb2:
+      dataset_name: nextstrain/flu/h1n1/pb2
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb2
+    pb1:
+      dataset_name: nextstrain/flu/h1n1/pb1
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb1
+    pa:
+      dataset_name: nextstrain/flu/h1n1/pa
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pa
+    np:
+      dataset_name: nextstrain/flu/h1n1/np
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_np
+    mp:
+      dataset_name: nextstrain/flu/h1n1/mp
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_mp
+    ns:
+      dataset_name: nextstrain/flu/h1n1/ns
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ns
+  h2n2:
+    ha:
+      dataset_name: nextstrain/flu/h2n2/ha
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ha
+    na:
+      dataset_name: nextstrain/flu/h2n2/na
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_na
+    pb2:
+      dataset_name: nextstrain/flu/h2n2/pb2
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb2
+    pb1:
+      dataset_name: nextstrain/flu/h2n2/pb1
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb1
+    pa:
+      dataset_name: nextstrain/flu/h2n2/pa
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pa
+    np:
+      dataset_name: nextstrain/flu/h2n2/np
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_np
+    mp:
+      dataset_name: nextstrain/flu/h2n2/mp
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_mp
+    ns:
+      dataset_name: nextstrain/flu/h2n2/ns
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ns

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -277,6 +277,42 @@ nextclade:
         seqName: seqName
         clade: subclade_nextclade_na
         qc.overallStatus: qc.overallStatus_na
+    pb2:
+      dataset_name: nextstrain/flu/h3n2/pb2
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb2
+    pb1:
+      dataset_name: nextstrain/flu/h3n2/pb1
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb1
+    pa:
+      dataset_name: nextstrain/flu/h3n2/pa
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pa
+    np:
+      dataset_name: nextstrain/flu/h3n2/np
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_np
+    mp:
+      dataset_name: nextstrain/flu/h3n2/mp
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_mp
+    ns:
+      dataset_name: nextstrain/flu/h3n2/ns
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ns
   h1n1pdm:
     ha:
       dataset_name: nextstrain/flu/h1n1pdm/ha
@@ -302,6 +338,42 @@ nextclade:
         seqName: seqName
         clade: subclade_nextclade_na
         qc.overallStatus: qc.overallStatus_na
+    pb2:
+      dataset_name: nextstrain/flu/h1n1pdm/pb2
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb2
+    pb1:
+      dataset_name: nextstrain/flu/h1n1pdm/pb1
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb1
+    pa:
+      dataset_name: nextstrain/flu/h1n1pdm/pa
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pa
+    np:
+      dataset_name: nextstrain/flu/h1n1pdm/np
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_np
+    mp:
+      dataset_name: nextstrain/flu/h1n1pdm/mp
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_mp
+    ns:
+      dataset_name: nextstrain/flu/h1n1pdm/ns
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ns
   vic:
     ha:
       dataset_name: nextstrain/flu/vic/ha
@@ -327,3 +399,39 @@ nextclade:
         seqName: seqName
         clade: subclade_nextclade_na
         qc.overallStatus: qc.overallStatus_na
+    pb2:
+      dataset_name: nextstrain/flu/vic/pb2
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb2
+    pb1:
+      dataset_name: nextstrain/flu/vic/pb1
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pb1
+    pa:
+      dataset_name: nextstrain/flu/vic/pa
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_pa
+    np:
+      dataset_name: nextstrain/flu/vic/np
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_np
+    mp:
+      dataset_name: nextstrain/flu/vic/mp
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_mp
+    ns:
+      dataset_name: nextstrain/flu/vic/ns
+      id_field: seqName
+      field_map:
+        seqName: seqName
+        qc.overallStatus: qc.overallStatus_ns


### PR DESCRIPTION
## Description of proposed changes

Now includes all available Nextclade datasets and segments, which is a total of 49 Nextclade runs per ingest. 
Moves the automated ingest workflow to run on AWS Batch to speed up the workflow with more cores. 

## Related issue(s)

Part of https://github.com/nextstrain/seasonal-flu/issues/313

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog
- [x] Test [aws-batch workflow](https://github.com/nextstrain/seasonal-flu/actions/runs/25137176310)

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
