### PR TITLE
Annotate fitness effects for recurrent substitutions based on Turner …

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@ benchmarks/
 nextclade_dataset/
 config/*/*/clades.tsv
 config/*/*/subclades.tsv
+config/*/*/lcr_weights.tsv
+config/*/*/lcr_windows.tsv
 
 # Sensitive environment variables
 environment*

--- a/Snakefile
+++ b/Snakefile
@@ -49,6 +49,15 @@ subclade_url_by_lineage_and_segment = {
     }
 }
 
+lcr_url_by_lineage_and_segment = {
+    "h3n2": {
+        "ha": {
+            "weights": "https://raw.githubusercontent.com/SamT123/nextstrain-flu-convergence/main/results/lcr_weights.tsv",
+            "windows": "https://raw.githubusercontent.com/SamT123/nextstrain-flu-convergence/main/results/lcr_windows.tsv",
+        },
+    }
+}
+
 # Optionally support inputs to keep workflow backwards compatible
 if config.get("inputs"):
 

--- a/config/h3n2/ha/auspice_config.json
+++ b/config/h3n2/ha/auspice_config.json
@@ -207,6 +207,11 @@
       "type": "continuous"
     },
     {
+      "key": "lcr_sum",
+      "title": "Convergence (Turner et al. 2026)",
+      "type": "continuous"
+    },
+    {
       "key": "region",
       "title": "Region",
       "type": "categorical"

--- a/profiles/ci/builds.yaml
+++ b/profiles/ci/builds.yaml
@@ -41,6 +41,7 @@ builds:
       enable_lbi: true
       enable_glycosylation: true
       enable_embeddings: true
+      enable_lcr_sum: true
       titer_collections:
         - name: cdc_cell_fra
           data: "example_data/cdc_h3n2_cell_fra_titers.tsv"

--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -157,6 +157,7 @@ array-builds:
       enable_lbi: true
       enable_titer_models: true
       enable_embeddings: true
+      enable_lcr_sum: true
       include: "'config/{lineage}/reference_strains.txt'"
       exclude: "'config/{lineage}/outliers.txt'"
       titer_collections:
@@ -188,6 +189,7 @@ array-builds:
       enable_titer_models: true
       enable_forecasts: false
       enable_embeddings: true
+      enable_lcr_sum: true
       include: "'config/{lineage}/reference_strains.txt'"
       exclude: "'config/{lineage}/outliers.txt'"
       titer_collections:

--- a/scripts/calculate_lcr_sum.py
+++ b/scripts/calculate_lcr_sum.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+import argparse
+
+from augur.io import write_json
+from augur.utils import read_node_data, read_tree
+from bisect import bisect_right
+import pandas as pd
+
+
+def annotate_tree(mutations_by_node, tree, weights, starts, ends, dates):
+    """Annotates log convergence ratio attributes to nodes of a given tree.
+    """
+    lcr_sum = {tree.root.name: 0.0}
+    total = 0
+    missing = 0
+    outside_windows = 0
+    after_last_window = 0
+
+    for node in tree.find_clades():
+        for child in node.clades:
+            # Get mutations between current node and its parent.
+            mutations = [
+                (gene, mutation)
+                for gene, gene_mutations in mutations_by_node[child.name].items()
+                for mutation in gene_mutations
+            ]
+
+            # Find the window to use for scoring the current node (earliest end date after the branch date)
+            date = dates[child.name]
+            window = bisect_right(ends, date)
+
+            # Calculate the log convergence ratio sum on the branch to the current node.
+            total += len(mutations)
+            branch = 0.0
+
+            if window == len(ends):
+                # Past every window's end, so score with the last window.
+                after_last_window += len(mutations)
+                window = len(ends) - 1
+
+            if starts[window] > date:
+                outside_windows += len(mutations)
+            else:
+                for gene, mutation in mutations:
+                    weight = weights.get((f"{gene}:{mutation}", window))
+                    if weight is None:
+                        missing += 1
+                        continue
+
+                    branch += weight
+
+            # Calculate cumulative log convergence ratio from root to current node.
+            lcr_sum[child.name] = lcr_sum[node.name] + branch
+
+    return lcr_sum, total, missing, outside_windows, after_last_window
+
+
+def main(args):
+    """Calculate log convergence ratio.
+    """
+    # Load log convergence ratios &  time windows
+    weight_table = pd.read_csv(args.weights, sep="\t", comment="#")
+
+    # Sort windows by end date to help find first window with end date after current node in annotate_tree
+    windows = pd.read_csv(args.windows, sep="\t").sort_values("window_end_numeric", ignore_index=True)
+    starts = windows["window_start_numeric"].tolist()
+    ends = windows["window_end_numeric"].tolist()
+    window_index = {end: index for index, end in enumerate(windows["window_end"])}
+
+    weights = {
+        (f"{row.gene}:{row.from_aa}{row.site}{row.derived_aa}", window_index[row.window_end]): float(row.lcr)
+        for row in weight_table.itertuples()
+    }
+
+    # Load node dates.
+    dates = {
+        name: node["numdate"]
+        for name, node in read_node_data(args.branch_lengths)["nodes"].items()
+    }
+
+    # Load tree.
+    tree = read_tree(args.tree)
+
+    # Load amino acid mutations per gene on the branch to each node.
+    mutations_by_node = {
+        name: node["aa_muts"]
+        for name, node in read_node_data(args.mutations)["nodes"].items()
+    }
+
+    lcr_sum, total, missing, outside_windows, after_last_window = annotate_tree(
+        mutations_by_node,
+        tree,
+        weights,
+        starts,
+        ends,
+        dates,
+    )
+
+    node_data = {
+        node.name: {"lcr_sum": lcr_sum[node.name]}
+        for node in tree.find_clades()
+    }
+
+    # Export log convergence ratio sum per node.
+    write_json(
+        {
+            "nodes": node_data,
+            "params": {
+                "mutations": total,
+                "mutations_missing_from_weights": missing,
+                "mutations_outside_windows": outside_windows,
+                "mutations_after_last_window": after_last_window,
+            },
+        },
+        args.output_node_data
+    )
+
+    # print to log
+    print(f"{total} mutations, {missing} missing from the weights table, {outside_windows} in no window, {after_last_window} after the last window")
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument("--weights", required=True, help="TSV file with one log convergence ratio per substitution per time window, defined in columns 'gene', 'site', 'from_aa', 'derived_aa', 'window_end', and 'lcr'. 'window_end' is the last day included in the time window, and is used to identify the window in the windows file")
+    parser.add_argument("--windows", required=True, help="TSV file with the windows used in the weights file, containing 'window_start', 'window_end', 'window_start_numeric', and 'window_end_numeric'")
+    parser.add_argument("--tree", required=True, help="Newick file of a tree with named internal nodes for which log convergence ratio should be calculated")
+    parser.add_argument("--branch-lengths", required=True, help="node data JSON from augur refine with a numeric date ('numdate') per node in the given tree")
+    parser.add_argument("--mutations", required=True, help="node data JSON from augur ancestral with amino acid mutations ('aa_muts') per node in the given tree")
+    parser.add_argument("--output-node-data", required=True, help="node data JSON file with log convergence ratio per node")
+
+    args = parser.parse_args()
+
+    main(args)

--- a/scripts/calculate_lcr_sum.py
+++ b/scripts/calculate_lcr_sum.py
@@ -2,7 +2,7 @@
 import argparse
 
 from augur.io import write_json
-from augur.utils import read_node_data, read_tree
+from augur.utils import annotate_parents_for_tree, read_node_data, read_tree
 from bisect import bisect_right
 import pandas as pd
 
@@ -17,40 +17,42 @@ def annotate_tree(mutations_by_node, tree, weights, starts, ends, dates):
     after_last_window = 0
 
     for node in tree.find_clades():
-        for child in node.clades:
-            # Get mutations between current node and its parent.
-            mutations = [
-                (gene, mutation)
-                for gene, gene_mutations in mutations_by_node[child.name].items()
-                for mutation in gene_mutations
-            ]
+        # Get mutations between current node and its parent.
+        mutations = [
+            (gene, mutation)
+            for gene, gene_mutations in mutations_by_node[node.name].items()
+            for mutation in gene_mutations
+        ]
 
-            # Find the window to use for scoring the current node (earliest end date after the branch date)
-            date = dates[child.name]
-            window = bisect_right(ends, date)
+        # Find the window to use for scoring the current node (earliest end date after the branch date)
+        date = dates[node.name]
+        window = bisect_right(ends, date)
 
-            # Calculate the log convergence ratio sum on the branch to the current node.
-            total += len(mutations)
-            branch = 0.0
+        # Calculate the log convergence ratio sum on the branch to the current node.
+        total += len(mutations)
+        branch = 0.0
 
-            if window == len(ends):
-                # Past every window's end, so score with the last window.
-                after_last_window += len(mutations)
-                window = len(ends) - 1
+        if window == len(ends):
+            # Past every window's end, so score with the last window.
+            after_last_window += len(mutations)
+            window = len(ends) - 1
 
-            if starts[window] > date:
-                outside_windows += len(mutations)
-            else:
-                for gene, mutation in mutations:
-                    weight = weights.get((f"{gene}:{mutation}", window))
-                    if weight is None:
-                        missing += 1
-                        continue
+        if starts[window] > date:
+            outside_windows += len(mutations)
+        else:
+            for gene, mutation in mutations:
+                weight = weights.get((f"{gene}:{mutation}", window))
+                if weight is None:
+                    missing += 1
+                    continue
 
-                    branch += weight
+                branch += weight
 
-            # Calculate cumulative log convergence ratio from root to current node.
-            lcr_sum[child.name] = lcr_sum[node.name] + branch
+        # Calculate cumulative log convergence ratio from root to current node.
+        lcr_sum[node.name] = branch
+        if getattr(node, "parent"):
+            lcr_sum[node.name] += lcr_sum.get(node.parent.name, 0.0)
+
 
     return lcr_sum, total, missing, outside_windows, after_last_window
 
@@ -80,6 +82,7 @@ def main(args):
 
     # Load tree.
     tree = read_tree(args.tree)
+    tree = annotate_parents_for_tree(tree)
 
     # Load amino acid mutations per gene on the branch to each node.
     mutations_by_node = {

--- a/workflow/snakemake_rules/export.smk
+++ b/workflow/snakemake_rules/export.smk
@@ -50,6 +50,9 @@ def _get_node_data_by_wildcards(wildcards):
     if config["builds"][wildcards.build_name].get("enable_embeddings", False):
         inputs.append(rules.convert_embedding_clusters_to_node_data.output.node_data)
 
+    if config["builds"][wildcards.build_name].get('enable_lcr_sum', False) and wildcards.segment in lcr_url_by_lineage_and_segment.get(config["builds"][wildcards.build_name].get("lineage"), {}):
+        inputs.append(rules.lcr_sum.output.node_data)
+
     if wildcards.segment == "ha":
         inputs.append(rules.annotate_derived_haplotypes.output.haplotypes)
 

--- a/workflow/snakemake_rules/fitness.smk
+++ b/workflow/snakemake_rules/fitness.smk
@@ -206,6 +206,52 @@ rule distances:
             --output {output.distances} 2>&1 | tee {log}
         """
 
+#
+# Calculate log convergence ratio sum
+#
+
+rule download_lcr_weights:
+    output:
+        weights="config/{lineage}/{segment}/lcr_weights.tsv",
+        windows="config/{lineage}/{segment}/lcr_windows.tsv",
+    conda: "../envs/nextstrain.yaml"
+    params:
+        weights_url=lambda wildcards: lcr_url_by_lineage_and_segment.get(wildcards.lineage, {}).get(wildcards.segment, {}).get("weights"),
+        windows_url=lambda wildcards: lcr_url_by_lineage_and_segment.get(wildcards.lineage, {}).get(wildcards.segment, {}).get("windows"),
+    shell:
+        """
+        curl -o {output.weights} "{params.weights_url}"
+        curl -o {output.windows} "{params.windows_url}"
+        """
+
+rule lcr_sum:
+    input:
+        tree = rules.refine.output.tree,
+        branch_lengths = rules.refine.output.node_data,
+        mutations = rules.ancestral.output.node_data,
+        weights = lambda w: rules.download_lcr_weights.output.weights.format(lineage=config["builds"][w.build_name]["lineage"], segment=w.segment),
+        windows = lambda w: rules.download_lcr_weights.output.windows.format(lineage=config["builds"][w.build_name]["lineage"], segment=w.segment),
+    output:
+        node_data = build_dir + "/{build_name}/{segment}/lcr_sum.json",
+    conda: "../envs/nextstrain.yaml"
+    benchmark:
+        "benchmarks/lcr_sum_{build_name}_{segment}.txt"
+    log:
+        "logs/lcr_sum_{build_name}_{segment}.txt"
+    resources:
+        mem_mb=8000,
+        time="00:30:00",
+    shell:
+        """
+        python3 scripts/calculate_lcr_sum.py \
+            --weights {input.weights} \
+            --windows {input.windows} \
+            --tree {input.tree} \
+            --branch-lengths {input.branch_lengths} \
+            --mutations {input.mutations} \
+            --output-node-data {output.node_data} 2>&1 | tee {log}
+        """
+
 def _get_node_data_for_predictors(wildcards):
     """Return a list of node data files for fitness predictors
     """


### PR DESCRIPTION
## Description of proposed changes

Add `lcr_sum`, the sum of LCR values / fitness effects from Turner et al. 2026 [1] for each substitution on the path from the root of the tree to the node, for H3N2 HA tree.

The LCR value for a substitution on a branch is taken from the 1y time interval containing that branch, from https://github.com/SamT123/nextstrain-flu-convergence.

scripts/calculate_lcr_sum.py is based on scripts/calculate_antigenic_advance.py

Substitutions on branches older than the first window are given a value of 0; the value for substitutions on branches after the last window is taken from the last window.

[1] https://www.biorxiv.org/content/10.64898/2026.04.10.717627v1

## Related issue(s)

- Resolves #344

## Checklist

I've run `nextstrain build . --configfile profiles/ci/builds.yaml` locally, and the output appears correct.

- [ ] Checks pass
- [ ] Update changeling
