### PR TITLE
nextstrain-public: Rename builds to seasonal-flu_gisaid_*

### DIFF
--- a/profiles/nextstrain-public.yaml
+++ b/profiles/nextstrain-public.yaml
@@ -33,9 +33,9 @@ array-builds:
         - 6Y6M
       resolution:
         - 6m
-    build_name: "seasonal-flu_{lineage}_6m"
+    build_name: "seasonal-flu_gisaid_{lineage}_6m"
     build_params: &shared-hi-build-params
-      auspice_name: "seasonal-flu_{lineage}_{{segment}}_{resolution}"
+      auspice_name: "seasonal-flu_gisaid_{lineage}_{{segment}}_{resolution}"
       reference: "config/{lineage}/{{segment}}/reference.fasta"
       annotation: "config/{lineage}/{{segment}}/genemap.gff"
       tree_exclude_sites: "config/{lineage}/{{segment}}/exclude-sites.txt"
@@ -75,9 +75,9 @@ array-builds:
         - 8Y
       resolution:
         - 2y
-    build_name: "seasonal-flu_{lineage}_2y"
+    build_name: "seasonal-flu_gisaid_{lineage}_2y"
     build_params:
-      auspice_name: "seasonal-flu_{lineage}_{{segment}}_{resolution}"
+      auspice_name: "seasonal-flu_gisaid_{lineage}_{{segment}}_{resolution}"
       reference: "config/{lineage}/{{segment}}/reference.fasta"
       annotation: "config/{lineage}/{{segment}}/genemap.gff"
       tree_exclude_sites: "config/{lineage}/{{segment}}/exclude-sites.txt"
@@ -109,7 +109,7 @@ array-builds:
         - 9Y
       resolution:
         - 3y
-    build_name: "seasonal-flu_{lineage}_3y"
+    build_name: "seasonal-flu_gisaid_{lineage}_3y"
     build_params: *shared-hi-build-params
     subsamples: *subsampling-scheme
   6Y-hi-builds:
@@ -123,7 +123,7 @@ array-builds:
         - 12Y
       resolution:
         - 6y
-    build_name: "seasonal-flu_{lineage}_6y"
+    build_name: "seasonal-flu_gisaid_{lineage}_6y"
     build_params: *shared-hi-build-params
     subsamples: *subsampling-scheme
   12Y-hi-builds:
@@ -137,7 +137,7 @@ array-builds:
         - 18Y
       resolution:
         - 12y
-    build_name: "seasonal-flu_{lineage}_12y"
+    build_name: "seasonal-flu_gisaid_{lineage}_12y"
     build_params: *shared-hi-build-params
     subsamples: *subsampling-scheme
   6M-fra-builds:
@@ -148,10 +148,10 @@ array-builds:
         - 6Y6M
       resolution:
         - 6m
-    build_name: "seasonal-flu_h3n2_6m"
+    build_name: "seasonal-flu_gisaid_h3n2_6m"
     build_params: &shared-fra-build-params
       lineage: h3n2
-      auspice_name: "seasonal-flu_{lineage}_{{segment}}_{resolution}"
+      auspice_name: "seasonal-flu_gisaid_{lineage}_{{segment}}_{resolution}"
       reference: "config/{lineage}/{{segment}}/reference.fasta"
       annotation: "config/{lineage}/{{segment}}/genemap.gff"
       tree_exclude_sites: "config/{lineage}/{{segment}}/exclude-sites.txt"
@@ -182,10 +182,10 @@ array-builds:
         - 8Y
       resolution:
         - 2y
-    build_name: "seasonal-flu_h3n2_2y"
+    build_name: "seasonal-flu_gisaid_h3n2_2y"
     build_params:
       lineage: h3n2
-      auspice_name: "seasonal-flu_{lineage}_{{segment}}_{resolution}"
+      auspice_name: "seasonal-flu_gisaid_{lineage}_{{segment}}_{resolution}"
       reference: "config/{lineage}/{{segment}}/reference.fasta"
       annotation: "config/{lineage}/{{segment}}/genemap.gff"
       tree_exclude_sites: "config/{lineage}/{{segment}}/exclude-sites.txt"
@@ -216,7 +216,7 @@ array-builds:
         - 9Y
       resolution:
         - 3y
-    build_name: "seasonal-flu_h3n2_3y"
+    build_name: "seasonal-flu_gisaid_h3n2_3y"
     build_params: *shared-fra-build-params
     subsamples: *subsampling-scheme
   6Y-fra-builds:
@@ -227,7 +227,7 @@ array-builds:
         - 12Y
       resolution:
         - 6y
-    build_name: "seasonal-flu_h3n2_6y"
+    build_name: "seasonal-flu_gisaid_h3n2_6y"
     build_params: *shared-fra-build-params
     subsamples: *subsampling-scheme
   12Y-fra-builds:
@@ -238,7 +238,7 @@ array-builds:
         - 18Y
       resolution:
         - 12y
-    build_name: "seasonal-flu_h3n2_12y"
+    build_name: "seasonal-flu_gisaid_h3n2_12y"
     build_params: *shared-fra-build-params
     subsamples: *subsampling-scheme
 


### PR DESCRIPTION
## Description of proposed changes

Differentiate the public GISAID builds from the open builds in the URL of the deployed builds.

Previously deployed builds will need to rely on redirects in nextstrain.org.

## Related issue(s)

Related to https://github.com/nextstrain/seasonal-flu/issues/330

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass
- [ ] ~Update changelog~

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
