### PR TITLE
ingest-open: use "strain" as id and add "original strain"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,12 @@ Changes for this project _do not_ currently follow the [Semantic Versioning rule
 Instead, changes appear below grouped by the date they were added to the workflow.
 The "__NEXT__" heading below describes changes in the unreleased development source code and as such may not be routinely kept up to date.
 
+# 29 July 2026
+
+- Update ingest-open workflow to output the curated "strain" field as the
+  metadata and FASTA id field. The new "original_strain" field preserves the
+  original value of the strain name for display purposes.
+
 # 23 July 2026
 
 - Add colorings for the number of HA, HA1, and NA amino acid substitutions per node to corresponding gene trees for all subtypes. See [#250](https://github.com/nextstrain/seasonal-flu/pull/250) for details.

--- a/ingest-open/defaults/config.yaml
+++ b/ingest-open/defaults/config.yaml
@@ -45,7 +45,7 @@ curate:
   field_map:
     accession: accession
     accessionVersion: accession_version
-    specimenCollectorSampleId: strain
+    specimenCollectorSampleId: original_strain
     sampleCollectionDate: date
     hostNameScientific: host
     ncbiReleaseDate: date_released
@@ -54,10 +54,9 @@ curate:
     authors: full_authors
     authorAffiliations: institution
 
-  # TODO: add stricter regex
-  strain_regex: '^(A|B)/.+/.+$'
-  # Back up strain name field to use if 'strain' doesn't match regex above
-  strain_backup_fields: ['accession']
+  original_strain_field: original_strain
+  record_id_field: accession
+  strain_field: strain
 
   date_fields:
     - date
@@ -92,13 +91,11 @@ curate:
   annotations: annotations.tsv
   annotations_id: strain
 
-  record_id_field: accession
-  strain_field: strain
-
   metadata_columns:
     - accession
     - accession_version
     - strain
+    - original_strain
     - date
     - date_released
     - region

--- a/ingest-open/defaults/config.yaml
+++ b/ingest-open/defaults/config.yaml
@@ -91,6 +91,7 @@ curate:
   annotations: annotations.tsv
   annotations_id: strain
 
+  output_id_field: strain
   metadata_columns:
     - accession
     - accession_version

--- a/ingest-open/defaults/config.yaml
+++ b/ingest-open/defaults/config.yaml
@@ -91,6 +91,8 @@ curate:
   annotations: annotations.tsv
   annotations_id: strain
 
+  reference_strains: ../config/{lineage}/reference_strains.txt
+  reference_column: is_reference
   output_id_field: strain
   metadata_columns:
     - accession
@@ -107,6 +109,7 @@ curate:
     - authors
     - full_authors
     - institution
+    - is_reference
 
 nextclade:
   nextclade:

--- a/ingest-open/rules/curate.smk
+++ b/ingest-open/rules/curate.smk
@@ -29,11 +29,11 @@ rule curate:
         annotations=resolve_config_path(config["curate"]["annotations"]),
     output:
         ndjson="data/{lineage}/curated.ndjson.zst",
+        invalid_strains="data/{lineage}/invalid-strains.ndjson",
     params:
         field_map=format_field_map(config["curate"]["field_map"]),
         original_strain_field=config["curate"]["original_strain_field"],
         strain_field=config["curate"]["strain_field"],
-        record_id_field=config["curate"]["record_id_field"],
         date_fields=config["curate"]["date_fields"],
         expected_date_formats=config["curate"]["expected_date_formats"],
         division_field=config["curate"]["genspectrum_division_field"],
@@ -60,7 +60,7 @@ rule curate:
             | {workflow.basedir}/scripts/standardize-strain-name \
                 --strain-field {params.original_strain_field:q} \
                 --new-strain-field {params.strain_field:q} \
-                --id-field {params.record_id_field:q} \
+                --invalid-strains-output {output.invalid_strains:q} \
             | augur curate format-dates \
                 --date-fields {params.date_fields:q} \
                 --expected-date-formats {params.expected_date_formats:q} \

--- a/ingest-open/rules/curate.smk
+++ b/ingest-open/rules/curate.smk
@@ -178,7 +178,7 @@ rule split_ndjson_by_segment:
     params:
         segments=config["segments"],
         seq_output_dir=lambda w, output: Path(output.sequences[0]).parent,
-        id_field=config["curate"]["record_id_field"],
+        id_field=config["curate"]["output_id_field"],
         select_seq="error",
     shell:
         r"""

--- a/ingest-open/rules/curate.smk
+++ b/ingest-open/rules/curate.smk
@@ -31,8 +31,9 @@ rule curate:
         ndjson="data/{lineage}/curated.ndjson.zst",
     params:
         field_map=format_field_map(config["curate"]["field_map"]),
-        strain_regex=config["curate"]["strain_regex"],
-        strain_backup_fields=config["curate"]["strain_backup_fields"],
+        original_strain_field=config["curate"]["original_strain_field"],
+        strain_field=config["curate"]["strain_field"],
+        record_id_field=config["curate"]["record_id_field"],
         date_fields=config["curate"]["date_fields"],
         expected_date_formats=config["curate"]["expected_date_formats"],
         division_field=config["curate"]["genspectrum_division_field"],
@@ -56,9 +57,10 @@ rule curate:
             | augur curate rename \
                 --field-map {params.field_map:q} \
             | augur curate normalize-strings \
-            | augur curate transform-strain-name \
-                --strain-regex {params.strain_regex:q} \
-                --backup-fields {params.strain_backup_fields:q} \
+            | {workflow.basedir}/scripts/standardize-strain-name \
+                --strain-field {params.original_strain_field:q} \
+                --new-strain-field {params.strain_field:q} \
+                --id-field {params.record_id_field:q} \
             | augur curate format-dates \
                 --date-fields {params.date_fields:q} \
                 --expected-date-formats {params.expected_date_formats:q} \

--- a/ingest-open/rules/curate.smk
+++ b/ingest-open/rules/curate.smk
@@ -194,6 +194,52 @@ rule split_ndjson_by_segment:
         """
 
 
+# Modified from top level rule
+# <https://github.com/nextstrain/seasonal-flu/blob/f073d3e055ab6efaae6d4c91a06efa621b6247d9/workflow/snakemake_rules/select_strains.smk#L94-L113>
+rule build_reference_strains_table:
+    input:
+        references=resolve_config_path(config["curate"]["reference_strains"]),
+    output:
+        references="data/{lineage}/reference_strains.tsv",
+    params:
+        reference_column=config["curate"]["reference_column"],
+        id_field=config["curate"]["output_id_field"],
+    shell:
+        r"""
+        csvtk add-header \
+            --names {params.id_field:q} \
+            {input.references:q} \
+            | csvtk uniq \
+            | csvtk --out-tabs mutate2 \
+                --name {params.reference_column:q} \
+                --expression "'True'" > {output.references:q}
+        """
+
+
+# Modified from top level rule
+# https://github.com/nextstrain/seasonal-flu/blob/f073d3e055ab6efaae6d4c91a06efa621b6247d9/workflow/snakemake_rules/select_strains.smk#L115-L137
+rule annotate_metadata_with_reference_strains:
+    input:
+        references="data/{lineage}/reference_strains.tsv",
+        metadata="data/{lineage}/curated_metadata.tsv",
+    output:
+        metadata="data/{lineage}/curated_metadata_with_references.tsv",
+    params:
+        id_field=config["curate"]["output_id_field"],
+    shell:
+        r"""
+        if [[ -s {input.metadata:q} ]]; then
+            csvtk -t join \
+                --left-join \
+                --na "False" \
+                -f {params.id_field:q} \
+                {input.metadata:q} \
+                {input.references:q} > {output.metadata:q}
+        else
+            touch {output.metadata:q}
+        fi
+        """
+
 def metadata_fields(wildcards) -> str:
     """
     Returns config defined columns and any additional segment
@@ -211,7 +257,7 @@ def metadata_fields(wildcards) -> str:
 
 rule subset_metadata:
     input:
-        metadata="data/{lineage}/curated_metadata.tsv",
+        metadata="data/{lineage}/curated_metadata_with_references.tsv",
     output:
         subset_metadata="data/{lineage}/subset_metadata.tsv",
     params:

--- a/ingest-open/rules/nextclade.smk
+++ b/ingest-open/rules/nextclade.smk
@@ -189,7 +189,7 @@ rule join_metadata_and_nextclade:
     output:
         metadata="data/{lineage}/metadata_with_nextclade.tsv",
     params:
-        metadata_id_field=config["curate"]["record_id_field"],
+        metadata_id_field=config["curate"]["output_id_field"],
         # augur merge requires named inputs
         named_subset_nextclade=lambda w, input: (
             f"{segment}={path}"

--- a/ingest-open/scripts/standardize-strain-name
+++ b/ingest-open/scripts/standardize-strain-name
@@ -4,10 +4,16 @@ Standardizes strain name to our expected patterns so that they can be used to
 deduplicate samples and be used as the id column.
 """
 import argparse
+import re
 import sys
 from typing import Iterable
 from augur.io.file import open_file
 from augur.io.json import as_json, dump_ndjson, load_ndjson
+
+
+# Invalid characters for Augur metadata ids
+# See <https://docs.nextstrain.org/projects/augur/en/stable/faq/metadata.html#format>
+INVALID_CHARACTERS=re.compile(r"\s|\(|\)|\[|\]|{|}|\||#|>|<")
 
 
 def standardize_record_strains(records: Iterable,
@@ -29,7 +35,7 @@ def standardize_record_strains(records: Iterable,
                 raise Exception(f"Records must have the expected original strain field: {original_strain_field!r}")
 
             original_strain = record[original_strain_field].strip()
-            new_strain = original_strain
+            new_strain = standardize_strain_name(original_strain)
 
             if not new_strain:
                 print(as_json(record), file=invalid_strain_handle)
@@ -37,6 +43,14 @@ def standardize_record_strains(records: Iterable,
 
             record[new_strain_field] = new_strain
             yield record
+
+
+def standardize_strain_name(original_strain: str) -> str:
+    """
+    Standardize the *original_strain*
+    - remove invalid characters to fit Augur's criteria to be used as id
+    """
+    return re.sub(INVALID_CHARACTERS, "", original_strain)
 
 
 if __name__ == '__main__':

--- a/ingest-open/scripts/standardize-strain-name
+++ b/ingest-open/scripts/standardize-strain-name
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""
+Standardizes strain name to our expected patterns so that they can be used to
+deduplicate samples and be used as the id column.
+"""
+import argparse
+import sys
+from augur.io.json import dump_ndjson, load_ndjson
+from typing import Iterable
+
+
+def standardize_record_strains(records: Iterable,
+                               original_strain_field: str,
+                               id_field: str,
+                               new_strain_field: str) -> Iterable:
+    """
+    Adds the *new_strain_field* to the *records*, with standardized strain name
+    that was created from the *original_strain_field*.
+
+    Yields the modified records.
+    """
+
+    for record in records:
+        record = record.copy()
+        if original_strain_field not in record:
+            raise Exception(f"Records must have the expected original strain field: {original_strain_field!r}")
+        if id_field not in record:
+            raise Exception(f"Record must have the expected id field: {id_field!r}")
+
+        original_strain = record[original_strain_field].strip()
+        record_id = record[id_field].strip()
+        # TODO: standardize strain name
+        new_strain = original_strain or record_id
+        record[new_strain_field] = new_strain
+
+        yield record
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description=__doc__)
+
+    parser.add_argument("--strain-field", default="original_strain",
+        help="The record field containing the original strain name")
+    parser.add_argument("--id-field", default="accession",
+        help="The name of the id field to use as the back up strain name")
+    parser.add_argument("--new-strain-field", default="strain",
+        help="The name of the new field to add to the record with the standardized strain name")
+
+    args = parser.parse_args()
+
+    records = load_ndjson(sys.stdin)
+    modified_records = standardize_record_strains(
+        records,
+        args.strain_field,
+        args.id_field,
+        args.new_strain_field)
+    dump_ndjson(modified_records)

--- a/ingest-open/scripts/standardize-strain-name
+++ b/ingest-open/scripts/standardize-strain-name
@@ -5,35 +5,38 @@ deduplicate samples and be used as the id column.
 """
 import argparse
 import sys
-from augur.io.json import dump_ndjson, load_ndjson
 from typing import Iterable
+from augur.io.file import open_file
+from augur.io.json import as_json, dump_ndjson, load_ndjson
 
 
 def standardize_record_strains(records: Iterable,
                                original_strain_field: str,
-                               id_field: str,
-                               new_strain_field: str) -> Iterable:
+                               new_strain_field: str,
+                               invalid_strains_output: str) -> Iterable:
     """
     Adds the *new_strain_field* to the *records*, with standardized strain name
     that was created from the *original_strain_field*.
 
+    Skips records that do not have a valid strain name.
     Yields the modified records.
     """
 
-    for record in records:
-        record = record.copy()
-        if original_strain_field not in record:
-            raise Exception(f"Records must have the expected original strain field: {original_strain_field!r}")
-        if id_field not in record:
-            raise Exception(f"Record must have the expected id field: {id_field!r}")
+    with open_file(invalid_strains_output, "w") as invalid_strain_handle:
+        for record in records:
+            record = record.copy()
+            if original_strain_field not in record:
+                raise Exception(f"Records must have the expected original strain field: {original_strain_field!r}")
 
-        original_strain = record[original_strain_field].strip()
-        record_id = record[id_field].strip()
-        # TODO: standardize strain name
-        new_strain = original_strain or record_id
-        record[new_strain_field] = new_strain
+            original_strain = record[original_strain_field].strip()
+            new_strain = original_strain
 
-        yield record
+            if not new_strain:
+                print(as_json(record), file=invalid_strain_handle)
+                continue
+
+            record[new_strain_field] = new_strain
+            yield record
 
 
 if __name__ == '__main__':
@@ -41,10 +44,10 @@ if __name__ == '__main__':
 
     parser.add_argument("--strain-field", default="original_strain",
         help="The record field containing the original strain name")
-    parser.add_argument("--id-field", default="accession",
-        help="The name of the id field to use as the back up strain name")
     parser.add_argument("--new-strain-field", default="strain",
         help="The name of the new field to add to the record with the standardized strain name")
+    parser.add_argument("--invalid-strains-output",
+        help="NDJSON to save records with invalid strain names that are excluded from the output to stdout")
 
     args = parser.parse_args()
 
@@ -52,6 +55,6 @@ if __name__ == '__main__':
     modified_records = standardize_record_strains(
         records,
         args.strain_field,
-        args.id_field,
-        args.new_strain_field)
+        args.new_strain_field,
+        args.invalid_strains_output)
     dump_ndjson(modified_records)


### PR DESCRIPTION
## Description of proposed changes

Follow up to https://github.com/nextstrain/seasonal-flu/pull/331#discussion_r3599444564

Use "strain" as the metadata and FASTA id to match the phylo workflow expectations, which required stripping invalid characters from the strain name. Add "original_strain" to preserve the original value of the strain name for display purposes. 

This does drop a small percentage of records that just do not have a strain name, which we can investigate separately to see if we can work with upstream data sources to fill in.

## Related issue(s)

Part of https://github.com/nextstrain/seasonal-flu/issues/330

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [x] Update changelog

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
