### PR TITLE
Add GH Action for nextstrain-open

### DIFF
--- a/.github/workflows/run-nextstrain-open-builds.yaml
+++ b/.github/workflows/run-nextstrain-open-builds.yaml
@@ -1,0 +1,34 @@
+name: Run the Nextstrain open builds
+
+defaults:
+  run:
+    # This is the same as GitHub Action's `bash` keyword as of 20 June 2023:
+    # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsshell
+    #
+    # Completely spelling it out here so that GitHub can't change it out from under us
+    # and we don't have to refer to the docs to know the expected behavior.
+    shell: bash --noprofile --norc -eo pipefail {0}
+
+on:
+  workflow_dispatch:
+    inputs:
+      dockerImage:
+        description: "Specific container image to use for build (will override the default of `nextstrain build`)"
+        required: false
+        type: string
+
+jobs:
+  run-build:
+    permissions:
+      id-token: write
+    uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master
+    secrets: inherit
+    with:
+      runtime: docker
+      env: |
+        NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
+      run: |
+        nextstrain build \
+          . \
+          deploy_all \
+          --configfile profiles/nextstrain-open.yaml

--- a/.github/workflows/run-nextstrain-open-builds.yaml
+++ b/.github/workflows/run-nextstrain-open-builds.yaml
@@ -10,6 +10,15 @@ defaults:
     shell: bash --noprofile --norc -eo pipefail {0}
 
 on:
+  # This workflow will be triggered after the "Ingest open" workflow has completed on the "master" branch.
+  workflow_run:
+    workflows:
+      - Ingest open
+    types:
+      - completed
+    branches:
+      - master
+
   workflow_dispatch:
     inputs:
       dockerImage:
@@ -18,7 +27,65 @@ on:
         type: string
 
 jobs:
+  check-new-data:
+    if: |
+      github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    outputs:
+      cache-hit: ${{ steps.check-cache.outputs.cache-hit }}
+    steps:
+      - name: Get sha256sum
+        id: get-sha256sum
+        env:
+          AWS_DEFAULT_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: |
+          s3_urls=(
+            "s3://nextstrain-data/files/workflows/seasonal-flu/h1n1pdm/metadata.tsv.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/h1n1pdm/ha/sequences.fasta.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/h1n1pdm/na/sequences.fasta.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/h3n2/metadata.tsv.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/h3n2/ha/sequences.fasta.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/h3n2/na/sequences.fasta.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/vic/metadata.tsv.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/vic/ha/sequences.fasta.zst"
+            "s3://nextstrain-data/files/workflows/seasonal-flu/vic/na/sequences.fasta.zst"
+          )
+
+          # Code below is modified from ingest/upload-to-s3
+          # https://github.com/nextstrain/ingest/blob/c0b4c6bb5e6ccbba86374d2c09b42077768aac23/upload-to-s3#L23-L29
+
+          no_hash=0000000000000000000000000000000000000000000000000000000000000000
+
+          for s3_url in "${s3_urls[@]}"; do
+            s3path="${s3_url#s3://}"
+            bucket="${s3path%%/*}"
+            key="${s3path#*/}"
+
+            s3_hash="$(aws s3api head-object --no-sign-request --bucket "$bucket" --key "$key" --query Metadata.sha256sum --output text 2>/dev/null || echo "$no_hash")"
+            echo "${s3_hash}" | tee -a ingest-open-output-sha256sum
+          done
+
+      - name: Check cache
+        id: check-cache
+        uses: actions/cache@v6
+        with:
+          path: ingest-open-output-sha256sum
+          key: ingest-open-output-sha256sum-${{ hashFiles('ingest-open-output-sha256sum') }}
+          lookup-only: true
+
+
   run-build:
+    # Run the workflow under two conditions
+    # 1. `workflow_run` triggered `check-new-data` and there's new data (no cache hit)
+    # 2. the workflow is being manually run by `workflow_dispatch`
+    needs: [check-new-data]
+    if: |
+      always() &&
+      (
+        (needs.check-new-data.result == 'success' && needs.check-new-data.outputs.cache-hit != 'true') ||
+        github.event_name == 'workflow_dispatch'
+      )
     permissions:
       id-token: write
     uses: nextstrain/.github/.github/workflows/pathogen-repo-build.yaml@master

--- a/.github/workflows/run-nextstrain-open-builds.yaml
+++ b/.github/workflows/run-nextstrain-open-builds.yaml
@@ -25,6 +25,14 @@ on:
         description: "Specific container image to use for build (will override the default of `nextstrain build`)"
         required: false
         type: string
+      trial_name:
+        description: |
+          Trial name for deploying builds.
+          If not set, builds will overwrite existing builds at s3://nextstrain-data/seasonal-flu_open*
+          If set, builds will be deployed to s3://nextstrain-staging/seasonal-flu_trials_<trial_name>_*
+        required: false
+        type: string
+
 
 jobs:
   check-new-data:
@@ -94,8 +102,16 @@ jobs:
       runtime: docker
       env: |
         NEXTSTRAIN_DOCKER_IMAGE: ${{ inputs.dockerImage }}
+        TRIAL_NAME: ${{ inputs.trial_name }}
       run: |
+        declare -a config
+
+        if [[ "$TRIAL_NAME" ]]; then
+          config+=("deploy_url=s3://nextstrain-staging/seasonal-flu_trials_${TRIAL_NAME}_")
+        fi
+
         nextstrain build \
           . \
           deploy_all \
-          --configfile profiles/nextstrain-open.yaml
+          --configfile profiles/nextstrain-open.yaml \
+          --config "${config[@]}"


### PR DESCRIPTION
## Description of proposed changes

Add GH Action workflow for the nextstrain-open build added in https://github.com/nextstrain/seasonal-flu/pull/332.
The workflow is able to run completely within the Docker runtime in ~2h within GH Actions. 

## Related issue(s)

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass
- [ ] ~Update changelog~
- [x] [Test run](https://github.com/nextstrain/seasonal-flu/actions/runs/32072417777) -> https://nextstrain.org/staging/seasonal-flu/trials/test-open/seasonal-flu/open/h3n2/ha/2y

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
