### PR TITLE
ingest/nextstrain-automation: Fix empty gisaid cache

### DIFF
--- a/ingest/build-configs/nextstrain-automation/fetch_from_s3.smk
+++ b/ingest/build-configs/nextstrain-automation/fetch_from_s3.smk
@@ -19,7 +19,7 @@ rule fetch_gisaid_ndjson:
             aws s3 cp {params.s3_file:q} {output.ndjson:q}
         else
             echo "{params.s3_file:q} does not exist, creating empty file."
-            touch {output.ndjson:q}
+            cat /dev/null | zstd -c > {output.ndjson:q}
         fi
         """
 


### PR DESCRIPTION
## Description of proposed changes

When I ran the workflow without cache for the annual refresh, it ran into an error with zstd

> zstd: data/gisaid_cache.ndjson.zst: unexpected end of file

Create the correctly compressed empty file so that zstdcat can work as expected.

Follow up to https://github.com/nextstrain/seasonal-flu/commit/98b34c97274f1c25d3c85d451ad3cb1c6c50c173.

## Related issue(s)

Related to https://github.com/nextstrain/private/issues/211

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
