### PR TITLE
Add config interface to set traits columns

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,12 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
 
-# XX May 2026
+# 8 June 2026
+
+- Add configuration interface, `traits`, to set the metadata columns to use for discrete trait analysis with `augur traits`.
+  See [#319](https://github.com/nextstrain/seasonal-flu/pull/319) for details.
+
+# 6 May 2026
 
 - *MAJOR CHANGE* The steps for running Nextclade and adding haplotype annotations
   have been removed from the core workflow. If you would like to include

--- a/profiles/ci/builds.yaml
+++ b/profiles/ci/builds.yaml
@@ -20,6 +20,9 @@ embedding:
   # Set lower value of perplexity when sample size is small.
   perplexity: 9
 
+traits:
+  columns: "region subclade_nextclade_{segment}"
+
 builds:
     "ci_build":
       lineage: h3n2

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -317,7 +317,7 @@ rule traits:
     output:
         node_data = build_dir + "/{build_name}/{segment}/traits.json",
     params:
-        columns = "region"
+        columns = config.get("traits", {}).get("columns", "region"),
     conda: "../envs/nextstrain.yaml"
     benchmark:
         "benchmarks/traits_{build_name}_{segment}.txt"


### PR DESCRIPTION
## Description of proposed changes

Adds a build configuration block, `traits`, that allows users to set which metadata columns to use for discrete trait analysis with `augur traits`. The default value remains "region", but users can supply a space-delimited list of columns just like they would on the command line to override this default.
<!-- What is the goal of this pull request? What does this pull request change? -->

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
