### PR TITLE
[ingest] Expand avian-flu subtypes

### DIFF
--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -202,8 +202,8 @@ filtering:
   avian-flu:
     lineages:
       - h5nx # this'll include more than avian-flu currently subsamples to, but that's ok!
-      - h7n9
-      - h9n2
+      - h7nx
+      - h9nx
     metadata_columns: # <https://github.com/nextstrain/avian-flu/blob/f963447179c2b500b5598f056054374d3c9557a0/ingest/rules/ingest_fauna.smk#L37>
       - strain
       - vtype


### PR DESCRIPTION
Related slack thread <https://bedfordlab.slack.com/archives/C0K3GS3J8/p1781204631570609>

~There's an [ingest action running from this branch now](https://github.com/nextstrain/seasonal-flu/actions/runs/27376974511)~ (didn't trigger GenoFLU so wasn't uploaded into the avian-flu namespace on S3)

[Ingest action](https://github.com/nextstrain/seasonal-flu/actions/runs/27379910036) succeeded, which triggered [GenoFLU action](https://github.com/nextstrain/avian-flu/actions/runs/27380895449) which successfully updated the avian-flu files as expected.
