### PR TITLE
Add `refine.divergence_units` config param

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,10 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
 
+# 21 July 2026
+
+- Added optional configurations param `refine.divergence_units` to support setting divergence units for `augur refine`.
+
 # 26 June 2026
 
 - Added ingest-open workflow to ingest public data from GenSpectrum.

--- a/workflow/snakemake_rules/core.smk
+++ b/workflow/snakemake_rules/core.smk
@@ -239,7 +239,8 @@ rule refine:
         date_inference = "marginal",
         clock_filter_iqd = lambda wildcards: config.get("refine", {}).get("clock_filter_iqd", 4),
         clock_rate = clock_rate,
-        clock_std_dev = clock_std_dev
+        clock_std_dev = clock_std_dev,
+        divergence_units = lambda wildcards: config.get("refine", {}).get("divergence_units", "mutations-per-site"),
     conda: "../envs/nextstrain.yaml"
     benchmark:
         "benchmarks/refine_{build_name}_{segment}.txt"
@@ -266,6 +267,7 @@ rule refine:
             --coalescent {params.coalescent} \
             --date-confidence \
             --date-inference {params.date_inference} \
+            --divergence-units {params.divergence_units} \
             --clock-filter-iqd {params.clock_filter_iqd} 2>&1 | tee {log}
         """
 


### PR DESCRIPTION
## Description of proposed changes

Supports setting divergence units per run (not per build) to match other config params besides filter/subsample.

Still defaults to the Augur default value "mutations-per-site".



## Related issue(s)

Part of <https://github.com/nextstrain/public/issues/45>

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog
- [x] Update TBD in changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
