### PR TITLE
Mark ingest/build-configs/manual-upload `nextstrain run` compatible

### DIFF
--- a/nextstrain-pathogen.yaml
+++ b/nextstrain-pathogen.yaml
@@ -1,5 +1,13 @@
-# This is currently an empty file to indicate the top level pathogen repo.
-# The inclusion of this file allows the Nextstrain CLI to run the
-# `nextstrain build` from any directory regardless of runtime.
+# This file's *existence* marks the top level of a Nextstrain pathogen repo,
+# which allows `nextstrain build` to be run from any subdirectory of the repo
+# regardless of runtime.  For more details, see
+# <https://github.com/nextstrain/cli/releases/tag/8.2.0>.
 #
-# See https://github.com/nextstrain/cli/releases/tag/8.2.0 for more details.
+# This file's *contents* is the "registration metadata" for the pathogen repo,
+# used by `nextstrain setup` and `nextstrain run`.
+---
+$schema: https://nextstrain.org/schemas/pathogen/v0
+workflows:
+  ingest/build-configs/manual-upload:
+    compatibility:
+      nextstrain run: true


### PR DESCRIPTION
## Description of proposed changes

This workflow was made compatible with `nextstrain run` in <https://github.com/nextstrain/seasonal-flu/pull/226>, but that was before the Nextstrain CLI released workflow specific compatibility schema in v10.4.0.¹

I meant to update the nextstrain-pathogen.yaml, but just never got around to it. I use this workflow weekly with `nextstrain run` and it has worked well so far.

¹ <https://github.com/nextstrain/cli/releases/tag/10.4.0>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
